### PR TITLE
ci: fixed auto_version pipeline

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bump-version:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     name: Auto-bump using Commitizen
 
     steps:


### PR DESCRIPTION
changed pipeline to run on windows since we create a .exe file for windows, it is more native to do so on windows