### PR TITLE
fix(backend): replace deprecated .dict() with .model_dump()

### DIFF
--- a/backend/routes/budget.py
+++ b/backend/routes/budget.py
@@ -86,7 +86,7 @@ async def update_budget_rule(
 ) -> dict[str, str]:
     """Update a budget rule."""
     service = BudgetService(db)
-    updates = {k: v for k, v in rule.dict().items() if v is not None}
+    updates = {k: v for k, v in rule.model_dump().items() if v is not None}
     service.update_rule(rule_id, **updates)
     return {"status": "success"}
 

--- a/backend/routes/investments.py
+++ b/backend/routes/investments.py
@@ -146,7 +146,7 @@ async def update_investment(
 ) -> dict[str, str]:
     """Update an investment."""
     service = InvestmentsService(db)
-    updates = {k: v for k, v in investment.dict().items() if v is not None}
+    updates = {k: v for k, v in investment.model_dump().items() if v is not None}
     service.update_investment(investment_id, **updates)
     return {"status": "success"}
 
@@ -234,7 +234,7 @@ async def update_balance_snapshot(
 ) -> dict[str, str]:
     """Update an existing balance snapshot."""
     service = InvestmentsService(db)
-    updates = {k: v for k, v in snapshot.dict().items() if v is not None}
+    updates = {k: v for k, v in snapshot.model_dump().items() if v is not None}
     service.update_balance_snapshot(snapshot_id, **updates)
     return {"status": "success"}
 


### PR DESCRIPTION
Pydantic v1's .dict() is deprecated in v2. Replace all three occurrences with .model_dump() for forward compatibility.

https://claude.ai/code/session_017JuXbqUyUjnfpyofcKHkJL