### PR TITLE
fix(frontend): remove max-width constraint from insurance pages

### DIFF
--- a/frontend/src/pages/Insurances.tsx
+++ b/frontend/src/pages/Insurances.tsx
@@ -69,7 +69,7 @@ export function Insurances() {
     .reduce((s, t) => s + Math.abs(t.amount), 0) ?? 0;
 
   return (
-    <div className="flex flex-col gap-6 p-6 max-w-6xl">
+    <div className="flex flex-col gap-6 p-6">
       <header className="flex items-center gap-3">
         <div className="p-2.5 rounded-xl bg-emerald-500/10 text-emerald-400">
           <Shield size={24} />

--- a/frontend/src/pages/InsurancesPrototype.tsx
+++ b/frontend/src/pages/InsurancesPrototype.tsx
@@ -435,7 +435,7 @@ export function InsurancesPrototype() {
   const trackSums = tracksWithSum.map((t) => t.sum ?? 0);
 
   return (
-    <div className="flex flex-col gap-6 p-6 max-w-7xl">
+    <div className="flex flex-col gap-6 p-6">
       {/* Header */}
       <header className="flex items-center gap-3">
         <div className="p-2.5 rounded-xl bg-emerald-500/10 text-emerald-400">


### PR DESCRIPTION
## Summary
- Removed `max-w-6xl` from `Insurances.tsx` and `max-w-7xl` from `InsurancesPrototype.tsx` so both insurance pages utilize the full available screen width

## Test plan
- [ ] Open Insurance page and verify it spans the full content area
- [ ] Check responsive behavior at different viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)