### PR TITLE
ci(backend): add pytest-cov configuration for test coverage reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,24 @@ pytest-cov = "^7.0.0"
 [tool.pytest.ini_options]
 pythonpath = ["."]
 markers = ["sensitive: marks tests that pulls sensitive data from the internet"]
+addopts = "--cov=backend --cov-report=term-missing"
+
+[tool.coverage.run]
+source = ["backend"]
+omit = [
+    "tests/*",
+    "*/__pycache__/*",
+    "backend/scraper/*",
+]
+
+[tool.coverage.report]
+fail_under = 40
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
 
 [tool.commitizen]
 name = "cz_conventional_commits"


### PR DESCRIPTION
Configure coverage to track backend/ source with 40% minimum threshold and term-missing report output by default.

https://claude.ai/code/session_017JuXbqUyUjnfpyofcKHkJL