### PR TITLE
feat: auto-create investments from scraped Keren Hishtalmut

### DIFF
--- a/backend/alembic/versions/ecec034aa367_add_insurance_policy_id_to_investments.py
+++ b/backend/alembic/versions/ecec034aa367_add_insurance_policy_id_to_investments.py
@@ -1,0 +1,32 @@
+"""add insurance_policy_id to investments
+
+Revision ID: ecec034aa367
+Revises: 7beb5c98691f
+Create Date: 2026-03-11 20:26:47.448217
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ecec034aa367'
+down_revision: Union[str, Sequence[str], None] = '7beb5c98691f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add insurance_policy_id column to investments table."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = [c['name'] for c in inspector.get_columns('investments')]
+    if 'insurance_policy_id' not in columns:
+        op.add_column('investments', sa.Column('insurance_policy_id', sa.String(), nullable=True, unique=True))
+
+
+def downgrade() -> None:
+    """Remove insurance_policy_id column from investments table."""
+    op.drop_column('investments', 'insurance_policy_id')

--- a/backend/alembic/versions/ecec034aa367_add_insurance_policy_id_to_investments.py
+++ b/backend/alembic/versions/ecec034aa367_add_insurance_policy_id_to_investments.py
@@ -24,9 +24,12 @@ def upgrade() -> None:
     inspector = sa.inspect(conn)
     columns = [c['name'] for c in inspector.get_columns('investments')]
     if 'insurance_policy_id' not in columns:
-        op.add_column('investments', sa.Column('insurance_policy_id', sa.String(), nullable=True, unique=True))
+        with op.batch_alter_table('investments') as batch_op:
+            batch_op.add_column(sa.Column('insurance_policy_id', sa.String(), nullable=True))
+            batch_op.create_unique_constraint('uq_investments_insurance_policy_id', ['insurance_policy_id'])
 
 
 def downgrade() -> None:
     """Remove insurance_policy_id column from investments table."""
-    op.drop_column('investments', 'insurance_policy_id')
+    with op.batch_alter_table('investments') as batch_op:
+        batch_op.drop_column('insurance_policy_id')

--- a/backend/constants/tables.py
+++ b/backend/constants/tables.py
@@ -151,6 +151,7 @@ class InvestmentsTableFields(Enum):
     CREATED_DATE = "created_date"
     CLOSED_DATE = "closed_date"
     NOTES = "notes"
+    INSURANCE_POLICY_ID = "insurance_policy_id"
 
 
 class InvestmentBalanceSnapshotsTableFields(Enum):

--- a/backend/models/investment.py
+++ b/backend/models/investment.py
@@ -76,3 +76,4 @@ class Investment(Base, TimestampMixin):
     closed_date = Column(String, nullable=True)
     notes = Column(Text, nullable=True)
     prior_wealth_amount = Column(Float, nullable=False, default=0.0)
+    insurance_policy_id = Column(String, nullable=True, unique=True)

--- a/backend/repositories/investments_repository.py
+++ b/backend/repositories/investments_repository.py
@@ -176,6 +176,24 @@ class InvestmentsRepository:
         )
         return pd.read_sql(stmt, self.db.bind)
 
+    def get_by_insurance_policy_id(self, policy_id: str) -> pd.DataFrame:
+        """Find an investment linked to an insurance policy.
+
+        Parameters
+        ----------
+        policy_id : str
+            The insurance policy ID to look up.
+
+        Returns
+        -------
+        pd.DataFrame
+            Matching investment row, or empty DataFrame if not found.
+        """
+        stmt = select(Investment).where(
+            Investment.insurance_policy_id == policy_id
+        )
+        return pd.read_sql(stmt, self.db.bind)
+
     def update_investment(self, investment_id: int, **fields) -> None:
         """Update an investment by ID.
 

--- a/backend/routes/insurance_accounts.py
+++ b/backend/routes/insurance_accounts.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from backend.dependencies import get_database
 from backend.models.insurance_account import InsuranceAccount
+from backend.services.investments_service import InvestmentsService
 
 router = APIRouter()
 
@@ -45,3 +46,37 @@ async def get_insurance_accounts(
         }
         for r in rows
     ]
+
+
+@router.post("/sync-investments")
+async def sync_hishtalmut_investments(
+    db: Session = Depends(get_database),
+) -> dict:
+    """Backfill investments from existing hishtalmut insurance accounts.
+
+    Creates Investment records (with balance snapshots) for any hishtalmut
+    policies that don't already have a linked investment.
+
+    Returns
+    -------
+    dict
+        Count of synced policies.
+    """
+    rows = db.query(InsuranceAccount).filter_by(policy_type="hishtalmut").all()
+    inv_service = InvestmentsService(db)
+    synced = 0
+    for r in rows:
+        meta = {
+            "policy_type": r.policy_type,
+            "policy_id": r.policy_id,
+            "provider": r.provider,
+            "account_name": r.account_name,
+            "balance": r.balance,
+            "balance_date": r.balance_date,
+            "commission_deposits_pct": r.commission_deposits_pct,
+            "commission_savings_pct": r.commission_savings_pct,
+            "liquidity_date": r.liquidity_date,
+        }
+        inv_service.sync_from_insurance(meta)
+        synced += 1
+    return {"synced": synced}

--- a/backend/scraper/adapter.py
+++ b/backend/scraper/adapter.py
@@ -440,3 +440,21 @@ class InsuranceScraperAdapter(ScraperAdapter):
                 "%s: %s: Saved metadata for %d insurance accounts",
                 self.provider_name, self.account_name, len(accounts_to_upsert),
             )
+
+            # Sync hishtalmut policies to investments
+            from backend.services.investments_service import InvestmentsService
+
+            inv_service = InvestmentsService(db)
+            for meta in accounts_to_upsert:
+                if meta.get("policy_type") == "hishtalmut":
+                    try:
+                        inv_service.sync_from_insurance(meta)
+                        logger.info(
+                            "%s: %s: Synced hishtalmut investment for policy %s",
+                            self.provider_name, self.account_name, meta["policy_id"],
+                        )
+                    except Exception:
+                        logger.exception(
+                            "%s: %s: Failed to sync hishtalmut investment for policy %s",
+                            self.provider_name, self.account_name, meta["policy_id"],
+                        )

--- a/backend/services/investments_service.py
+++ b/backend/services/investments_service.py
@@ -191,33 +191,34 @@ class InvestmentsService:
         policy_id = insurance_meta["policy_id"]
         provider = insurance_meta.get("provider", "unknown")
         account_name = insurance_meta["account_name"]
+        tag = f"Keren Hishtalmut - {provider} ({policy_id})"
 
         existing = self.investments_repo.get_by_insurance_policy_id(policy_id)
 
         if existing.empty:
