### PR TITLE
feat(frontend): add i18n support to Insurances page

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -513,7 +513,9 @@
     "mashlima": "Mashlima",
     "kerenHistahlmut": "Keren Hishtalmut",
     "policy": "Policy",
-    "updated": "Updated"
+    "updated": "Updated",
+    "chartMonthly": "Monthly",
+    "chartCumulative": "Cumulative"
   },
   "modals": {
     "confirm": {

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -513,7 +513,9 @@
     "mashlima": "משלימה",
     "kerenHistahlmut": "קרן השתלמות",
     "policy": "פוליסה",
-    "updated": "עודכן"
+    "updated": "עודכן",
+    "chartMonthly": "חודשי",
+    "chartCumulative": "מצטבר"
   },
   "modals": {
     "confirm": {

--- a/frontend/src/pages/InsurancesPrototype.tsx
+++ b/frontend/src/pages/InsurancesPrototype.tsx
@@ -196,7 +196,7 @@ function AccountCardFull({
             </p>
           </div>
         </div>
-        <div className="text-right">
+        <div className="text-end">
           <p className="text-2xl font-black text-white">{fmt(account.balance ?? 0)}</p>
           <p className="text-xs text-[var(--text-muted)]">{t("insurance.currentBalance")}</p>
         </div>
@@ -211,7 +211,7 @@ function AccountCardFull({
           </p>
           {tracks.map((t, i) => (
             <div key={i} className="flex justify-between items-center text-xs mb-1">
-              <span className="text-[var(--text-muted)] truncate mr-2">{t.name}</span>
+              <span className="text-[var(--text-muted)] truncate me-2">{t.name}</span>
               <span
                 className={`font-mono font-bold whitespace-nowrap ${t.yield_pct >= 0 ? "text-emerald-400" : "text-rose-400"}`}
               >
@@ -261,7 +261,7 @@ function AccountCardFull({
             </p>
             {covers.map((c, i) => (
               <div key={i} className="flex justify-between text-xs mb-1">
-                <span className="text-[var(--text-muted)] truncate mr-2">{c.title}</span>
+                <span className="text-[var(--text-muted)] truncate me-2">{c.title}</span>
                 <span className="text-white font-mono font-bold">{fmt(unwrapAmount(c.sum))}</span>
               </div>
             ))}
@@ -318,10 +318,10 @@ function AccountCardFull({
                 <tr className="text-[var(--text-muted)] text-[10px] uppercase tracking-widest border-b border-[var(--surface-light)]">
                   <th className="text-start px-6 py-2 font-bold">{t("common.date")}</th>
                   <th className="text-start px-6 py-2 font-bold">{t("common.description")}</th>
-                  <th className="text-right px-6 py-2 font-bold">{t("insurance.employee")}</th>
-                  <th className="text-right px-6 py-2 font-bold">{t("insurance.employer")}</th>
-                  <th className="text-right px-6 py-2 font-bold">{t("insurance.compensation")}</th>
-                  <th className="text-right px-6 py-2 font-bold">{t("common.total")}</th>
+                  <th className="text-end px-6 py-2 font-bold">{t("insurance.employee")}</th>
+                  <th className="text-end px-6 py-2 font-bold">{t("insurance.employer")}</th>
+                  <th className="text-end px-6 py-2 font-bold">{t("insurance.compensation")}</th>
+                  <th className="text-end px-6 py-2 font-bold">{t("common.total")}</th>
                 </tr>
               </thead>
               <tbody>
@@ -334,16 +334,16 @@ function AccountCardFull({
                     >
                       <td className="px-6 py-2 text-[var(--text-muted)] whitespace-nowrap">{tx.date}</td>
                       <td className="px-6 py-2 text-white">{tx.description}</td>
-                      <td className="px-6 py-2 text-right font-mono text-xs text-[var(--text-muted)]">
+                      <td className="px-6 py-2 text-end font-mono text-xs text-[var(--text-muted)]">
                         {breakdown.employee !== null ? fmt(breakdown.employee) : "—"}
                       </td>
-                      <td className="px-6 py-2 text-right font-mono text-xs text-[var(--text-muted)]">
+                      <td className="px-6 py-2 text-end font-mono text-xs text-[var(--text-muted)]">
                         {breakdown.employer !== null ? fmt(breakdown.employer) : "—"}
                       </td>
-                      <td className="px-6 py-2 text-right font-mono text-xs text-[var(--text-muted)]">
+                      <td className="px-6 py-2 text-end font-mono text-xs text-[var(--text-muted)]">
                         {breakdown.compensation !== null ? fmt(breakdown.compensation) : "—"}
                       </td>
-                      <td className="px-6 py-2 text-right whitespace-nowrap">
+                      <td className="px-6 py-2 text-end whitespace-nowrap">
                         <span
                           className={`font-mono font-bold ${tx.amount >= 0 ? "text-emerald-400" : "text-rose-400"}`}
                         >
@@ -384,7 +384,7 @@ export function InsurancesPrototype() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-96 text-[var(--text-muted)]">
-        <Loader2 size={24} className="animate-spin mr-2" />
+        <Loader2 size={24} className="animate-spin me-2" />
         {t("insurance.loadingData")}
       </div>
     );
@@ -479,14 +479,14 @@ export function InsurancesPrototype() {
                 type: "bar",
                 x: months.map((m) => m + "-01"),
                 y: monthlyValues,
-                name: "Monthly",
+                name: t("insurance.chartMonthly"),
                 marker: { color: "#10b981", opacity: 0.7 },
               },
               {
                 type: "scatter",
                 x: months.map((m) => m + "-01"),
                 y: cumulativeValues,
-                name: "Cumulative",
+                name: t("insurance.chartCumulative"),
                 yaxis: "y2",
                 line: { color: "#3b82f6", width: 2 },
                 mode: "lines",
@@ -502,7 +502,7 @@ export function InsurancesPrototype() {
                 color: "#94a3b8",
                 gridcolor: "#334155",
                 tickfont: { size: 10 },
-                title: { text: "Monthly", font: { size: 10, color: "#94a3b8" } },
+                title: { text: t("insurance.chartMonthly"), font: { size: 10, color: "#94a3b8" } },
               },
               yaxis2: {
                 color: "#94a3b8",
@@ -510,7 +510,7 @@ export function InsurancesPrototype() {
                 side: "right",
                 gridcolor: "transparent",
                 tickfont: { size: 10 },
-                title: { text: "Cumulative", font: { size: 10, color: "#94a3b8" } },
+                title: { text: t("insurance.chartCumulative"), font: { size: 10, color: "#94a3b8" } },
               },
               legend: { font: { color: "#94a3b8", size: 10 }, x: 0, y: 1.15, orientation: "h" },
               showlegend: true,


### PR DESCRIPTION
Replace hardcoded English chart labels with translation keys and convert physical CSS properties (mr-*, text-right) to logical properties (me-*, text-end) for proper RTL support.

https://claude.ai/code/session_017JuXbqUyUjnfpyofcKHkJL