### PR TITLE
ci: fixed auto_version pipeline

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -35,6 +35,11 @@ jobs:
         run: |
           pip install commitizen
 
+      - name: 🛠️ Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: 🔖 Bump version and changelog
         id: cz
         run: |


### PR DESCRIPTION
cz bump creates a commit
Git doesn’t have user.name and user.email set
CI fails with exit code 6
so added git configuration before using cz bump