-            # Check if an unlinked investment exists with the base tag
-            base_tag = f"Keren Hishtalmut - {provider}"
-            by_tag = self.investments_repo.get_by_category_tag(
-                INVESTMENTS_CATEGORY, base_tag
-            )
-            if not by_tag.empty and pd.isna(by_tag.iloc[0].get("insurance_policy_id")):
-                # Link the existing unlinked investment to this policy
-                inv_id = int(by_tag.iloc[0]["id"])
-                self.investments_repo.update_investment(
-                    inv_id,
-                    insurance_policy_id=policy_id,
-                    name=account_name,
-                    commission_deposit=insurance_meta.get("commission_deposits_pct"),
-                    commission_management=insurance_meta.get("commission_savings_pct"),
-                    liquidity_date=insurance_meta.get("liquidity_date"),
+            # Check if an unlinked investment exists with any legacy tag for this provider
+            legacy_tags = [
+                f"Keren Hishtalmut - {provider}",
+            ]
+            linked = False
+            for legacy_tag in legacy_tags:
+                by_tag = self.investments_repo.get_by_category_tag(
+                    INVESTMENTS_CATEGORY, legacy_tag
                 )
-            else:
-                # Use policy_id suffix for uniqueness when base tag is taken
-                tag = base_tag
-                if not by_tag.empty:
-                    # Extract short suffix from policy_id (last parenthesized number or last segment)
-                    suffix = policy_id.split("(")[-1].rstrip(")") if "(" in policy_id else policy_id[-6:]
-                    tag = f"{base_tag} ({suffix})"
+                if not by_tag.empty and pd.isna(by_tag.iloc[0].get("insurance_policy_id")):
+                    inv_id = int(by_tag.iloc[0]["id"])
+                    self.investments_repo.update_investment(
+                        inv_id,
+                        insurance_policy_id=policy_id,
+                        tag=tag,
+                        name=account_name,
+                        commission_deposit=insurance_meta.get("commission_deposits_pct"),
+                        commission_management=insurance_meta.get("commission_savings_pct"),
+                        liquidity_date=insurance_meta.get("liquidity_date"),
+                    )
+                    linked = True
+                    break
+            if not linked:
                 self.investments_repo.create_investment(
                     category=INVESTMENTS_CATEGORY,
                     tag=tag,
@@ -238,7 +239,8 @@ class InvestmentsService:
             inv_id = int(existing.iloc[0]["id"])
             self.investments_repo.update_investment(
                 inv_id,
-                name=insurance_meta["account_name"],
+                tag=tag,
+                name=account_name,
                 commission_deposit=insurance_meta.get("commission_deposits_pct"),
                 commission_management=insurance_meta.get("commission_savings_pct"),
                 liquidity_date=insurance_meta.get("liquidity_date"),

--- a/backend/services/investments_service.py
+++ b/backend/services/investments_service.py
@@ -195,22 +195,36 @@ class InvestmentsService:
         existing = self.investments_repo.get_by_insurance_policy_id(policy_id)
 
         if existing.empty:
-            self.investments_repo.create_investment(
-                category=INVESTMENTS_CATEGORY,
-                tag=tag,
-                type_="hishtalmut",
-                name=insurance_meta["account_name"],
-                interest_rate_type="variable",
-                commission_deposit=insurance_meta.get("commission_deposits_pct"),
-                commission_management=insurance_meta.get("commission_savings_pct"),
-                liquidity_date=insurance_meta.get("liquidity_date"),
-            )
-            created = self.investments_repo.get_by_category_tag(INVESTMENTS_CATEGORY, tag)
-            if not created.empty:
-                inv_id = int(created.iloc[0]["id"])
+            # Check if an investment already exists by category+tag but isn't linked yet
+            by_tag = self.investments_repo.get_by_category_tag(INVESTMENTS_CATEGORY, tag)
+            if not by_tag.empty:
+                # Link the existing investment to this policy
+                inv_id = int(by_tag.iloc[0]["id"])
                 self.investments_repo.update_investment(
-                    inv_id, insurance_policy_id=policy_id
+                    inv_id,
+                    insurance_policy_id=policy_id,
+                    name=insurance_meta["account_name"],
+                    commission_deposit=insurance_meta.get("commission_deposits_pct"),
+                    commission_management=insurance_meta.get("commission_savings_pct"),
+                    liquidity_date=insurance_meta.get("liquidity_date"),
                 )
+            else:
+                self.investments_repo.create_investment(
+                    category=INVESTMENTS_CATEGORY,
+                    tag=tag,
+                    type_="hishtalmut",
+                    name=insurance_meta["account_name"],
+                    interest_rate_type="variable",
+                    commission_deposit=insurance_meta.get("commission_deposits_pct"),
+                    commission_management=insurance_meta.get("commission_savings_pct"),
+                    liquidity_date=insurance_meta.get("liquidity_date"),
+                )
+                created = self.investments_repo.get_by_category_tag(INVESTMENTS_CATEGORY, tag)
+                if not created.empty:
+                    inv_id = int(created.iloc[0]["id"])
+                    self.investments_repo.update_investment(
+                        inv_id, insurance_policy_id=policy_id
+                    )
         else:
             inv_id = int(existing.iloc[0]["id"])
             self.investments_repo.update_investment(

--- a/backend/services/investments_service.py
+++ b/backend/services/investments_service.py
@@ -190,30 +190,39 @@ class InvestmentsService:
 
         policy_id = insurance_meta["policy_id"]
         provider = insurance_meta.get("provider", "unknown")
-        tag = f"Keren Hishtalmut - {provider}"
+        account_name = insurance_meta["account_name"]
 
         existing = self.investments_repo.get_by_insurance_policy_id(policy_id)
 
         if existing.empty:
-            # Check if an investment already exists by category+tag but isn't linked yet
-            by_tag = self.investments_repo.get_by_category_tag(INVESTMENTS_CATEGORY, tag)
-            if not by_tag.empty:
-                # Link the existing investment to this policy
+            # Check if an unlinked investment exists with the base tag
+            base_tag = f"Keren Hishtalmut - {provider}"
+            by_tag = self.investments_repo.get_by_category_tag(
+                INVESTMENTS_CATEGORY, base_tag
+            )
+            if not by_tag.empty and pd.isna(by_tag.iloc[0].get("insurance_policy_id")):
+                # Link the existing unlinked investment to this policy
                 inv_id = int(by_tag.iloc[0]["id"])
                 self.investments_repo.update_investment(
                     inv_id,
                     insurance_policy_id=policy_id,
-                    name=insurance_meta["account_name"],
+                    name=account_name,
                     commission_deposit=insurance_meta.get("commission_deposits_pct"),
                     commission_management=insurance_meta.get("commission_savings_pct"),
                     liquidity_date=insurance_meta.get("liquidity_date"),
                 )
             else:
+                # Use policy_id suffix for uniqueness when base tag is taken
+                tag = base_tag
+                if not by_tag.empty:
+                    # Extract short suffix from policy_id (last parenthesized number or last segment)
+                    suffix = policy_id.split("(")[-1].rstrip(")") if "(" in policy_id else policy_id[-6:]
+                    tag = f"{base_tag} ({suffix})"
                 self.investments_repo.create_investment(
                     category=INVESTMENTS_CATEGORY,
                     tag=tag,
                     type_="hishtalmut",
-                    name=insurance_meta["account_name"],
+                    name=account_name,
                     interest_rate_type="variable",
                     commission_deposit=insurance_meta.get("commission_deposits_pct"),
                     commission_management=insurance_meta.get("commission_savings_pct"),
@@ -756,7 +765,9 @@ class InvestmentsService:
             inv["category"], inv["tag"]
         )
 
-        if transactions_df.empty:
+        snapshots_df = self.snapshots_repo.get_snapshots_for_investment(investment_id)
+
+        if transactions_df.empty and snapshots_df.empty:
             return []
 
         # For closed investments, stop at the last transaction date
@@ -765,8 +776,6 @@ class InvestmentsService:
             last_txn_date = pd.to_datetime(transactions_df["date"]).max().date()
             requested_end_date = datetime.strptime(end_date, "%Y-%m-%d").date()
             actual_end_date = min(last_txn_date, requested_end_date).strftime("%Y-%m-%d")
-
-        snapshots_df = self.snapshots_repo.get_snapshots_for_investment(investment_id)
 
         if snapshots_df.empty:
             # No snapshots — use transaction-based approach
@@ -849,6 +858,24 @@ class InvestmentsService:
         )
 
         if transactions_df.empty:
+            # No transactions — check if there's a snapshot (e.g. insurance-synced)
+            if not inv["is_closed"]:
+                latest = self.snapshots_repo.get_latest_snapshot_on_or_before(
+                    investment_id, date.today().strftime("%Y-%m-%d")
+                )
+                if latest is not None:
+                    balance = float(latest["balance"])
+                    return {
+                        "total_deposits": 0.0,
+                        "total_withdrawals": 0.0,
+                        "net_invested": 0.0,
+                        "current_balance": balance,
+                        "absolute_profit_loss": balance,
+                        "roi_percentage": 0.0,
+                        "total_years": 0.0,
+                        "cagr_percentage": 0.0,
+                        "first_transaction_date": None,
+                    }
             return {
                 "total_deposits": 0.0,
                 "total_withdrawals": 0.0,

--- a/backend/services/investments_service.py
+++ b/backend/services/investments_service.py
@@ -76,7 +76,7 @@ class InvestmentsService:
             record["latest_snapshot_date"] = latest["date"] if latest else None
 
             txns = self._get_all_transactions_for_investment(
-                record["category"], record["tag"]
+                record["category"], record["tag"], investment_id=record["id"]
             )
             if not txns.empty:
                 record["first_transaction_date"] = pd.to_datetime(txns["date"]).min().strftime("%Y-%m-%d")
@@ -278,7 +278,7 @@ class InvestmentsService:
         self.investments_repo.close_investment(investment_id, closed_date)
 
         inv = self.investments_repo.get_by_id(investment_id).iloc[0]
-        txns = self._get_all_transactions_for_investment(inv["category"], inv["tag"])
+        txns = self._get_all_transactions_for_investment(inv["category"], inv["tag"], investment_id=investment_id)
         if not txns.empty:
             txns["date_parsed"] = pd.to_datetime(txns["date"])
             last_txn_date = txns["date_parsed"].max().strftime("%Y-%m-%d")
@@ -403,7 +403,7 @@ class InvestmentsService:
         daily_rate = (1 + annual_rate) ** (1 / 365) - 1
 
         transactions_df = self._get_all_transactions_for_investment(
-            inv["category"], inv["tag"]
+            inv["category"], inv["tag"], investment_id=investment_id
         )
         if transactions_df.empty:
             return
@@ -731,7 +731,7 @@ class InvestmentsService:
 
         # Fall back to transaction-based
         transactions_df = self._get_all_transactions_for_investment(
-            inv["category"], inv["tag"]
+            inv["category"], inv["tag"], investment_id=investment_id
         )
         return self._calculate_balance_from_transactions(transactions_df)
 
@@ -764,7 +764,7 @@ class InvestmentsService:
 
         inv = investment.iloc[0]
         transactions_df = self._get_all_transactions_for_investment(
-            inv["category"], inv["tag"]
+            inv["category"], inv["tag"], investment_id=investment_id
         )
 
         snapshots_df = self.snapshots_repo.get_snapshots_for_investment(investment_id)
@@ -856,7 +856,7 @@ class InvestmentsService:
         investment = self.investments_repo.get_by_id(investment_id)
         inv = investment.iloc[0]
         transactions_df = self._get_all_transactions_for_investment(
-            inv["category"], inv["tag"]
+            inv["category"], inv["tag"], investment_id=investment_id
         )
 
         if transactions_df.empty:
@@ -977,7 +977,7 @@ class InvestmentsService:
 
         frames = []
         for _, inv in investments.iterrows():
-            txns = self._get_all_transactions_for_investment(inv["category"], inv["tag"])
+            txns = self._get_all_transactions_for_investment(inv["category"], inv["tag"], investment_id=int(inv["id"]))
             if not txns.empty:
                 frames.append(txns)
 
@@ -990,10 +990,14 @@ class InvestmentsService:
         return combined
 
     def _get_all_transactions_for_investment(
-        self, category: str, tag: str
+        self, category: str, tag: str, investment_id: Optional[int] = None
     ) -> pd.DataFrame:
         """
         Fetch all transactions for a given investment identified by category and tag.
+
+        For insurance-linked investments, also includes insurance deposit
+        transactions (with amounts negated to match the investment convention:
+        negative = deposit).
 
         Parameters
         ----------
@@ -1001,13 +1005,49 @@ class InvestmentsService:
             Investment category (e.g. ``"Investments"``).
         tag : str
             Investment tag identifying the specific instrument.
+        investment_id : int, optional
+            Investment ID used to look up insurance linkage.
 
         Returns
         -------
         pd.DataFrame
             Matching transactions from the merged analysis table.
         """
-        return self.transactions_service.get_transactions_by_tag(category, tag)
+        manual_txns = self.transactions_service.get_transactions_by_tag(category, tag)
+
+        if investment_id is None:
+            return manual_txns
+
+        inv_df = self.investments_repo.get_by_id(investment_id)
+        if inv_df.empty:
+            return manual_txns
+
+        policy_id = inv_df.iloc[0].get("insurance_policy_id")
+        if not policy_id or pd.isna(policy_id):
+            return manual_txns
+
+        from backend.models.transaction import InsuranceTransaction
+        from sqlalchemy import select
+
+        stmt = select(InsuranceTransaction).where(
+            InsuranceTransaction.account_number == policy_id
+        )
+        ins_txns = pd.read_sql(stmt, self.db.bind)
+
+        if ins_txns.empty:
+            return manual_txns
+
+        # Negate amounts: insurance txns are positive (deposits received),
+        # but investment convention is negative = deposit (money out)
+        ins_txns["amount"] = -ins_txns["amount"]
+
+        if manual_txns.empty:
+            return ins_txns
+
+        common_cols = list(set(manual_txns.columns) & set(ins_txns.columns))
+        return pd.concat(
+            [manual_txns[common_cols], ins_txns[common_cols]], ignore_index=True
+        )
 
     def _calculate_balance_from_transactions(
         self, transactions_df: pd.DataFrame, as_of_date: Optional[str] = None

--- a/backend/services/investments_service.py
+++ b/backend/services/investments_service.py
@@ -167,6 +167,74 @@ class InvestmentsService:
         """
         self.investments_repo.update_investment(investment_id, **updates)
 
+    def sync_from_insurance(self, insurance_meta: dict) -> None:
+        """Create or update an Investment from scraped insurance account metadata.
+
+        Only processes hishtalmut policies. Creates the Investment if not found
+        by ``insurance_policy_id``, otherwise updates metadata fields. Upserts
+        a ``"scraped"`` balance snapshot if balance data is present, without
+        overwriting existing ``"manual"`` snapshots.
+
+        Parameters
+        ----------
+        insurance_meta : dict
+            Insurance account metadata with keys: ``policy_id``, ``policy_type``,
+            ``provider``, ``account_name``, ``balance``, ``balance_date``,
+            ``commission_deposits_pct``, ``commission_savings_pct``,
+            ``liquidity_date``.
+        """
+        if insurance_meta.get("policy_type") != "hishtalmut":
+            return
+
+        from backend.constants.categories import INVESTMENTS_CATEGORY
+
+        policy_id = insurance_meta["policy_id"]
+        provider = insurance_meta.get("provider", "unknown")
+        tag = f"Keren Hishtalmut - {provider}"
+
+        existing = self.investments_repo.get_by_insurance_policy_id(policy_id)
+
+        if existing.empty:
+            self.investments_repo.create_investment(
+                category=INVESTMENTS_CATEGORY,
+                tag=tag,
+                type_="hishtalmut",
+                name=insurance_meta["account_name"],
+                interest_rate_type="variable",
+                commission_deposit=insurance_meta.get("commission_deposits_pct"),
+                commission_management=insurance_meta.get("commission_savings_pct"),
+                liquidity_date=insurance_meta.get("liquidity_date"),
+            )
+            created = self.investments_repo.get_by_category_tag(INVESTMENTS_CATEGORY, tag)
+            if not created.empty:
+                inv_id = int(created.iloc[0]["id"])
+                self.investments_repo.update_investment(
+                    inv_id, insurance_policy_id=policy_id
+                )
+        else:
+            inv_id = int(existing.iloc[0]["id"])
+            self.investments_repo.update_investment(
+                inv_id,
+                name=insurance_meta["account_name"],
+                commission_deposit=insurance_meta.get("commission_deposits_pct"),
+                commission_management=insurance_meta.get("commission_savings_pct"),
+                liquidity_date=insurance_meta.get("liquidity_date"),
+            )
+
+        balance = insurance_meta.get("balance")
+        balance_date = insurance_meta.get("balance_date")
+        if balance is not None and balance_date is not None:
+            inv_df = self.investments_repo.get_by_insurance_policy_id(policy_id)
+            inv_id = int(inv_df.iloc[0]["id"])
+
+            existing_snapshots = self.snapshots_repo.get_snapshots_for_investment(inv_id)
+            if not existing_snapshots.empty:
+                date_match = existing_snapshots[existing_snapshots["date"] == balance_date]
+                if not date_match.empty and date_match.iloc[0]["source"] == "manual":
+                    return
+
+            self.snapshots_repo.upsert_snapshot(inv_id, balance_date, balance, source="scraped")
+
     def close_investment(self, investment_id: int, closed_date: str) -> None:
         """
         Mark an investment as closed.

--- a/docs/superpowers/plans/2026-03-11-auto-investment-from-hishtalmut.md
+++ b/docs/superpowers/plans/2026-03-11-auto-investment-from-hishtalmut.md
@@ -1,0 +1,520 @@
+# Auto-create Investments from Scraped Keren Hishtalmut — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically create and maintain Investment records + balance snapshots when Keren Hishtalmut data is scraped from insurance providers.
+
+**Architecture:** Extend `InsuranceScraperAdapter._post_save_hook()` to call a new `InvestmentsService.sync_from_insurance()` method for hishtalmut policies. Link investments to insurance accounts via a new `insurance_policy_id` column on the `investments` table.
+
+**Tech Stack:** Python, SQLAlchemy ORM, Alembic, pytest
+
+---
+
+## Chunk 1: Model + Migration + Repository
+
+### Task 1: Add `insurance_policy_id` column to Investment model
+
+**Files:**
+- Modify: `backend/models/investment.py`
+- Modify: `backend/constants/tables.py:119-145` (InvestmentsTableFields enum)
+
+- [ ] **Step 1: Add column to Investment model**
+
+In `backend/models/investment.py`, add after `prior_wealth_amount`:
+
+```python
+insurance_policy_id = Column(String, nullable=True, unique=True)
+```
+
+- [ ] **Step 2: Add field to InvestmentsTableFields enum**
+
+In `backend/constants/tables.py`, add to the `InvestmentsTableFields` enum:
+
+```python
+INSURANCE_POLICY_ID = "insurance_policy_id"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/models/investment.py backend/constants/tables.py
+git commit -m "feat: add insurance_policy_id column to Investment model"
+```
+
+### Task 2: Create Alembic migration
+
+**Files:**
+- Create: `backend/alembic/versions/<auto>_add_insurance_policy_id_to_investments.py`
+
+- [ ] **Step 1: Generate migration**
+
+```bash
+cd /Users/tomer/Desktop/finance-analysis/.claude/worktrees/charming-brahmagupta
+source .venv/bin/activate
+alembic -c backend/alembic.ini revision --autogenerate -m "add insurance_policy_id to investments"
+```
+
+- [ ] **Step 2: Verify migration contents**
+
+Open the generated file and confirm it contains:
+- `op.add_column('investments', sa.Column('insurance_policy_id', sa.String(), nullable=True))`
+- `op.create_unique_constraint(...)` for the column
+- Corresponding `downgrade()` that drops the column
+
+If autogenerate didn't pick it up (common with SQLite), manually write:
+
+```python
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = [c['name'] for c in inspector.get_columns('investments')]
+    if 'insurance_policy_id' not in columns:
+        op.add_column('investments', sa.Column('insurance_policy_id', sa.String(), nullable=True, unique=True))
+
+def downgrade() -> None:
+    op.drop_column('investments', 'insurance_policy_id')
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/alembic/versions/
+git commit -m "feat: add migration for insurance_policy_id column"
+```
+
+### Task 3: Add `get_by_insurance_policy_id` to InvestmentsRepository
+
+**Files:**
+- Modify: `backend/repositories/investments_repository.py`
+- Test: `tests/backend/unit/repositories/test_investments_repository.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/backend/unit/repositories/test_investments_repository.py`:
+
+```python
+class TestGetByInsurancePolicyId:
+    """Tests for looking up investments by insurance_policy_id."""
+
+    def test_returns_matching_investment(self, db_session):
+        """Verify lookup by insurance_policy_id returns the linked investment."""
+        from backend.models.investment import Investment
+
+        inv = Investment(
+            category="Investments",
+            tag="Keren Hishtalmut - hafenix",
+            type="hishtalmut",
+            name="Test Hishtalmut",
+            interest_rate_type="variable",
+            created_date="2025-01-01",
+            is_closed=0,
+            prior_wealth_amount=0.0,
+            insurance_policy_id="POL-123",
+        )
+        db_session.add(inv)
+        db_session.flush()
+
+        repo = InvestmentsRepository(db_session)
+        result = repo.get_by_insurance_policy_id("POL-123")
+        assert not result.empty
+        assert result.iloc[0]["name"] == "Test Hishtalmut"
+
+    def test_returns_empty_when_not_found(self, db_session):
+        """Verify lookup returns empty DataFrame when no match exists."""
+        repo = InvestmentsRepository(db_session)
+        result = repo.get_by_insurance_policy_id("NONEXISTENT")
+        assert result.empty
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+poetry run pytest tests/backend/unit/repositories/test_investments_repository.py::TestGetByInsurancePolicyId -v
+```
+
+Expected: FAIL — `AttributeError: 'InvestmentsRepository' object has no attribute 'get_by_insurance_policy_id'`
+
+- [ ] **Step 3: Implement the method**
+
+Add to `backend/repositories/investments_repository.py` after `get_by_category_tag`:
+
+```python
+def get_by_insurance_policy_id(self, policy_id: str) -> pd.DataFrame:
+    """Find an investment linked to an insurance policy.
+
+    Parameters
+    ----------
+    policy_id : str
+        The insurance policy ID to look up.
+
+    Returns
+    -------
+    pd.DataFrame
+        Matching investment row, or empty DataFrame if not found.
+    """
+    stmt = select(Investment).where(
+        Investment.insurance_policy_id == policy_id
+    )
+    return pd.read_sql(stmt, self.db.bind)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+poetry run pytest tests/backend/unit/repositories/test_investments_repository.py::TestGetByInsurancePolicyId -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/repositories/investments_repository.py tests/backend/unit/repositories/test_investments_repository.py
+git commit -m "feat: add get_by_insurance_policy_id to InvestmentsRepository"
+```
+
+## Chunk 2: Service Method + Adapter Integration
+
+### Task 4: Add `sync_from_insurance` to InvestmentsService
+
+**Files:**
+- Modify: `backend/services/investments_service.py`
+- Test: `tests/backend/unit/services/test_investments_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/backend/unit/services/test_investments_service.py`:
+
+```python
+class TestSyncFromInsurance:
+    """Tests for syncing investments from scraped insurance data."""
+
+    def _make_hishtalmut_meta(self, **overrides):
+        """Build a minimal hishtalmut insurance metadata dict."""
+        meta = {
+            "policy_id": "POL-HST-001",
+            "policy_type": "hishtalmut",
+            "provider": "hafenix",
+            "account_name": "קרן השתלמות כלשהי",
+            "balance": 150000.0,
+            "balance_date": "2025-06-15",
+            "commission_deposits_pct": 1.0,
+            "commission_savings_pct": 0.5,
+            "liquidity_date": "2029-05-31",
+        }
+        meta.update(overrides)
+        return meta
+
+    def test_creates_investment_on_first_sync(self, db_session):
+        """Verify first sync creates a new Investment record with correct fields."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+
+        service.sync_from_insurance(meta)
+
+        investments = service.get_all_investments()
+        assert len(investments) == 1
+        inv = investments[0]
+        assert inv["insurance_policy_id"] == "POL-HST-001"
+        assert inv["type"] == "hishtalmut"
+        assert inv["category"] == "Investments"
+        assert inv["tag"] == "Keren Hishtalmut - hafenix"
+        assert inv["name"] == "קרן השתלמות כלשהי"
+        assert inv["commission_deposit"] == 1.0
+        assert inv["commission_management"] == 0.5
+        assert inv["liquidity_date"] == "2029-05-31"
+        assert inv["interest_rate_type"] == "variable"
+
+    def test_creates_balance_snapshot_on_first_sync(self, db_session):
+        """Verify first sync creates a scraped balance snapshot."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+
+        service.sync_from_insurance(meta)
+
+        investments = service.get_all_investments()
+        snapshots = service.get_balance_snapshots(investments[0]["id"])
+        assert len(snapshots) == 1
+        assert snapshots[0]["balance"] == 150000.0
+        assert snapshots[0]["date"] == "2025-06-15"
+        assert snapshots[0]["source"] == "scraped"
+
+    def test_updates_existing_investment_on_resync(self, db_session):
+        """Verify subsequent sync updates metadata without creating duplicates."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+        service.sync_from_insurance(meta)
+
+        updated_meta = self._make_hishtalmut_meta(
+            account_name="קרן השתלמות מעודכנת",
+            commission_deposits_pct=0.8,
+            commission_savings_pct=0.4,
+            liquidity_date="2030-01-01",
+            balance=160000.0,
+            balance_date="2025-07-15",
+        )
+        service.sync_from_insurance(updated_meta)
+
+        investments = service.get_all_investments()
+        assert len(investments) == 1
+        inv = investments[0]
+        assert inv["name"] == "קרן השתלמות מעודכנת"
+        assert inv["commission_deposit"] == 0.8
+        assert inv["commission_management"] == 0.4
+        assert inv["liquidity_date"] == "2030-01-01"
+
+    def test_skips_pension_policies(self, db_session):
+        """Verify pension policies are ignored by sync."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta(policy_type="pension")
+
+        service.sync_from_insurance(meta)
+
+        investments = service.get_all_investments()
+        assert len(investments) == 0
+
+    def test_does_not_overwrite_manual_snapshot(self, db_session):
+        """Verify scraped snapshot skips dates with existing manual snapshots."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+        service.sync_from_insurance(meta)
+
+        inv_id = service.get_all_investments()[0]["id"]
+        # Overwrite the scraped snapshot with a manual one on the same date
+        service.create_balance_snapshot(inv_id, "2025-06-15", 999999.0, source="manual")
+
+        # Re-sync with different balance on same date
+        meta["balance"] = 160000.0
+        service.sync_from_insurance(meta)
+
+        snapshots = service.get_balance_snapshots(inv_id)
+        snapshot_on_date = [s for s in snapshots if s["date"] == "2025-06-15"]
+        assert len(snapshot_on_date) == 1
+        assert snapshot_on_date[0]["balance"] == 999999.0
+        assert snapshot_on_date[0]["source"] == "manual"
+
+    def test_updates_existing_scraped_snapshot_on_same_date(self, db_session):
+        """Verify re-scraping the same date updates the scraped snapshot balance."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+        service.sync_from_insurance(meta)
+
+        meta["balance"] = 155000.0
+        service.sync_from_insurance(meta)
+
+        inv_id = service.get_all_investments()[0]["id"]
+        snapshots = service.get_balance_snapshots(inv_id)
+        assert len(snapshots) == 1
+        assert snapshots[0]["balance"] == 155000.0
+
+    def test_skips_snapshot_when_no_balance(self, db_session):
+        """Verify no snapshot is created when balance data is missing."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta(balance=None, balance_date=None)
+
+        service.sync_from_insurance(meta)
+
+        investments = service.get_all_investments()
+        assert len(investments) == 1
+        snapshots = service.get_balance_snapshots(investments[0]["id"])
+        assert len(snapshots) == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+poetry run pytest tests/backend/unit/services/test_investments_service.py::TestSyncFromInsurance -v
+```
+
+Expected: FAIL — `AttributeError: 'InvestmentsService' object has no attribute 'sync_from_insurance'`
+
+- [ ] **Step 3: Implement `sync_from_insurance`**
+
+Add to `backend/services/investments_service.py`:
+
+```python
+def sync_from_insurance(self, insurance_meta: dict) -> None:
+    """Create or update an Investment from scraped insurance account metadata.
+
+    Only processes hishtalmut policies. Creates the Investment if not found
+    by ``insurance_policy_id``, otherwise updates metadata fields. Upserts
+    a ``"scraped"`` balance snapshot if balance data is present, without
+    overwriting existing ``"manual"`` snapshots.
+
+    Parameters
+    ----------
+    insurance_meta : dict
+        Insurance account metadata with keys: ``policy_id``, ``policy_type``,
+        ``provider``, ``account_name``, ``balance``, ``balance_date``,
+        ``commission_deposits_pct``, ``commission_savings_pct``,
+        ``liquidity_date``.
+    """
+    if insurance_meta.get("policy_type") != "hishtalmut":
+        return
+
+    from backend.constants.categories import INVESTMENTS_CATEGORY
+
+    policy_id = insurance_meta["policy_id"]
+    provider = insurance_meta.get("provider", "unknown")
+    tag = f"Keren Hishtalmut - {provider}"
+
+    existing = self.investments_repo.get_by_insurance_policy_id(policy_id)
+
+    if existing.empty:
+        self.investments_repo.create_investment(
+            category=INVESTMENTS_CATEGORY,
+            tag=tag,
+            type_="hishtalmut",
+            name=insurance_meta["account_name"],
+            interest_rate_type="variable",
+            commission_deposit=insurance_meta.get("commission_deposits_pct"),
+            commission_management=insurance_meta.get("commission_savings_pct"),
+            liquidity_date=insurance_meta.get("liquidity_date"),
+        )
+        # Set insurance_policy_id on the newly created record
+        created = self.investments_repo.get_by_category_tag(INVESTMENTS_CATEGORY, tag)
+        if not created.empty:
+            inv_id = int(created.iloc[0]["id"])
+            self.investments_repo.update_investment(
+                inv_id, insurance_policy_id=policy_id
+            )
+    else:
+        inv_id = int(existing.iloc[0]["id"])
+        self.investments_repo.update_investment(
+            inv_id,
+            name=insurance_meta["account_name"],
+            commission_deposit=insurance_meta.get("commission_deposits_pct"),
+            commission_management=insurance_meta.get("commission_savings_pct"),
+            liquidity_date=insurance_meta.get("liquidity_date"),
+        )
+
+    # Upsert balance snapshot if balance data is present
+    balance = insurance_meta.get("balance")
+    balance_date = insurance_meta.get("balance_date")
+    if balance is not None and balance_date is not None:
+        inv_df = self.investments_repo.get_by_insurance_policy_id(policy_id)
+        inv_id = int(inv_df.iloc[0]["id"])
+
+        # Check for existing manual snapshot on this date — don't overwrite
+        existing_snapshot = self.snapshots_repo.get_snapshots_for_investment(inv_id)
+        if not existing_snapshot.empty:
+            date_match = existing_snapshot[existing_snapshot["date"] == balance_date]
+            if not date_match.empty and date_match.iloc[0]["source"] == "manual":
+                return
+
+        self.snapshots_repo.upsert_snapshot(inv_id, balance_date, balance, source="scraped")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+poetry run pytest tests/backend/unit/services/test_investments_service.py::TestSyncFromInsurance -v
+```
+
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Run full investments test suite for regressions**
+
+```bash
+poetry run pytest tests/backend/unit/services/test_investments_service.py -v
+```
+
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/services/investments_service.py tests/backend/unit/services/test_investments_service.py
+git commit -m "feat: add sync_from_insurance to InvestmentsService"
+```
+
+### Task 5: Integrate into InsuranceScraperAdapter._post_save_hook
+
+**Files:**
+- Modify: `backend/scraper/adapter.py:415-443`
+
+- [ ] **Step 1: Extend `_post_save_hook`**
+
+In `backend/scraper/adapter.py`, modify `InsuranceScraperAdapter._post_save_hook()` — after the existing metadata upsert loop and commit, add investment sync:
+
+```python
+def _post_save_hook(self, result) -> None:
+    """Persist insurance account metadata and sync hishtalmut investments."""
+    from backend.models.insurance_account import InsuranceAccount
+
+    accounts_to_upsert = [
+        account.metadata
+        for account in result.accounts
+        if account.metadata
+    ]
+    if not accounts_to_upsert:
+        return
+
+    with get_db_context() as db:
+        for meta in accounts_to_upsert:
+            existing = db.query(InsuranceAccount).filter_by(
+                policy_id=meta["policy_id"]
+            ).first()
+            if existing:
+                for key, value in meta.items():
+                    if key != "policy_id":
+                        setattr(existing, key, value)
+            else:
+                db.add(InsuranceAccount(**meta))
+        db.commit()
+        logger.info(
+            "%s: %s: Saved metadata for %d insurance accounts",
+            self.provider_name, self.account_name, len(accounts_to_upsert),
+        )
+
+        # Sync hishtalmut policies to investments
+        from backend.services.investments_service import InvestmentsService
+
+        inv_service = InvestmentsService(db)
+        for meta in accounts_to_upsert:
+            if meta.get("policy_type") == "hishtalmut":
+                try:
+                    inv_service.sync_from_insurance(meta)
+                    logger.info(
+                        "%s: %s: Synced hishtalmut investment for policy %s",
+                        self.provider_name, self.account_name, meta["policy_id"],
+                    )
+                except Exception:
+                    logger.exception(
+                        "%s: %s: Failed to sync hishtalmut investment for policy %s",
+                        self.provider_name, self.account_name, meta["policy_id"],
+                    )
+```
+
+- [ ] **Step 2: Run full test suite to check for regressions**
+
+```bash
+poetry run pytest tests/backend/ -v
+```
+
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/scraper/adapter.py
+git commit -m "feat: sync hishtalmut investments from insurance scraper post-save hook"
+```
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+poetry run pytest
+```
+
+Expected: All tests PASS
+
+- [ ] **Step 2: Run frontend build to verify no type issues**
+
+```bash
+cd /Users/tomer/Desktop/finance-analysis/.claude/worktrees/charming-brahmagupta/frontend && npm run build
+```
+
+Expected: Build succeeds (no frontend changes, but verify nothing broke)

--- a/docs/superpowers/specs/2026-03-11-auto-investment-from-hishtalmut-design.md
+++ b/docs/superpowers/specs/2026-03-11-auto-investment-from-hishtalmut-design.md
@@ -1,0 +1,114 @@
+# Auto-create Investments from Scraped Keren Hishtalmut
+
+## Problem
+
+When insurance data is scraped from HaPhoenix, Keren Hishtalmut policies are stored as `InsuranceAccount` records with balance and metadata. However, to track them as investments (balance history, profit/loss, portfolio overview), users must manually create an `Investment` record. This should happen automatically.
+
+## Scope
+
+- **In scope:** Keren Hishtalmut policies only (`policy_type == "hishtalmut"`)
+- **Out of scope:** Pension policies, transaction linking (deposits stay in `insurance_transactions` only)
+
+## Design
+
+### Linking Mechanism
+
+A new nullable `insurance_policy_id` column on the `investments` table links an Investment to its source `InsuranceAccount.policy_id`. This enables:
+
+- **First scrape:** No matching Investment found → create one
+- **Subsequent scrapes:** Matching Investment found → update metadata + upsert balance snapshot
+
+### Data Mapping
+
+| InsuranceAccount | Investment | Notes |
+|---|---|---|
+| `policy_id` | `insurance_policy_id` | New column, lookup key |
+| `account_name` | `name` | Human-readable policy name |
+| `"Investments"` | `category` | Standard investment category constant |
+| `"Keren Hishtalmut - {provider}"` | `tag` | Provider-qualified tag |
+| `"hishtalmut"` | `type` | Investment type |
+| `commission_deposits_pct` | `commission_deposit` | Fee on deposits |
+| `commission_savings_pct` | `commission_management` | Fee on savings |
+| `liquidity_date` | `liquidity_date` | Withdrawal eligibility date |
+| _(not set)_ | `interest_rate_type` | `"variable"` (market-linked) |
+| _(today)_ | `created_date` | Set on first creation only |
+
+### Balance Snapshots
+
+On each scrape where `balance` and `balance_date` are present on the insurance account:
+
+- Upsert a balance snapshot with `source="scraped"` for that date
+- If a `"scraped"` snapshot already exists for that exact date, update its balance value
+- Never overwrite `"manual"` snapshots (same protection as fixed-rate calculated snapshots)
+
+### Integration Point
+
+`InsuranceScraperAdapter._post_save_hook()` — after upserting insurance account metadata (existing logic), iterate hishtalmut accounts and call `InvestmentsService.sync_from_insurance()`.
+
+## Changes
+
+### 1. Database Migration
+
+Add `insurance_policy_id` column (nullable `String`) to `investments` table. Use Alembic or inline migration pattern consistent with existing codebase.
+
+### 2. Investment Model (`backend/models/investment.py`)
+
+Add:
+```python
+insurance_policy_id = Column(String, nullable=True, unique=True)
+```
+
+### 3. InvestmentsRepository (`backend/repositories/investments_repository.py`)
+
+Add method:
+```python
+def get_by_insurance_policy_id(self, policy_id: str) -> pd.DataFrame:
+    """Find investment linked to an insurance policy."""
+```
+
+### 4. InvestmentsService (`backend/services/investments_service.py`)
+
+Add method:
+```python
+def sync_from_insurance(self, insurance_meta: dict) -> None:
+    """Create or update an Investment from scraped insurance account metadata.
+
+    Parameters
+    ----------
+    insurance_meta : dict
+        Insurance account metadata dict with keys: policy_id, policy_type,
+        provider, account_name, balance, balance_date, commission_deposits_pct,
+        commission_savings_pct, liquidity_date.
+
+    Only processes hishtalmut policies. Creates the Investment if not found
+    by insurance_policy_id, otherwise updates metadata. Upserts a "scraped"
+    balance snapshot if balance data is present.
+    """
+```
+
+Logic:
+1. Skip if `policy_type != "hishtalmut"`
+2. Look up existing Investment by `insurance_policy_id`
+3. If not found: create Investment with mapped fields
+4. If found: update `name`, `commission_deposit`, `commission_management`, `liquidity_date`
+5. If `balance` and `balance_date` present: upsert scraped balance snapshot (skip if manual snapshot exists for that date)
+
+### 5. InsuranceScraperAdapter (`backend/scraper/adapter.py`)
+
+Extend `_post_save_hook()`:
+```python
+# After existing metadata upsert loop
+from backend.services.investments_service import InvestmentsService
+inv_service = InvestmentsService(db)
+for meta in accounts_to_upsert:
+    inv_service.sync_from_insurance(meta)
+```
+
+### 6. Tests
+
+- `test_sync_from_insurance_creates_investment`: First scrape creates Investment with correct fields
+- `test_sync_from_insurance_updates_existing`: Subsequent scrape updates metadata
+- `test_sync_from_insurance_creates_balance_snapshot`: Snapshot created with source="scraped"
+- `test_sync_from_insurance_skips_pension`: Pension policies are ignored
+- `test_sync_from_insurance_no_overwrite_manual_snapshot`: Manual snapshots preserved
+- `test_sync_from_insurance_updates_existing_scraped_snapshot`: Re-scrape same date updates balance

--- a/tests/backend/unit/repositories/test_investments_repository.py
+++ b/tests/backend/unit/repositories/test_investments_repository.py
@@ -248,3 +248,34 @@ class TestInvestmentsRepositoryEmptyUpdate:
         # Verify no changes were made
         db_session.refresh(inv)
         assert inv.name == "Original Name"
+
+
+class TestGetByInsurancePolicyId:
+    """Tests for looking up investments by insurance_policy_id."""
+
+    def test_returns_matching_investment(self, db_session):
+        """Verify lookup by insurance_policy_id returns the linked investment."""
+        inv = Investment(
+            category="Investments",
+            tag="Keren Hishtalmut - hafenix",
+            type="hishtalmut",
+            name="Test Hishtalmut",
+            interest_rate_type="variable",
+            created_date="2025-01-01",
+            is_closed=0,
+            prior_wealth_amount=0.0,
+            insurance_policy_id="POL-123",
+        )
+        db_session.add(inv)
+        db_session.flush()
+
+        repo = InvestmentsRepository(db_session)
+        result = repo.get_by_insurance_policy_id("POL-123")
+        assert not result.empty
+        assert result.iloc[0]["name"] == "Test Hishtalmut"
+
+    def test_returns_empty_when_not_found(self, db_session):
+        """Verify lookup returns empty DataFrame when no match exists."""
+        repo = InvestmentsRepository(db_session)
+        result = repo.get_by_insurance_policy_id("NONEXISTENT")
+        assert result.empty

--- a/tests/backend/unit/services/test_investments_service.py
+++ b/tests/backend/unit/services/test_investments_service.py
@@ -561,3 +561,137 @@ class TestInvestmentsServiceEdgeCases:
         mid_balance = balance_by_date.get("2023-07-16")
         if mid_balance is not None:
             assert 10500.0 < mid_balance < 11000.0
+
+
+class TestSyncFromInsurance:
+    """Tests for syncing investments from scraped insurance data."""
+
+    def _make_hishtalmut_meta(self, **overrides):
+        """Build a minimal hishtalmut insurance metadata dict."""
+        meta = {
+            "policy_id": "POL-HST-001",
+            "policy_type": "hishtalmut",
+            "provider": "hafenix",
+            "account_name": "קרן השתלמות כלשהי",
+            "balance": 150000.0,
+            "balance_date": "2025-06-15",
+            "commission_deposits_pct": 1.0,
+            "commission_savings_pct": 0.5,
+            "liquidity_date": "2029-05-31",
+        }
+        meta.update(overrides)
+        return meta
+
+    def test_creates_investment_on_first_sync(self, db_session):
+        """Verify first sync creates a new Investment record with correct fields."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+
+        service.sync_from_insurance(meta)
+
+        investments = service.get_all_investments()
+        assert len(investments) == 1
+        inv = investments[0]
+        assert inv["insurance_policy_id"] == "POL-HST-001"
+        assert inv["type"] == "hishtalmut"
+        assert inv["category"] == "Investments"
+        assert inv["tag"] == "Keren Hishtalmut - hafenix"
+        assert inv["name"] == "קרן השתלמות כלשהי"
+        assert inv["commission_deposit"] == 1.0
+        assert inv["commission_management"] == 0.5
+        assert inv["liquidity_date"] == "2029-05-31"
+        assert inv["interest_rate_type"] == "variable"
+
+    def test_creates_balance_snapshot_on_first_sync(self, db_session):
+        """Verify first sync creates a scraped balance snapshot."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+
+        service.sync_from_insurance(meta)
+
+        investments = service.get_all_investments()
+        snapshots = service.get_balance_snapshots(investments[0]["id"])
+        assert len(snapshots) == 1
+        assert snapshots[0]["balance"] == 150000.0
+        assert snapshots[0]["date"] == "2025-06-15"
+        assert snapshots[0]["source"] == "scraped"
+
+    def test_updates_existing_investment_on_resync(self, db_session):
+        """Verify subsequent sync updates metadata without creating duplicates."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+        service.sync_from_insurance(meta)
+
+        updated_meta = self._make_hishtalmut_meta(
+            account_name="קרן השתלמות מעודכנת",
+            commission_deposits_pct=0.8,
+            commission_savings_pct=0.4,
+            liquidity_date="2030-01-01",
+            balance=160000.0,
+            balance_date="2025-07-15",
+        )
+        service.sync_from_insurance(updated_meta)
+
+        investments = service.get_all_investments()
+        assert len(investments) == 1
+        inv = investments[0]
+        assert inv["name"] == "קרן השתלמות מעודכנת"
+        assert inv["commission_deposit"] == 0.8
+        assert inv["commission_management"] == 0.4
+        assert inv["liquidity_date"] == "2030-01-01"
+
+    def test_skips_pension_policies(self, db_session):
+        """Verify pension policies are ignored by sync."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta(policy_type="pension")
+
+        service.sync_from_insurance(meta)
+
+        investments = service.get_all_investments()
+        assert len(investments) == 0
+
+    def test_does_not_overwrite_manual_snapshot(self, db_session):
+        """Verify scraped snapshot skips dates with existing manual snapshots."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+        service.sync_from_insurance(meta)
+
+        inv_id = service.get_all_investments()[0]["id"]
+        # Overwrite the scraped snapshot with a manual one on the same date
+        service.create_balance_snapshot(inv_id, "2025-06-15", 999999.0, source="manual")
+
+        # Re-sync with different balance on same date
+        meta["balance"] = 160000.0
+        service.sync_from_insurance(meta)
+
+        snapshots = service.get_balance_snapshots(inv_id)
+        snapshot_on_date = [s for s in snapshots if s["date"] == "2025-06-15"]
+        assert len(snapshot_on_date) == 1
+        assert snapshot_on_date[0]["balance"] == 999999.0
+        assert snapshot_on_date[0]["source"] == "manual"
+
+    def test_updates_existing_scraped_snapshot_on_same_date(self, db_session):
+        """Verify re-scraping the same date updates the scraped snapshot balance."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta()
+        service.sync_from_insurance(meta)
+
+        meta["balance"] = 155000.0
+        service.sync_from_insurance(meta)
+
+        inv_id = service.get_all_investments()[0]["id"]
+        snapshots = service.get_balance_snapshots(inv_id)
+        assert len(snapshots) == 1
+        assert snapshots[0]["balance"] == 155000.0
+
+    def test_skips_snapshot_when_no_balance(self, db_session):
+        """Verify no snapshot is created when balance data is missing."""
+        service = InvestmentsService(db_session)
+        meta = self._make_hishtalmut_meta(balance=None, balance_date=None)
+
+        service.sync_from_insurance(meta)
+
+        investments = service.get_all_investments()
+        assert len(investments) == 1
+        snapshots = service.get_balance_snapshots(investments[0]["id"])
+        assert len(snapshots) == 0

--- a/tests/backend/unit/services/test_investments_service.py
+++ b/tests/backend/unit/services/test_investments_service.py
@@ -595,7 +595,7 @@ class TestSyncFromInsurance:
         assert inv["insurance_policy_id"] == "POL-HST-001"
         assert inv["type"] == "hishtalmut"
         assert inv["category"] == "Investments"
-        assert inv["tag"] == "Keren Hishtalmut - hafenix"
+        assert inv["tag"] == "Keren Hishtalmut - hafenix (POL-HST-001)"
         assert inv["name"] == "קרן השתלמות כלשהי"
         assert inv["commission_deposit"] == 1.0
         assert inv["commission_management"] == 0.5


### PR DESCRIPTION
## Summary

- Automatically create Investment records when Keren Hishtalmut policies are scraped from insurance providers (HaPhoenix)
- Link investments to insurance policies via new `insurance_policy_id` column on the investments table
- Create/update balance snapshots (source=`scraped`) on each scrape, without overwriting manual snapshots
- Include insurance deposit transactions in investment profit/loss and balance calculations
- Support multiple hishtalmut policies per provider with unique tags containing policy IDs
- Add backfill endpoint `POST /api/insurance-accounts/sync-investments` for existing data

## Key Changes

- **Model**: Added `insurance_policy_id` column to `investments` table (unique, nullable)
- **Repository**: Added `get_by_insurance_policy_id()` lookup method
- **Service**: `sync_from_insurance()` creates/updates investments from insurance metadata; `_get_all_transactions_for_investment()` now includes insurance deposit transactions (negated) for linked investments
- **Scraper adapter**: `InsuranceScraperAdapter._post_save_hook()` calls sync for hishtalmut policies
- **Route**: Backfill endpoint for retroactive sync of existing insurance data
- **Fixes**: `calculate_profit_loss` and `calculate_balance_over_time` now work for snapshot-only investments (no transactions)

## Test plan

- [x] 869 backend tests pass
- [x] Frontend builds successfully
- [x] Backfill creates investments for all existing hishtalmut policies
- [x] Investment analysis shows correct deposits, balance, and profit from insurance transactions
- [x] Manual snapshots are not overwritten by scraped ones
- [x] Multiple policies per provider get unique tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)