### PR TITLE
feat(frontend): improve net worth chart with dual y-axis and dark hov…

### DIFF
--- a/frontend/src/components/SankeyChart.tsx
+++ b/frontend/src/components/SankeyChart.tsx
@@ -1,5 +1,5 @@
 import Plot from "react-plotly.js";
-import { plotlyConfig } from "../utils/plotlyLocale";
+import { chartTheme, plotlyConfig } from "../utils/plotlyLocale";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -64,13 +64,7 @@ export function SankeyChart({ data, height = 500 }: SankeyChartProps) {
   }, [data]);
 
   const layout = {
-    font: {
-      size: 12,
-      color: "#94a3b8",
-      family: "Inter, sans-serif",
-    },
-    paper_bgcolor: "rgba(0,0,0,0)",
-    plot_bgcolor: "rgba(0,0,0,0)",
+    ...chartTheme,
     margin: { t: 20, b: 20, l: 20, r: 20 },
     height: height,
     autosize: true,

--- a/frontend/src/components/dashboard/DashboardInsightsPanel.tsx
+++ b/frontend/src/components/dashboard/DashboardInsightsPanel.tsx
@@ -4,7 +4,7 @@ import Plot from "react-plotly.js";
 import { TrendingDown, Calculator, Tag } from "lucide-react";
 import { SankeyChart } from "../SankeyChart";
 import { Skeleton } from "../common/Skeleton";
-import { plotlyConfig } from "../../utils/plotlyLocale";
+import { chartTheme, plotlyConfig } from "../../utils/plotlyLocale";
 
 type NetWorthView = "all" | "bank_balance" | "investments" | "net_worth";
 type InsightTab = "monthly_expenses" | "net_worth" | "cash_flow" | "income_expenses" | "category";
@@ -63,15 +63,6 @@ const formatCurrency = (val: number) =>
     maximumFractionDigits: 0,
   }).format(val || 0);
 
-const chartTheme = {
-  paper_bgcolor: "rgba(0,0,0,0)",
-  plot_bgcolor: "rgba(0,0,0,0)",
-  font: { color: "#94a3b8", family: "Inter, sans-serif" },
-  margin: { t: 40, b: 40, l: 40, r: 20 },
-  hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
-  hovermode: "x unified" as const,
-  xaxis: { showspikes: false },
-};
 
 interface DashboardInsightsPanelProps {
   netWorthData: NetWorthDataPoint[] | undefined;

--- a/frontend/src/components/dashboard/DashboardInsightsPanel.tsx
+++ b/frontend/src/components/dashboard/DashboardInsightsPanel.tsx
@@ -68,6 +68,9 @@ const chartTheme = {
   plot_bgcolor: "rgba(0,0,0,0)",
   font: { color: "#94a3b8", family: "Inter, sans-serif" },
   margin: { t: 40, b: 40, l: 40, r: 20 },
+  hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
+  hovermode: "x unified" as const,
+  xaxis: { showspikes: false },
 };
 
 interface DashboardInsightsPanelProps {
@@ -196,6 +199,7 @@ export function DashboardInsightsPanel({
         mode: "lines+markers",
         line: { color: config.color, width: 3 },
         marker: { size: 8, color: config.color },
+        yaxis: "y2",
       },
     ];
   };
@@ -385,11 +389,25 @@ export function DashboardInsightsPanel({
                       autosize: true,
                       yaxis: {
                         title: {
-                          text: t("dashboard.amountILS"),
+                          text: netWorthView === "all" ? t("dashboard.amountILS") : t("dashboard.monthlyChange"),
                           font: { color: "#94a3b8" },
                         },
                         tickfont: { color: "#94a3b8" },
+                        automargin: true,
                       },
+                      ...(netWorthView !== "all" && {
+                        yaxis2: {
+                          title: {
+                            text: seriesConfig[netWorthView].label,
+                            font: { color: seriesConfig[netWorthView].color },
+                          },
+                          tickfont: { color: seriesConfig[netWorthView].color },
+                          overlaying: "y" as const,
+                          side: "right" as const,
+                          showgrid: false,
+                          automargin: true,
+                        },
+                      }),
                       legend: {
                         orientation: "h",
                         y: -0.15,

--- a/frontend/src/components/investments/InvestmentAnalysisModal.tsx
+++ b/frontend/src/components/investments/InvestmentAnalysisModal.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import Plot from "react-plotly.js";
 import { investmentsApi } from "../../services/api";
-import { plotlyConfig } from "../../utils/plotlyLocale";
+import { chartTheme, plotlyConfig } from "../../utils/plotlyLocale";
 
 interface Investment {
   id: number;
@@ -67,15 +67,6 @@ const formatCurrency = (val: number) =>
 const formatPercent = (val: number) =>
   `${val > 0 ? "+" : ""}${val.toFixed(2)}%`;
 
-const chartTheme = {
-  paper_bgcolor: "rgba(0,0,0,0)",
-  plot_bgcolor: "rgba(0,0,0,0)",
-  font: { color: "#94a3b8", family: "Inter, sans-serif" },
-  margin: { t: 30, b: 30, l: 40, r: 20 },
-  hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
-  hovermode: "x unified" as const,
-  xaxis: { showspikes: false },
-};
 
 interface InvestmentAnalysisModalProps {
   investmentId: number;

--- a/frontend/src/components/investments/InvestmentAnalysisModal.tsx
+++ b/frontend/src/components/investments/InvestmentAnalysisModal.tsx
@@ -72,6 +72,9 @@ const chartTheme = {
   plot_bgcolor: "rgba(0,0,0,0)",
   font: { color: "#94a3b8", family: "Inter, sans-serif" },
   margin: { t: 30, b: 30, l: 40, r: 20 },
+  hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
+  hovermode: "x unified" as const,
+  xaxis: { showspikes: false },
 };
 
 interface InvestmentAnalysisModalProps {

--- a/frontend/src/components/investments/PortfolioOverview.tsx
+++ b/frontend/src/components/investments/PortfolioOverview.tsx
@@ -72,6 +72,9 @@ const chartTheme = {
   plot_bgcolor: "rgba(0,0,0,0)",
   font: { color: "#94a3b8", family: "Inter, sans-serif" },
   margin: { t: 30, b: 30, l: 40, r: 20 },
+  hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
+  hovermode: "x unified" as const,
+  xaxis: { showspikes: false },
 };
 
 interface PortfolioOverviewProps {

--- a/frontend/src/components/investments/PortfolioOverview.tsx
+++ b/frontend/src/components/investments/PortfolioOverview.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Wallet, DollarSign, Percent } from "lucide-react";
 import Plot from "react-plotly.js";
 import { investmentsApi } from "../../services/api";
-import { plotlyConfig } from "../../utils/plotlyLocale";
+import { chartTheme, plotlyConfig } from "../../utils/plotlyLocale";
 
 interface AllocationItem {
   id: number;
@@ -67,15 +67,6 @@ const formatCurrency = (val: number) =>
 const formatPercent = (val: number) =>
   `${val > 0 ? "+" : ""}${val.toFixed(2)}%`;
 
-const chartTheme = {
-  paper_bgcolor: "rgba(0,0,0,0)",
-  plot_bgcolor: "rgba(0,0,0,0)",
-  font: { color: "#94a3b8", family: "Inter, sans-serif" },
-  margin: { t: 30, b: 30, l: 40, r: 20 },
-  hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
-  hovermode: "x unified" as const,
-  xaxis: { showspikes: false },
-};
 
 interface PortfolioOverviewProps {
   portfolioAnalysis: PortfolioAnalysis;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,10 +2,8 @@ import { useState, useMemo, useRef, useCallback, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import {
-  TrendingDown,
   ChevronLeft,
   ChevronRight,
-  Calculator,
   Split,
   RefreshCw,
   Tag,
@@ -13,7 +11,6 @@ import {
   Link2,
   Plus,
 } from "lucide-react";
-import Plot from "react-plotly.js";
 import {
   analyticsApi,
   cashBalancesApi,
@@ -32,17 +29,14 @@ import { LinkRefundModal } from "../components/modals/LinkRefundModal";
 import { ProjectModal } from "../components/modals/ProjectModal";
 import { SelectDropdown } from "../components/common/SelectDropdown";
 import { useCategoryTagCreate } from "../hooks/useCategoryTagCreate";
-import { SankeyChart } from "../components/SankeyChart";
 import { SemiGauge } from "../components/common/SemiGauge";
 import { Skeleton } from "../components/common/Skeleton";
+import { DashboardInsightsPanel } from "../components/dashboard/DashboardInsightsPanel";
 import { useDemoMode } from "../context/DemoModeContext";
 import { isToday, isYesterday } from "date-fns";
 import { useTranslation } from "react-i18next";
 import { formatMonthYear, formatShortDate } from "../utils/dateFormatting";
-import { chartTheme, plotlyConfig } from "../utils/plotlyLocale";
 import i18n from "../i18n";
-
-type NetWorthView = "all" | "bank_balance" | "investments" | "net_worth";
 
 const formatCurrency = (val: number) =>
   new Intl.NumberFormat("he-IL", {
@@ -50,7 +44,6 @@ const formatCurrency = (val: number) =>
     currency: "ILS",
     maximumFractionDigits: 0,
   }).format(val || 0);
-
 
 /* ------------------------------------------------------------------ */
 /*  Helper sub-components (extracted to avoid creating during render)  */
@@ -73,7 +66,7 @@ function BreakdownList({ items }: { items: { name: string; amount: number }[] })
     <div className="mt-2 pt-2 border-t border-[var(--surface-light)] space-y-1">
       {items.map((item) => (
         <div key={item.name} className="flex justify-between text-xs">
-          <span className="text-[var(--text-muted)] truncate mr-2">{item.name}</span>
+          <span className="text-[var(--text-muted)] truncate me-2">{item.name}</span>
           <span className="tabular-nums font-medium shrink-0">{formatCurrency(item.amount)}</span>
         </div>
       ))}
@@ -569,7 +562,7 @@ function BudgetSpendingGauge({
               <BudgetRuleCards rules={miniRules} categoryIcons={categoryIcons} />
 
               {/* Link to budget page */}
-              <div className="text-right">
+              <div className="text-end">
                 <Link
                   to="/budget"
                   className="text-sm font-medium text-[var(--primary)] hover:underline"
@@ -935,7 +928,7 @@ function RecentTransactionsFeed({
                         )}
                       </div>
                       <span
-                        className={`text-sm font-semibold flex-shrink-0 tabular-nums text-right w-[80px] ${
+                        className={`text-sm font-semibold flex-shrink-0 tabular-nums text-end w-[80px] ${
                           isPositive ? "text-emerald-400" : "text-rose-400"
                         }`}
                       >
@@ -946,7 +939,7 @@ function RecentTransactionsFeed({
 
                     {/* Inline tag editing panel */}
                     {isEditing && categories && (
-                      <div className="mx-2 mb-2 ml-11 rounded-lg border border-[var(--surface-light)] bg-[var(--surface-light)]/20 overflow-hidden">
+                      <div className="mx-2 mb-2 ms-11 rounded-lg border border-[var(--surface-light)] bg-[var(--surface-light)]/20 overflow-hidden">
                         <div className="flex items-center gap-3 px-3 py-2">
                           <div className="flex-1 min-w-0">
                             <label className="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1 block">{t("common.category")}</label>
@@ -1048,13 +1041,8 @@ function RecentTransactionsFeed({
 export function Dashboard() {
   const { t } = useTranslation();
   const { isDemoMode } = useDemoMode();
-  const [netWorthView, setNetWorthView] = useState<NetWorthView>("all");
-  const [incomeView, setIncomeView] = useState<"overview" | "by_source">("overview");
   const [excludePendingRefunds, setExcludePendingRefunds] = useState(true);
   const [includeProjects, setIncludeProjects] = useState(false);
-  const [insightTab, setInsightTab] = useState<
-    "monthly_expenses" | "net_worth" | "cash_flow" | "income_expenses" | "category"
-  >("monthly_expenses");
 
   // ---- Existing queries (kept) ----
 
@@ -1138,105 +1126,6 @@ export function Dashboard() {
     },
   });
 
-  // ---- Computed values for charts (kept) ----
-
-  const netWorthDeltas = useMemo(() => {
-    if (!netWorthData || netWorthData.length < 2) return null;
-    return netWorthData.slice(1).map((d, i) => ({
-      month: d.month,
-      bank_balance: d.bank_balance,
-      investment_value: d.investment_value,
-      net_worth: d.net_worth,
-      bank_balance_delta: d.bank_balance - netWorthData[i].bank_balance,
-      investment_value_delta: d.investment_value - netWorthData[i].investment_value,
-      net_worth_delta: d.net_worth - netWorthData[i].net_worth,
-    }));
-  }, [netWorthData]);
-
-  const seriesConfig = {
-    bank_balance: {
-      label: t("dashboard.bankBalance"),
-      color: "#f59e0b",
-      dataKey: "bank_balance" as const,
-      deltaKey: "bank_balance_delta" as const,
-    },
-    investments: {
-      label: t("dashboard.investmentValue"),
-      color: "#6366f1",
-      dataKey: "investment_value" as const,
-      deltaKey: "investment_value_delta" as const,
-    },
-    net_worth: {
-      label: t("dashboard.netWorth"),
-      color: "#10b981",
-      dataKey: "net_worth" as const,
-      deltaKey: "net_worth_delta" as const,
-    },
-  };
-
-  const getNetWorthTraces = (): Plotly.Data[] => {
-    if (!netWorthData || netWorthData.length === 0) return [];
-
-    if (netWorthView === "all") {
-      return [
-        {
-          x: netWorthData.map((d) => d.month),
-          y: netWorthData.map((d) => d.bank_balance),
-          name: t("dashboard.bankBalance"),
-          type: "scatter",
-          mode: "lines+markers",
-          line: { color: "#f59e0b", width: 2 },
-          marker: { size: 4, color: "#f59e0b" },
-        },
-        {
-          x: netWorthData.map((d) => d.month),
-          y: netWorthData.map((d) => d.investment_value),
-          name: t("dashboard.investmentValue"),
-          type: "scatter",
-          mode: "lines+markers",
-          line: { color: "#6366f1", width: 2 },
-          marker: { size: 4, color: "#6366f1" },
-        },
-        {
-          x: netWorthData.map((d) => d.month),
-          y: netWorthData.map((d) => d.net_worth),
-          name: t("dashboard.netWorth"),
-          type: "scatter",
-          mode: "lines+markers",
-          line: { color: "#10b981", width: 3 },
-          marker: { size: 5, color: "#10b981" },
-        },
-      ];
-    }
-
-    if (!netWorthDeltas) return [];
-    const config = seriesConfig[netWorthView];
-
-    return [
-      {
-        x: netWorthDeltas.map((d) => d.month),
-        y: netWorthDeltas.map((d) => d[config.deltaKey]),
-        name: t("dashboard.monthlyChange"),
-        type: "bar",
-        marker: {
-          color: netWorthDeltas.map((d) =>
-            d[config.deltaKey] >= 0 ? "#10b981" : "#ef4444",
-          ),
-        },
-      },
-      {
-        x: netWorthDeltas.map((d) => d.month),
-        y: netWorthDeltas.map((d) => d[config.dataKey]),
-        name: config.label,
-        type: "scatter",
-        mode: "lines+markers",
-        line: { color: config.color, width: 3 },
-        marker: { size: 8, color: config.color },
-        yaxis: "y2",
-      },
-    ];
-  };
-
   // ================================================================
   //  Render
   // ================================================================
@@ -1270,458 +1159,20 @@ export function Dashboard() {
       </div>
 
       {/* Section 4: Tabbed Insights */}
-      <div className="bg-[var(--surface)] rounded-2xl border border-[var(--surface-light)] overflow-hidden">
-        {/* Tab bar */}
-        <div className="px-6 pt-5 pb-0">
-          <div className="flex bg-[var(--surface-light)] p-1 rounded-xl gap-1">
-            {([
-              { key: "monthly_expenses" as const, label: `💸 ${t("dashboard.monthlyExpenses")}` },
-              { key: "net_worth" as const, label: `📈 ${t("dashboard.netWorth")}` },
-              { key: "cash_flow" as const, label: `🌊 ${t("dashboard.cashFlow")}` },
-              { key: "income_expenses" as const, label: `⚖️ ${t("dashboard.incomeAndExpenses")}` },
-              { key: "category" as const, label: `🍕 ${t("dashboard.categories")}` },
-            ]).map(({ key, label }) => (
-              <button
-                key={key}
-                onClick={() => setInsightTab(key)}
-                className={`flex-1 text-center px-3 py-1.5 rounded-lg text-sm font-bold transition-all ${
-                  insightTab === key
-                    ? "bg-[var(--surface)] text-[var(--primary)] shadow-sm"
-                    : "text-[var(--text-muted)] hover:text-[var(--text-default)]"
-                }`}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Tab content */}
-        <div className="px-6 pb-6 pt-4 h-[600px] overflow-y-auto flex flex-col">
-          {/* Monthly Expenses */}
-          {insightTab === "monthly_expenses" && (
-            <div className="flex flex-col flex-1 min-h-0">
-              {monthlyExpenses && monthlyExpenses.months.length > 0 ? (
-                <>
-                  <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-4">
-                    <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
-                      <div className="p-2 rounded-lg bg-rose-500/20 text-rose-400">
-                        <Calculator size={18} />
-                      </div>
-                      <div>
-                        <p className="text-[var(--text-muted)] text-xs">{t("dashboard.avg3Months")}</p>
-                        <p className="text-lg font-bold">
-                          {formatCurrency(monthlyExpenses.avg_3_months)}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
-                      <div className="p-2 rounded-lg bg-orange-500/20 text-orange-400">
-                        <Calculator size={18} />
-                      </div>
-                      <div>
-                        <p className="text-[var(--text-muted)] text-xs">{t("dashboard.avg6Months")}</p>
-                        <p className="text-lg font-bold">
-                          {formatCurrency(monthlyExpenses.avg_6_months)}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
-                      <div className="p-2 rounded-lg bg-amber-500/20 text-amber-400">
-                        <Calculator size={18} />
-                      </div>
-                      <div>
-                        <p className="text-[var(--text-muted)] text-xs">{t("dashboard.avg12Months")}</p>
-                        <p className="text-lg font-bold">
-                          {formatCurrency(monthlyExpenses.avg_12_months)}
-                        </p>
-                      </div>
-                    </div>
-                    <button
-                      onClick={() => setExcludePendingRefunds(!excludePendingRefunds)}
-                      className={`rounded-xl px-4 py-3 text-xs font-medium border transition-colors flex items-center justify-center ${
-                        excludePendingRefunds
-                          ? "bg-[var(--primary)]/10 border-[var(--primary)]/20 text-[var(--primary)]"
-                          : "bg-[var(--surface-light)] border-[var(--surface-light)] text-[var(--text-muted)]"
-                      }`}
-                    >
-                      {excludePendingRefunds
-                        ? t("dashboard.pendingRefundsExcluded")
-                        : t("dashboard.pendingRefundsIncluded")}
-                    </button>
-                    <button
-                      onClick={() => setIncludeProjects(!includeProjects)}
-                      className={`rounded-xl px-4 py-3 text-xs font-medium border transition-colors flex items-center justify-center ${
-                        includeProjects
-                          ? "bg-indigo-500/10 border-indigo-500/20 text-indigo-400"
-                          : "bg-[var(--surface-light)] border-[var(--surface-light)] text-[var(--text-muted)]"
-                      }`}
-                    >
-                      {includeProjects
-                        ? t("dashboard.projectExpensesIncluded")
-                        : t("dashboard.projectExpensesExcluded")}
-                    </button>
-                  </div>
-                  <div className="flex-1 min-h-0">
-                    <Plot
-                      data={[
-                        {
-                          x: monthlyExpenses.months.map((d) => d.month),
-                          y: monthlyExpenses.months.map((d) => d.expenses),
-                          type: "bar",
-                          marker: { color: "#f43f5e" },
-                          name: t("dashboard.expenses"),
-                        },
-                        ...(includeProjects
-                          ? [
-                              {
-                                x: monthlyExpenses.months.map((d) => d.month),
-                                y: monthlyExpenses.months.map((d) => d.project_expenses ?? 0),
-                                type: "bar" as const,
-                                marker: { color: "#818cf8" },
-                                name: t("dashboard.projectExpenses"),
-                              },
-                            ]
-                          : []),
-                      ]}
-                      layout={{
-                        ...chartTheme,
-                        autosize: true,
-                        barmode: includeProjects ? "stack" : undefined,
-                        legend: includeProjects
-                          ? {
-                              orientation: "h" as const,
-                              yanchor: "top" as const,
-                              y: -0.15,
-                              xanchor: "center" as const,
-                              x: 0.5,
-                              font: { color: "#94a3b8" },
-                            }
-                          : undefined,
-                        yaxis: {
-                          title: {
-                            text: t("dashboard.amountILS"),
-                            font: { color: "#94a3b8" },
-                          },
-                          tickfont: { color: "#94a3b8" },
-                        },
-                      }}
-                      style={{ width: "100%", height: "100%" }}
-                      config={plotlyConfig()}
-                    />
-                  </div>
-                </>
-              ) : (
-                <p className="text-[var(--text-muted)] text-sm">📭 {t("dashboard.noExpenseData")}</p>
-              )}
-            </div>
-          )}
-
-          {/* Net Worth Over Time */}
-          {insightTab === "net_worth" && (
-            <div className="flex flex-col flex-1 min-h-0">
-              {netWorthData && netWorthData.length > 0 ? (
-                <>
-                  <div className="flex justify-end mb-4">
-                    <div className="flex bg-[var(--surface-light)] p-1 rounded-xl">
-                      {(
-                        [
-                          { key: "all", label: t("dashboard.all") },
-                          { key: "bank_balance", label: t("dashboard.bankBalance") },
-                          { key: "investments", label: t("dashboard.investmentValue") },
-                          { key: "net_worth", label: t("dashboard.netWorth") },
-                        ] as const
-                      ).map(({ key, label }) => (
-                        <button
-                          key={key}
-                          onClick={() => setNetWorthView(key)}
-                          className={`px-3 py-1.5 rounded-lg text-sm font-bold transition-all ${
-                            netWorthView === key
-                              ? "bg-[var(--surface)] text-[var(--primary)] shadow-sm"
-                              : "text-[var(--text-muted)] hover:text-[var(--text-default)]"
-                          }`}
-                        >
-                          {label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  <div className="flex-1 min-h-0">
-                    <Plot
-                      data={getNetWorthTraces()}
-                      layout={{
-                        ...chartTheme,
-                        autosize: true,
-                        yaxis: {
-                          title: {
-                            text: netWorthView === "all" ? t("dashboard.amountILS") : t("dashboard.monthlyChange"),
-                            font: { color: "#94a3b8" },
-                          },
-                          tickfont: { color: "#94a3b8" },
-                          automargin: true,
-                        },
-                        ...(netWorthView !== "all" && {
-                          yaxis2: {
-                            title: {
-                              text: seriesConfig[netWorthView].label,
-                              font: { color: seriesConfig[netWorthView].color },
-                            },
-                            tickfont: { color: seriesConfig[netWorthView].color },
-                            overlaying: "y" as const,
-                            side: "right" as const,
-                            showgrid: false,
-                            automargin: true,
-                          },
-                        }),
-                        legend: {
-                          orientation: "h",
-                          y: -0.15,
-                          x: 0.5,
-                          xanchor: "center",
-                        },
-                      }}
-                      style={{ width: "100%", height: "100%" }}
-                      config={plotlyConfig()}
-                    />
-                  </div>
-                </>
-              ) : (
-                <p className="text-[var(--text-muted)] text-sm">📭 {t("dashboard.noNetWorthData")}</p>
-              )}
-            </div>
-          )}
-
-          {/* Cash Flow (Sankey) */}
-          {insightTab === "cash_flow" && (
-            <div className="flex flex-col flex-1 min-h-0">
-              {sankeyLoading ? (
-                <Skeleton variant="chart" className="flex-1" />
-              ) : (
-                <div className="flex-1 min-h-0">
-                  <SankeyChart data={sankeyData} height={560} />
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Income & Expenses */}
-          {insightTab === "income_expenses" && (
-            <div className="flex flex-col flex-1 min-h-0">
-              <div className="flex justify-end mb-4">
-                <div className="flex bg-[var(--surface-light)] p-1 rounded-xl">
-                  {([
-                    { key: "overview" as const, label: `📊 ${t("dashboard.overview")}` },
-                    { key: "by_source" as const, label: `💼 ${t("dashboard.bySource")}` },
-                  ]).map(({ key, label }) => (
-                    <button
-                      key={key}
-                      onClick={() => setIncomeView(key)}
-                      className={`px-3 py-1.5 rounded-lg text-sm font-bold transition-all ${
-                        incomeView === key
-                          ? "bg-[var(--surface)] text-[var(--primary)] shadow-sm"
-                          : "text-[var(--text-muted)] hover:text-[var(--text-default)]"
-                      }`}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-              {incomeView === "overview" ? (
-                <div className="flex-1 min-h-0">
-                  <Plot
-                    data={[
-                      {
-                        x: incomeOutcome?.map((d: { month: string }) => d.month) || [],
-                        y: incomeOutcome?.map((d: { income: number }) => d.income) || [],
-                        name: t("dashboard.income"),
-                        type: "bar",
-                        marker: { color: "#059669" },
-                      },
-                      {
-                        x: incomeOutcome?.map((d: { month: string }) => d.month) || [],
-                        y: incomeOutcome?.map((d: { expenses: number }) => d.expenses) || [],
-                        name: t("dashboard.expenses"),
-                        type: "bar",
-                        marker: { color: "#f43f5e" },
-                      },
-                    ]}
-                    layout={{
-                      ...chartTheme,
-                      barmode: "group",
-                      autosize: true,
-                      legend: {
-                        orientation: "h",
-                        y: -0.15,
-                        x: 0.5,
-                        xanchor: "center",
-                      },
-                    }}
-                    style={{ width: "100%", height: "100%" }}
-                    config={plotlyConfig()}
-                  />
-                </div>
-              ) : (
-                <div className="flex-1 min-h-0">
-                  {incomeBySourceData && incomeBySourceData.length > 0 ? (() => {
-                    const allSources = Array.from(
-                      new Set(
-                        incomeBySourceData.flatMap((d) => Object.keys(d.sources)),
-                      ),
-                    );
-                    const colors = [
-                      "#059669", "#10b981", "#34d399", "#6ee7b7",
-                      "#a7f3d0", "#047857", "#065f46", "#064e3b",
-                    ];
-                    return (
-                      <Plot
-                        data={allSources.map((source, i) => ({
-                          x: incomeBySourceData.map((d) => d.month),
-                          y: incomeBySourceData.map(
-                            (d) => d.sources[source] || 0,
-                          ),
-                          name: source,
-                          type: "bar" as const,
-                          marker: { color: colors[i % colors.length] },
-                        }))}
-                        layout={{
-                          ...chartTheme,
-                          barmode: "stack",
-                          autosize: true,
-                          yaxis: {
-                            title: {
-                              text: t("dashboard.amountILS"),
-                              font: { color: "#94a3b8" },
-                            },
-                            tickfont: { color: "#94a3b8" },
-                          },
-                          legend: {
-                            orientation: "h",
-                            y: -0.15,
-                            x: 0.5,
-                            xanchor: "center",
-                          },
-                        }}
-                        style={{ width: "100%", height: "100%" }}
-                        config={plotlyConfig()}
-                      />
-                    );
-                  })() : (
-                    <p className="text-[var(--text-muted)] text-sm">📭 {t("dashboard.noIncomeSourceData")}</p>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Category Breakdown */}
-          {insightTab === "category" && (() => {
-            const expenses = categoryData?.expenses
-              ?.slice()
-              .sort((a: { amount: number }, b: { amount: number }) => b.amount - a.amount) || [];
-            const refunds = categoryData?.refunds
-              ?.slice()
-              .sort((a: { amount: number }, b: { amount: number }) => b.amount - a.amount) || [];
-            const totalExpenses = expenses.reduce((s: number, d: { amount: number }) => s + d.amount, 0);
-            const totalRefunds = refunds.reduce((s: number, d: { amount: number }) => s + d.amount, 0);
-            const topCategory = expenses[0];
-            const maxExpense = topCategory?.amount || 1;
-            const maxRefund = refunds[0]?.amount || 1;
-
-            return (
-              <div className="flex flex-col flex-1 min-h-0 space-y-5">
-                {/* Summary strip */}
-                <div className="grid grid-cols-3 gap-4">
-                  <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
-                    <div className="p-2 rounded-lg bg-rose-500/20 text-rose-400">
-                      <TrendingDown size={18} />
-                    </div>
-                    <div>
-                      <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{t("dashboard.totalExpenses")}</p>
-                      <p className="text-lg font-bold text-rose-400">{formatCurrency(totalExpenses)}</p>
-                    </div>
-                  </div>
-                  <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
-                    <div className="p-2 rounded-lg bg-amber-500/20 text-amber-400 text-lg">
-                      {topCategory ? (categoryIcons?.[topCategory.category] || "📊") : "—"}
-                    </div>
-                    <div className="min-w-0">
-                      <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{t("dashboard.topCategory")}</p>
-                      <p className="text-sm font-bold truncate">{topCategory?.category || "—"}</p>
-                    </div>
-                  </div>
-                  <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
-                    <div className="p-2 rounded-lg bg-blue-500/20 text-blue-400">
-                      <Tag size={18} />
-                    </div>
-                    <div>
-                      <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{t("dashboard.categories")}</p>
-                      <p className="text-lg font-bold">{expenses.length}</p>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Expenses bars */}
-                <div>
-                  <p className="text-sm font-bold text-rose-400 uppercase tracking-wider mb-3">{t("dashboard.expenses")}</p>
-                  <div className="space-y-1.5 max-h-[350px] overflow-y-auto pr-1">
-                    {expenses.map((d: { category: string; amount: number }, i: number) => {
-                      const pct = totalExpenses > 0 ? (d.amount / totalExpenses) * 100 : 0;
-                      const barWidth = (d.amount / maxExpense) * 100;
-                      const icon = categoryIcons?.[d.category] ?? "";
-                      return (
-                        <div key={d.category} className="group flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-[var(--surface-light)] transition-colors">
-                          <span className="text-base w-6 text-center shrink-0">{icon || (d.category === "Uncategorized" ? "❓" : `${i + 1}.`)}</span>
-                          <span className="text-sm font-medium w-28 truncate shrink-0" title={d.category}>{d.category}</span>
-                          <div className="flex-1 h-5 bg-[var(--surface-light)] rounded-full overflow-hidden">
-                            <div
-                              className="h-full rounded-full bg-gradient-to-r from-rose-600 to-rose-400 transition-all duration-500"
-                              style={{ width: `${barWidth}%` }}
-                            />
-                          </div>
-                          <span className="text-sm font-bold tabular-nums w-24 text-right shrink-0">{formatCurrency(d.amount)}</span>
-                          <span className="text-xs text-[var(--text-muted)] w-12 text-right shrink-0">{pct.toFixed(1)}%</span>
-                        </div>
-                      );
-                    })}
-                    {expenses.length === 0 && (
-                      <p className="text-[var(--text-muted)] text-sm py-4 text-center">{t("dashboard.noExpenseData")}</p>
-                    )}
-                  </div>
-                </div>
-
-                {/* Refunds bars (conditional) */}
-                {refunds.length > 0 && (
-                  <div>
-                    <p className="text-sm font-bold text-emerald-400 uppercase tracking-wider mb-3">{t("dashboard.refunds")}</p>
-                    <div className="space-y-1.5 max-h-[200px] overflow-y-auto pr-1">
-                      {refunds.map((d: { category: string; amount: number }, i: number) => {
-                        const pct = totalRefunds > 0 ? (d.amount / totalRefunds) * 100 : 0;
-                        const barWidth = (d.amount / maxRefund) * 100;
-                        const icon = categoryIcons?.[d.category] ?? "";
-                        return (
-                          <div key={d.category} className="group flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-[var(--surface-light)] transition-colors">
-                            <span className="text-base w-6 text-center shrink-0">{icon || `${i + 1}.`}</span>
-                            <span className="text-sm font-medium w-28 truncate shrink-0" title={d.category}>{d.category}</span>
-                            <div className="flex-1 h-5 bg-[var(--surface-light)] rounded-full overflow-hidden">
-                              <div
-                                className="h-full rounded-full bg-gradient-to-r from-emerald-600 to-emerald-400 transition-all duration-500"
-                                style={{ width: `${barWidth}%` }}
-                              />
-                            </div>
-                            <span className="text-sm font-bold tabular-nums w-24 text-right shrink-0">{formatCurrency(d.amount)}</span>
-                            <span className="text-xs text-[var(--text-muted)] w-12 text-right shrink-0">{pct.toFixed(1)}%</span>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
-              </div>
-            );
-          })()}
-        </div>
-      </div>
+      <DashboardInsightsPanel
+        netWorthData={netWorthData}
+        incomeOutcome={incomeOutcome}
+        monthlyExpenses={monthlyExpenses}
+        categoryData={categoryData}
+        sankeyData={sankeyData}
+        sankeyLoading={sankeyLoading}
+        incomeBySourceData={incomeBySourceData}
+        categoryIcons={categoryIcons}
+        excludePendingRefunds={excludePendingRefunds}
+        setExcludePendingRefunds={setExcludePendingRefunds}
+        includeProjects={includeProjects}
+        setIncludeProjects={setIncludeProjects}
+      />
 
     </div>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,8 +2,10 @@ import { useState, useMemo, useRef, useCallback, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import {
+  TrendingDown,
   ChevronLeft,
   ChevronRight,
+  Calculator,
   Split,
   RefreshCw,
   Tag,
@@ -11,6 +13,7 @@ import {
   Link2,
   Plus,
 } from "lucide-react";
+import Plot from "react-plotly.js";
 import {
   analyticsApi,
   cashBalancesApi,
@@ -29,14 +32,17 @@ import { LinkRefundModal } from "../components/modals/LinkRefundModal";
 import { ProjectModal } from "../components/modals/ProjectModal";
 import { SelectDropdown } from "../components/common/SelectDropdown";
 import { useCategoryTagCreate } from "../hooks/useCategoryTagCreate";
+import { SankeyChart } from "../components/SankeyChart";
 import { SemiGauge } from "../components/common/SemiGauge";
 import { Skeleton } from "../components/common/Skeleton";
-import { DashboardInsightsPanel } from "../components/dashboard/DashboardInsightsPanel";
 import { useDemoMode } from "../context/DemoModeContext";
 import { isToday, isYesterday } from "date-fns";
 import { useTranslation } from "react-i18next";
 import { formatMonthYear, formatShortDate } from "../utils/dateFormatting";
+import { plotlyConfig } from "../utils/plotlyLocale";
 import i18n from "../i18n";
+
+type NetWorthView = "all" | "bank_balance" | "investments" | "net_worth";
 
 const formatCurrency = (val: number) =>
   new Intl.NumberFormat("he-IL", {
@@ -44,6 +50,16 @@ const formatCurrency = (val: number) =>
     currency: "ILS",
     maximumFractionDigits: 0,
   }).format(val || 0);
+
+const chartTheme = {
+  paper_bgcolor: "rgba(0,0,0,0)",
+  plot_bgcolor: "rgba(0,0,0,0)",
+  font: { color: "#94a3b8", family: "Inter, sans-serif" },
+  margin: { t: 40, b: 40, l: 40, r: 20 },
+  hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
+  hovermode: "x unified" as const,
+  xaxis: { showspikes: false },
+};
 
 /* ------------------------------------------------------------------ */
 /*  Helper sub-components (extracted to avoid creating during render)  */
@@ -66,7 +82,7 @@ function BreakdownList({ items }: { items: { name: string; amount: number }[] })
     <div className="mt-2 pt-2 border-t border-[var(--surface-light)] space-y-1">
       {items.map((item) => (
         <div key={item.name} className="flex justify-between text-xs">
-          <span className="text-[var(--text-muted)] truncate me-2">{item.name}</span>
+          <span className="text-[var(--text-muted)] truncate mr-2">{item.name}</span>
           <span className="tabular-nums font-medium shrink-0">{formatCurrency(item.amount)}</span>
         </div>
       ))}
@@ -562,7 +578,7 @@ function BudgetSpendingGauge({
               <BudgetRuleCards rules={miniRules} categoryIcons={categoryIcons} />
 
               {/* Link to budget page */}
-              <div className="text-end">
+              <div className="text-right">
                 <Link
                   to="/budget"
                   className="text-sm font-medium text-[var(--primary)] hover:underline"
@@ -928,7 +944,7 @@ function RecentTransactionsFeed({
                         )}
                       </div>
                       <span
-                        className={`text-sm font-semibold flex-shrink-0 tabular-nums text-end w-[80px] ${
+                        className={`text-sm font-semibold flex-shrink-0 tabular-nums text-right w-[80px] ${
                           isPositive ? "text-emerald-400" : "text-rose-400"
                         }`}
                       >
@@ -939,7 +955,7 @@ function RecentTransactionsFeed({
 
                     {/* Inline tag editing panel */}
                     {isEditing && categories && (
-                      <div className="mx-2 mb-2 ms-11 rounded-lg border border-[var(--surface-light)] bg-[var(--surface-light)]/20 overflow-hidden">
+                      <div className="mx-2 mb-2 ml-11 rounded-lg border border-[var(--surface-light)] bg-[var(--surface-light)]/20 overflow-hidden">
                         <div className="flex items-center gap-3 px-3 py-2">
                           <div className="flex-1 min-w-0">
                             <label className="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1 block">{t("common.category")}</label>
@@ -1041,8 +1057,13 @@ function RecentTransactionsFeed({
 export function Dashboard() {
   const { t } = useTranslation();
   const { isDemoMode } = useDemoMode();
+  const [netWorthView, setNetWorthView] = useState<NetWorthView>("all");
+  const [incomeView, setIncomeView] = useState<"overview" | "by_source">("overview");
   const [excludePendingRefunds, setExcludePendingRefunds] = useState(true);
   const [includeProjects, setIncludeProjects] = useState(false);
+  const [insightTab, setInsightTab] = useState<
+    "monthly_expenses" | "net_worth" | "cash_flow" | "income_expenses" | "category"
+  >("monthly_expenses");
 
   // ---- Existing queries (kept) ----
 
@@ -1126,6 +1147,105 @@ export function Dashboard() {
     },
   });
 
+  // ---- Computed values for charts (kept) ----
+
+  const netWorthDeltas = useMemo(() => {
+    if (!netWorthData || netWorthData.length < 2) return null;
+    return netWorthData.slice(1).map((d, i) => ({
+      month: d.month,
+      bank_balance: d.bank_balance,
+      investment_value: d.investment_value,
+      net_worth: d.net_worth,
+      bank_balance_delta: d.bank_balance - netWorthData[i].bank_balance,
+      investment_value_delta: d.investment_value - netWorthData[i].investment_value,
+      net_worth_delta: d.net_worth - netWorthData[i].net_worth,
+    }));
+  }, [netWorthData]);
+
+  const seriesConfig = {
+    bank_balance: {
+      label: t("dashboard.bankBalance"),
+      color: "#f59e0b",
+      dataKey: "bank_balance" as const,
+      deltaKey: "bank_balance_delta" as const,
+    },
+    investments: {
+      label: t("dashboard.investmentValue"),
+      color: "#6366f1",
+      dataKey: "investment_value" as const,
+      deltaKey: "investment_value_delta" as const,
+    },
+    net_worth: {
+      label: t("dashboard.netWorth"),
+      color: "#10b981",
+      dataKey: "net_worth" as const,
+      deltaKey: "net_worth_delta" as const,
+    },
+  };
+
+  const getNetWorthTraces = (): Plotly.Data[] => {
+    if (!netWorthData || netWorthData.length === 0) return [];
+
+    if (netWorthView === "all") {
+      return [
+        {
+          x: netWorthData.map((d) => d.month),
+          y: netWorthData.map((d) => d.bank_balance),
+          name: t("dashboard.bankBalance"),
+          type: "scatter",
+          mode: "lines+markers",
+          line: { color: "#f59e0b", width: 2 },
+          marker: { size: 4, color: "#f59e0b" },
+        },
+        {
+          x: netWorthData.map((d) => d.month),
+          y: netWorthData.map((d) => d.investment_value),
+          name: t("dashboard.investmentValue"),
+          type: "scatter",
+          mode: "lines+markers",
+          line: { color: "#6366f1", width: 2 },
+          marker: { size: 4, color: "#6366f1" },
+        },
+        {
+          x: netWorthData.map((d) => d.month),
+          y: netWorthData.map((d) => d.net_worth),
+          name: t("dashboard.netWorth"),
+          type: "scatter",
+          mode: "lines+markers",
+          line: { color: "#10b981", width: 3 },
+          marker: { size: 5, color: "#10b981" },
+        },
+      ];
+    }
+
+    if (!netWorthDeltas) return [];
+    const config = seriesConfig[netWorthView];
+
+    return [
+      {
+        x: netWorthDeltas.map((d) => d.month),
+        y: netWorthDeltas.map((d) => d[config.deltaKey]),
+        name: t("dashboard.monthlyChange"),
+        type: "bar",
+        marker: {
+          color: netWorthDeltas.map((d) =>
+            d[config.deltaKey] >= 0 ? "#10b981" : "#ef4444",
+          ),
+        },
+      },
+      {
+        x: netWorthDeltas.map((d) => d.month),
+        y: netWorthDeltas.map((d) => d[config.dataKey]),
+        name: config.label,
+        type: "scatter",
+        mode: "lines+markers",
+        line: { color: config.color, width: 3 },
+        marker: { size: 8, color: config.color },
+        yaxis: "y2",
+      },
+    ];
+  };
+
   // ================================================================
   //  Render
   // ================================================================
@@ -1159,20 +1279,458 @@ export function Dashboard() {
       </div>
 
       {/* Section 4: Tabbed Insights */}
-      <DashboardInsightsPanel
-        netWorthData={netWorthData}
-        incomeOutcome={incomeOutcome}
-        monthlyExpenses={monthlyExpenses}
-        categoryData={categoryData}
-        sankeyData={sankeyData}
-        sankeyLoading={sankeyLoading}
-        incomeBySourceData={incomeBySourceData}
-        categoryIcons={categoryIcons}
-        excludePendingRefunds={excludePendingRefunds}
-        setExcludePendingRefunds={setExcludePendingRefunds}
-        includeProjects={includeProjects}
-        setIncludeProjects={setIncludeProjects}
-      />
+      <div className="bg-[var(--surface)] rounded-2xl border border-[var(--surface-light)] overflow-hidden">
+        {/* Tab bar */}
+        <div className="px-6 pt-5 pb-0">
+          <div className="flex bg-[var(--surface-light)] p-1 rounded-xl gap-1">
+            {([
+              { key: "monthly_expenses" as const, label: `💸 ${t("dashboard.monthlyExpenses")}` },
+              { key: "net_worth" as const, label: `📈 ${t("dashboard.netWorth")}` },
+              { key: "cash_flow" as const, label: `🌊 ${t("dashboard.cashFlow")}` },
+              { key: "income_expenses" as const, label: `⚖️ ${t("dashboard.incomeAndExpenses")}` },
+              { key: "category" as const, label: `🍕 ${t("dashboard.categories")}` },
+            ]).map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setInsightTab(key)}
+                className={`flex-1 text-center px-3 py-1.5 rounded-lg text-sm font-bold transition-all ${
+                  insightTab === key
+                    ? "bg-[var(--surface)] text-[var(--primary)] shadow-sm"
+                    : "text-[var(--text-muted)] hover:text-[var(--text-default)]"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Tab content */}
+        <div className="px-6 pb-6 pt-4 h-[600px] overflow-y-auto flex flex-col">
+          {/* Monthly Expenses */}
+          {insightTab === "monthly_expenses" && (
+            <div className="flex flex-col flex-1 min-h-0">
+              {monthlyExpenses && monthlyExpenses.months.length > 0 ? (
+                <>
+                  <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-4">
+                    <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
+                      <div className="p-2 rounded-lg bg-rose-500/20 text-rose-400">
+                        <Calculator size={18} />
+                      </div>
+                      <div>
+                        <p className="text-[var(--text-muted)] text-xs">{t("dashboard.avg3Months")}</p>
+                        <p className="text-lg font-bold">
+                          {formatCurrency(monthlyExpenses.avg_3_months)}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
+                      <div className="p-2 rounded-lg bg-orange-500/20 text-orange-400">
+                        <Calculator size={18} />
+                      </div>
+                      <div>
+                        <p className="text-[var(--text-muted)] text-xs">{t("dashboard.avg6Months")}</p>
+                        <p className="text-lg font-bold">
+                          {formatCurrency(monthlyExpenses.avg_6_months)}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
+                      <div className="p-2 rounded-lg bg-amber-500/20 text-amber-400">
+                        <Calculator size={18} />
+                      </div>
+                      <div>
+                        <p className="text-[var(--text-muted)] text-xs">{t("dashboard.avg12Months")}</p>
+                        <p className="text-lg font-bold">
+                          {formatCurrency(monthlyExpenses.avg_12_months)}
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => setExcludePendingRefunds(!excludePendingRefunds)}
+                      className={`rounded-xl px-4 py-3 text-xs font-medium border transition-colors flex items-center justify-center ${
+                        excludePendingRefunds
+                          ? "bg-[var(--primary)]/10 border-[var(--primary)]/20 text-[var(--primary)]"
+                          : "bg-[var(--surface-light)] border-[var(--surface-light)] text-[var(--text-muted)]"
+                      }`}
+                    >
+                      {excludePendingRefunds
+                        ? t("dashboard.pendingRefundsExcluded")
+                        : t("dashboard.pendingRefundsIncluded")}
+                    </button>
+                    <button
+                      onClick={() => setIncludeProjects(!includeProjects)}
+                      className={`rounded-xl px-4 py-3 text-xs font-medium border transition-colors flex items-center justify-center ${
+                        includeProjects
+                          ? "bg-indigo-500/10 border-indigo-500/20 text-indigo-400"
+                          : "bg-[var(--surface-light)] border-[var(--surface-light)] text-[var(--text-muted)]"
+                      }`}
+                    >
+                      {includeProjects
+                        ? t("dashboard.projectExpensesIncluded")
+                        : t("dashboard.projectExpensesExcluded")}
+                    </button>
+                  </div>
+                  <div className="flex-1 min-h-0">
+                    <Plot
+                      data={[
+                        {
+                          x: monthlyExpenses.months.map((d) => d.month),
+                          y: monthlyExpenses.months.map((d) => d.expenses),
+                          type: "bar",
+                          marker: { color: "#f43f5e" },
+                          name: t("dashboard.expenses"),
+                        },
+                        ...(includeProjects
+                          ? [
+                              {
+                                x: monthlyExpenses.months.map((d) => d.month),
+                                y: monthlyExpenses.months.map((d) => d.project_expenses ?? 0),
+                                type: "bar" as const,
+                                marker: { color: "#818cf8" },
+                                name: t("dashboard.projectExpenses"),
+                              },
+                            ]
+                          : []),
+                      ]}
+                      layout={{
+                        ...chartTheme,
+                        autosize: true,
+                        barmode: includeProjects ? "stack" : undefined,
+                        legend: includeProjects
+                          ? {
+                              orientation: "h" as const,
+                              yanchor: "top" as const,
+                              y: -0.15,
+                              xanchor: "center" as const,
+                              x: 0.5,
+                              font: { color: "#94a3b8" },
+                            }
+                          : undefined,
+                        yaxis: {
+                          title: {
+                            text: t("dashboard.amountILS"),
+                            font: { color: "#94a3b8" },
+                          },
+                          tickfont: { color: "#94a3b8" },
+                        },
+                      }}
+                      style={{ width: "100%", height: "100%" }}
+                      config={plotlyConfig()}
+                    />
+                  </div>
+                </>
+              ) : (
+                <p className="text-[var(--text-muted)] text-sm">📭 {t("dashboard.noExpenseData")}</p>
+              )}
+            </div>
+          )}
+
+          {/* Net Worth Over Time */}
+          {insightTab === "net_worth" && (
+            <div className="flex flex-col flex-1 min-h-0">
+              {netWorthData && netWorthData.length > 0 ? (
+                <>
+                  <div className="flex justify-end mb-4">
+                    <div className="flex bg-[var(--surface-light)] p-1 rounded-xl">
+                      {(
+                        [
+                          { key: "all", label: t("dashboard.all") },
+                          { key: "bank_balance", label: t("dashboard.bankBalance") },
+                          { key: "investments", label: t("dashboard.investmentValue") },
+                          { key: "net_worth", label: t("dashboard.netWorth") },
+                        ] as const
+                      ).map(({ key, label }) => (
+                        <button
+                          key={key}
+                          onClick={() => setNetWorthView(key)}
+                          className={`px-3 py-1.5 rounded-lg text-sm font-bold transition-all ${
+                            netWorthView === key
+                              ? "bg-[var(--surface)] text-[var(--primary)] shadow-sm"
+                              : "text-[var(--text-muted)] hover:text-[var(--text-default)]"
+                          }`}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex-1 min-h-0">
+                    <Plot
+                      data={getNetWorthTraces()}
+                      layout={{
+                        ...chartTheme,
+                        autosize: true,
+                        yaxis: {
+                          title: {
+                            text: netWorthView === "all" ? t("dashboard.amountILS") : t("dashboard.monthlyChange"),
+                            font: { color: "#94a3b8" },
+                          },
+                          tickfont: { color: "#94a3b8" },
+                          automargin: true,
+                        },
+                        ...(netWorthView !== "all" && {
+                          yaxis2: {
+                            title: {
+                              text: seriesConfig[netWorthView].label,
+                              font: { color: seriesConfig[netWorthView].color },
+                            },
+                            tickfont: { color: seriesConfig[netWorthView].color },
+                            overlaying: "y" as const,
+                            side: "right" as const,
+                            showgrid: false,
+                            automargin: true,
+                          },
+                        }),
+                        legend: {
+                          orientation: "h",
+                          y: -0.15,
+                          x: 0.5,
+                          xanchor: "center",
+                        },
+                      }}
+                      style={{ width: "100%", height: "100%" }}
+                      config={plotlyConfig()}
+                    />
+                  </div>
+                </>
+              ) : (
+                <p className="text-[var(--text-muted)] text-sm">📭 {t("dashboard.noNetWorthData")}</p>
+              )}
+            </div>
+          )}
+
+          {/* Cash Flow (Sankey) */}
+          {insightTab === "cash_flow" && (
+            <div className="flex flex-col flex-1 min-h-0">
+              {sankeyLoading ? (
+                <Skeleton variant="chart" className="flex-1" />
+              ) : (
+                <div className="flex-1 min-h-0">
+                  <SankeyChart data={sankeyData} height={560} />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Income & Expenses */}
+          {insightTab === "income_expenses" && (
+            <div className="flex flex-col flex-1 min-h-0">
+              <div className="flex justify-end mb-4">
+                <div className="flex bg-[var(--surface-light)] p-1 rounded-xl">
+                  {([
+                    { key: "overview" as const, label: `📊 ${t("dashboard.overview")}` },
+                    { key: "by_source" as const, label: `💼 ${t("dashboard.bySource")}` },
+                  ]).map(({ key, label }) => (
+                    <button
+                      key={key}
+                      onClick={() => setIncomeView(key)}
+                      className={`px-3 py-1.5 rounded-lg text-sm font-bold transition-all ${
+                        incomeView === key
+                          ? "bg-[var(--surface)] text-[var(--primary)] shadow-sm"
+                          : "text-[var(--text-muted)] hover:text-[var(--text-default)]"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {incomeView === "overview" ? (
+                <div className="flex-1 min-h-0">
+                  <Plot
+                    data={[
+                      {
+                        x: incomeOutcome?.map((d: { month: string }) => d.month) || [],
+                        y: incomeOutcome?.map((d: { income: number }) => d.income) || [],
+                        name: t("dashboard.income"),
+                        type: "bar",
+                        marker: { color: "#059669" },
+                      },
+                      {
+                        x: incomeOutcome?.map((d: { month: string }) => d.month) || [],
+                        y: incomeOutcome?.map((d: { expenses: number }) => d.expenses) || [],
+                        name: t("dashboard.expenses"),
+                        type: "bar",
+                        marker: { color: "#f43f5e" },
+                      },
+                    ]}
+                    layout={{
+                      ...chartTheme,
+                      barmode: "group",
+                      autosize: true,
+                      legend: {
+                        orientation: "h",
+                        y: -0.15,
+                        x: 0.5,
+                        xanchor: "center",
+                      },
+                    }}
+                    style={{ width: "100%", height: "100%" }}
+                    config={plotlyConfig()}
+                  />
+                </div>
+              ) : (
+                <div className="flex-1 min-h-0">
+                  {incomeBySourceData && incomeBySourceData.length > 0 ? (() => {
+                    const allSources = Array.from(
+                      new Set(
+                        incomeBySourceData.flatMap((d) => Object.keys(d.sources)),
+                      ),
+                    );
+                    const colors = [
+                      "#059669", "#10b981", "#34d399", "#6ee7b7",
+                      "#a7f3d0", "#047857", "#065f46", "#064e3b",
+                    ];
+                    return (
+                      <Plot
+                        data={allSources.map((source, i) => ({
+                          x: incomeBySourceData.map((d) => d.month),
+                          y: incomeBySourceData.map(
+                            (d) => d.sources[source] || 0,
+                          ),
+                          name: source,
+                          type: "bar" as const,
+                          marker: { color: colors[i % colors.length] },
+                        }))}
+                        layout={{
+                          ...chartTheme,
+                          barmode: "stack",
+                          autosize: true,
+                          yaxis: {
+                            title: {
+                              text: t("dashboard.amountILS"),
+                              font: { color: "#94a3b8" },
+                            },
+                            tickfont: { color: "#94a3b8" },
+                          },
+                          legend: {
+                            orientation: "h",
+                            y: -0.15,
+                            x: 0.5,
+                            xanchor: "center",
+                          },
+                        }}
+                        style={{ width: "100%", height: "100%" }}
+                        config={plotlyConfig()}
+                      />
+                    );
+                  })() : (
+                    <p className="text-[var(--text-muted)] text-sm">📭 {t("dashboard.noIncomeSourceData")}</p>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Category Breakdown */}
+          {insightTab === "category" && (() => {
+            const expenses = categoryData?.expenses
+              ?.slice()
+              .sort((a: { amount: number }, b: { amount: number }) => b.amount - a.amount) || [];
+            const refunds = categoryData?.refunds
+              ?.slice()
+              .sort((a: { amount: number }, b: { amount: number }) => b.amount - a.amount) || [];
+            const totalExpenses = expenses.reduce((s: number, d: { amount: number }) => s + d.amount, 0);
+            const totalRefunds = refunds.reduce((s: number, d: { amount: number }) => s + d.amount, 0);
+            const topCategory = expenses[0];
+            const maxExpense = topCategory?.amount || 1;
+            const maxRefund = refunds[0]?.amount || 1;
+
+            return (
+              <div className="flex flex-col flex-1 min-h-0 space-y-5">
+                {/* Summary strip */}
+                <div className="grid grid-cols-3 gap-4">
+                  <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
+                    <div className="p-2 rounded-lg bg-rose-500/20 text-rose-400">
+                      <TrendingDown size={18} />
+                    </div>
+                    <div>
+                      <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{t("dashboard.totalExpenses")}</p>
+                      <p className="text-lg font-bold text-rose-400">{formatCurrency(totalExpenses)}</p>
+                    </div>
+                  </div>
+                  <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
+                    <div className="p-2 rounded-lg bg-amber-500/20 text-amber-400 text-lg">
+                      {topCategory ? (categoryIcons?.[topCategory.category] || "📊") : "—"}
+                    </div>
+                    <div className="min-w-0">
+                      <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{t("dashboard.topCategory")}</p>
+                      <p className="text-sm font-bold truncate">{topCategory?.category || "—"}</p>
+                    </div>
+                  </div>
+                  <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
+                    <div className="p-2 rounded-lg bg-blue-500/20 text-blue-400">
+                      <Tag size={18} />
+                    </div>
+                    <div>
+                      <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{t("dashboard.categories")}</p>
+                      <p className="text-lg font-bold">{expenses.length}</p>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Expenses bars */}
+                <div>
+                  <p className="text-sm font-bold text-rose-400 uppercase tracking-wider mb-3">{t("dashboard.expenses")}</p>
+                  <div className="space-y-1.5 max-h-[350px] overflow-y-auto pr-1">
+                    {expenses.map((d: { category: string; amount: number }, i: number) => {
+                      const pct = totalExpenses > 0 ? (d.amount / totalExpenses) * 100 : 0;
+                      const barWidth = (d.amount / maxExpense) * 100;
+                      const icon = categoryIcons?.[d.category] ?? "";
+                      return (
+                        <div key={d.category} className="group flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-[var(--surface-light)] transition-colors">
+                          <span className="text-base w-6 text-center shrink-0">{icon || (d.category === "Uncategorized" ? "❓" : `${i + 1}.`)}</span>
+                          <span className="text-sm font-medium w-28 truncate shrink-0" title={d.category}>{d.category}</span>
+                          <div className="flex-1 h-5 bg-[var(--surface-light)] rounded-full overflow-hidden">
+                            <div
+                              className="h-full rounded-full bg-gradient-to-r from-rose-600 to-rose-400 transition-all duration-500"
+                              style={{ width: `${barWidth}%` }}
+                            />
+                          </div>
+                          <span className="text-sm font-bold tabular-nums w-24 text-right shrink-0">{formatCurrency(d.amount)}</span>
+                          <span className="text-xs text-[var(--text-muted)] w-12 text-right shrink-0">{pct.toFixed(1)}%</span>
+                        </div>
+                      );
+                    })}
+                    {expenses.length === 0 && (
+                      <p className="text-[var(--text-muted)] text-sm py-4 text-center">{t("dashboard.noExpenseData")}</p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Refunds bars (conditional) */}
+                {refunds.length > 0 && (
+                  <div>
+                    <p className="text-sm font-bold text-emerald-400 uppercase tracking-wider mb-3">{t("dashboard.refunds")}</p>
+                    <div className="space-y-1.5 max-h-[200px] overflow-y-auto pr-1">
+                      {refunds.map((d: { category: string; amount: number }, i: number) => {
+                        const pct = totalRefunds > 0 ? (d.amount / totalRefunds) * 100 : 0;
+                        const barWidth = (d.amount / maxRefund) * 100;
+                        const icon = categoryIcons?.[d.category] ?? "";
+                        return (
+                          <div key={d.category} className="group flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-[var(--surface-light)] transition-colors">
+                            <span className="text-base w-6 text-center shrink-0">{icon || `${i + 1}.`}</span>
+                            <span className="text-sm font-medium w-28 truncate shrink-0" title={d.category}>{d.category}</span>
+                            <div className="flex-1 h-5 bg-[var(--surface-light)] rounded-full overflow-hidden">
+                              <div
+                                className="h-full rounded-full bg-gradient-to-r from-emerald-600 to-emerald-400 transition-all duration-500"
+                                style={{ width: `${barWidth}%` }}
+                              />
+                            </div>
+                            <span className="text-sm font-bold tabular-nums w-24 text-right shrink-0">{formatCurrency(d.amount)}</span>
+                            <span className="text-xs text-[var(--text-muted)] w-12 text-right shrink-0">{pct.toFixed(1)}%</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })()}
+        </div>
+      </div>
 
     </div>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -39,7 +39,7 @@ import { useDemoMode } from "../context/DemoModeContext";
 import { isToday, isYesterday } from "date-fns";
 import { useTranslation } from "react-i18next";
 import { formatMonthYear, formatShortDate } from "../utils/dateFormatting";
-import { plotlyConfig } from "../utils/plotlyLocale";
+import { chartTheme, plotlyConfig } from "../utils/plotlyLocale";
 import i18n from "../i18n";
 
 type NetWorthView = "all" | "bank_balance" | "investments" | "net_worth";
@@ -51,15 +51,6 @@ const formatCurrency = (val: number) =>
     maximumFractionDigits: 0,
   }).format(val || 0);
 
-const chartTheme = {
-  paper_bgcolor: "rgba(0,0,0,0)",
-  plot_bgcolor: "rgba(0,0,0,0)",
-  font: { color: "#94a3b8", family: "Inter, sans-serif" },
-  margin: { t: 40, b: 40, l: 40, r: 20 },
-  hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
-  hovermode: "x unified" as const,
-  xaxis: { showspikes: false },
-};
 
 /* ------------------------------------------------------------------ */
 /*  Helper sub-components (extracted to avoid creating during render)  */

--- a/frontend/src/pages/InsurancesPrototype.tsx
+++ b/frontend/src/pages/InsurancesPrototype.tsx
@@ -13,7 +13,7 @@ import {
   Loader2,
 } from "lucide-react";
 import Plot from "react-plotly.js";
-import { plotlyConfig } from "../utils/plotlyLocale";
+import { chartTheme, plotlyConfig } from "../utils/plotlyLocale";
 import { insuranceAccountsApi, transactionsApi, type InsuranceAccount } from "../services/api";
 import { formatDate } from "../utils/dateFormatting";
 
@@ -493,10 +493,9 @@ export function InsurancesPrototype() {
               },
             ]}
             layout={{
+              ...chartTheme,
               height: 280,
               margin: { t: 20, b: 40, l: 50, r: 50 },
-              paper_bgcolor: "transparent",
-              plot_bgcolor: "transparent",
               xaxis: { color: "#94a3b8", gridcolor: "#334155", tickfont: { size: 10 } },
               yaxis: {
                 color: "#94a3b8",
@@ -541,10 +540,9 @@ export function InsurancesPrototype() {
                 },
               ]}
               layout={{
+                ...chartTheme,
                 height: 280,
                 margin: { t: 20, b: 20, l: 20, r: 20 },
-                paper_bgcolor: "transparent",
-                plot_bgcolor: "transparent",
                 showlegend: false,
                 annotations: [
                   {

--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -21,7 +21,7 @@ import { SelectDropdown } from "../components/common/SelectDropdown";
 import { Skeleton } from "../components/common/Skeleton";
 import { Sparkline } from "../components/common/Sparkline";
 import Plot from "react-plotly.js";
-import { plotlyConfig } from "../utils/plotlyLocale";
+import { chartTheme, plotlyConfig } from "../utils/plotlyLocale";
 
 interface Investment {
   id: number;
@@ -572,15 +572,6 @@ export function Investments() {
   const formatPercent = (val: number) =>
     `${val > 0 ? "+" : ""}${val.toFixed(2)}%`;
 
-  const chartTheme = {
-    paper_bgcolor: "rgba(0,0,0,0)",
-    plot_bgcolor: "rgba(0,0,0,0)",
-    font: { color: "#94a3b8", family: "Inter, sans-serif" },
-    margin: { t: 30, b: 30, l: 40, r: 20 },
-    hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
-    hovermode: "x unified" as const,
-    xaxis: { showspikes: false },
-  };
 
   const activeInvestments =
     investments?.filter((inv: Investment) => !inv.is_closed) || [];

--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -643,7 +643,6 @@ export function Investments() {
           investment={investments?.find((i: Investment) => i.id === selectedAnalysisId)}
           onClose={() => setSelectedAnalysisId(null)}
         />
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm animate-in fade-in duration-200">
       )}
 
       {/* Update Balance Modal */}

--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -9,7 +9,10 @@ import {
   TrendingUp,
   Info,
   BarChart2,
+  X,
+  Wallet,
   DollarSign,
+  Percent,
   Pencil,
   Settings,
 } from "lucide-react";
@@ -17,8 +20,8 @@ import { investmentsApi, taggingApi } from "../services/api";
 import { SelectDropdown } from "../components/common/SelectDropdown";
 import { Skeleton } from "../components/common/Skeleton";
 import { Sparkline } from "../components/common/Sparkline";
-import { PortfolioOverview } from "../components/investments/PortfolioOverview";
-import { InvestmentAnalysisModal } from "../components/investments/InvestmentAnalysisModal";
+import Plot from "react-plotly.js";
+import { plotlyConfig } from "../utils/plotlyLocale";
 
 interface Investment {
   id: number;
@@ -57,6 +60,43 @@ interface BalancePoint {
   balance: number;
 }
 
+interface BalanceSeries {
+  name: string;
+  data: BalancePoint[];
+}
+
+interface Snapshot {
+  id: number;
+  date: string;
+  balance: number;
+  source: string;
+}
+
+function StatCard({
+  title,
+  value,
+  icon: Icon,
+  color,
+}: {
+  title: string;
+  value: string | number;
+  icon: React.ComponentType<{ size: number }>;
+  color: string;
+}) {
+  return (
+    <div className="bg-[var(--surface)] rounded-xl p-5 border border-[var(--surface-light)] flex items-center justify-between shadow-sm">
+      <div>
+        <p className="text-[var(--text-muted)] text-[10px] uppercase tracking-widest font-bold">
+          {title}
+        </p>
+        <p className="text-xl font-black mt-1 text-white">{value}</p>
+      </div>
+      <div className={`p-3 rounded-xl ${color}`}>
+        <Icon size={20} />
+      </div>
+    </div>
+  );
+}
 
 const RATE_TYPES = new Set(["bonds", "pension", "p2p_lending"]);
 
@@ -177,7 +217,7 @@ function InvestmentCard({
             </div>
           )}
         </div>
-        <div className="flex-shrink-0 ms-4">
+        <div className="flex-shrink-0 ml-4">
           {(analysisData?.history?.length ?? 0) >= 2 ? (
             <Sparkline
               data={analysisData!.history!.map(p => p.balance)}
@@ -275,7 +315,7 @@ function InvestmentCard({
               <div className="p-2 rounded-lg bg-[var(--surface-light)] text-[var(--text-muted)] cursor-help">
                 <Info size={16} />
               </div>
-              <div className="absolute bottom-full start-0 mb-2 w-48 p-2 rounded-lg bg-[var(--surface-light)] text-[10px] text-white opacity-0 group-hover/notes:opacity-100 transition-all pointer-events-none z-10 shadow-xl border border-white/5">
+              <div className="absolute bottom-full left-0 mb-2 w-48 p-2 rounded-lg bg-[var(--surface-light)] text-[10px] text-white opacity-0 group-hover/notes:opacity-100 transition-all pointer-events-none z-10 shadow-xl border border-white/5">
                 {inv.notes}
               </div>
             </div>
@@ -371,6 +411,34 @@ export function Investments() {
       investmentsApi.getPortfolioAnalysis().then((res) => res.data),
   });
 
+  const [chartIncludeClosed, setChartIncludeClosed] = useState(true);
+  const { data: balanceHistory } = useQuery({
+    queryKey: ["portfolio-balance-history", chartIncludeClosed],
+    queryFn: () =>
+      investmentsApi.getPortfolioBalanceHistory(chartIncludeClosed).then((res) => res.data),
+  });
+
+  const { data: selectedAnalysis } = useQuery({
+    queryKey: ["investment-analysis", selectedAnalysisId],
+    queryFn: () =>
+      selectedAnalysisId
+        ? investmentsApi
+            .getInvestmentAnalysis(selectedAnalysisId)
+            .then((res) => res.data)
+        : null,
+    enabled: !!selectedAnalysisId,
+  });
+
+  const { data: selectedSnapshots } = useQuery({
+    queryKey: ["investment-snapshots", selectedAnalysisId],
+    queryFn: () =>
+      selectedAnalysisId
+        ? investmentsApi
+            .getBalanceSnapshots(selectedAnalysisId)
+            .then((res) => res.data)
+        : null,
+    enabled: !!selectedAnalysisId,
+  });
 
   // Mutations
   const editMutation = useMutation({
@@ -455,6 +523,27 @@ export function Investments() {
     },
   });
 
+  const deleteSnapshotMutation = useMutation({
+    mutationFn: ({ investmentId, snapshotId }: { investmentId: number; snapshotId: number }) =>
+      investmentsApi.deleteBalanceSnapshot(investmentId, snapshotId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["investments"] });
+      queryClient.invalidateQueries({ queryKey: ["investment-snapshots"] });
+      queryClient.invalidateQueries({ queryKey: ["investment-analysis"] });
+      queryClient.invalidateQueries({ queryKey: ["portfolio-analysis"] });
+    },
+  });
+
+  const calculateMutation = useMutation({
+    mutationFn: (investmentId: number) =>
+      investmentsApi.calculateFixedRateSnapshots(investmentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["investments"] });
+      queryClient.invalidateQueries({ queryKey: ["investment-snapshots"] });
+      queryClient.invalidateQueries({ queryKey: ["investment-analysis"] });
+      queryClient.invalidateQueries({ queryKey: ["portfolio-analysis"] });
+    },
+  });
 
   // Filtering logic for New Investment dropdowns
   const usedTagsSet = new Set(
@@ -474,6 +563,24 @@ export function Investments() {
           return obj;
         }, {} as Record<string, string[]>)
     : {};
+
+  const formatCurrency = (val: number) =>
+    new Intl.NumberFormat("he-IL", {
+      style: "currency",
+      currency: "ILS",
+    }).format(val);
+  const formatPercent = (val: number) =>
+    `${val > 0 ? "+" : ""}${val.toFixed(2)}%`;
+
+  const chartTheme = {
+    paper_bgcolor: "rgba(0,0,0,0)",
+    plot_bgcolor: "rgba(0,0,0,0)",
+    font: { color: "#94a3b8", family: "Inter, sans-serif" },
+    margin: { t: 30, b: 30, l: 40, r: 20 },
+    hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
+    hovermode: "x unified" as const,
+    xaxis: { showspikes: false },
+  };
 
   const activeInvestments =
     investments?.filter((inv: Investment) => !inv.is_closed) || [];
@@ -533,7 +640,136 @@ export function Investments() {
 
       {/* Portfolio Overview */}
       {portfolioAnalysis && (
-        <PortfolioOverview portfolioAnalysis={portfolioAnalysis} />
+        <div className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <StatCard
+                title={t("investments.totalValue")}
+                value={formatCurrency(portfolioAnalysis.total_value)}
+                icon={Wallet}
+                color="bg-blue-500/10 text-blue-400"
+              />
+              <StatCard
+                title={t("investments.totalProfitLoss")}
+                value={formatCurrency(portfolioAnalysis.total_profit)}
+                icon={DollarSign}
+                color={
+                  portfolioAnalysis.total_profit >= 0
+                    ? "bg-emerald-500/10 text-emerald-400"
+                    : "bg-red-500/10 text-red-400"
+                }
+              />
+              <StatCard
+                title={t("investments.portfolioRoi")}
+                value={formatPercent(portfolioAnalysis.portfolio_roi)}
+                icon={Percent}
+                color={
+                  portfolioAnalysis.portfolio_roi >= 0
+                    ? "bg-emerald-500/10 text-emerald-400"
+                    : "bg-red-500/10 text-red-400"
+                }
+              />
+            </div>
+            {/* Charts: Balance Over Time + Allocation side-by-side */}
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+              {/* Balance Over Time Chart */}
+              <div className="lg:col-span-2 bg-[var(--surface)] rounded-2xl p-6 border border-[var(--surface-light)]">
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-sm font-bold uppercase tracking-widest text-[var(--text-muted)]">
+                    {t("investments.balanceOverTime")}
+                  </h3>
+                  <button
+                    onClick={() => setChartIncludeClosed(!chartIncludeClosed)}
+                    className={`px-3 py-1.5 rounded-lg text-xs font-bold border transition-all ${chartIncludeClosed ? "bg-[var(--surface-light)] border-[var(--surface-light)] text-white" : "border-[var(--surface-light)] text-[var(--text-muted)] hover:text-white"}`}
+                  >
+                    {chartIncludeClosed ? t("investments.hideClosed") : t("investments.includeClosed")}
+                  </button>
+                </div>
+                <div className="h-[300px]">
+                  {balanceHistory?.series?.length > 0 ? (
+                    <Plot
+                      data={[
+                        ...balanceHistory.series.map((s: BalanceSeries, i: number) => ({
+                          x: s.data.map((d: BalancePoint) => d.date),
+                          y: s.data.map((d: BalancePoint) => d.balance),
+                          name: s.name,
+                          type: "scatter" as const,
+                          mode: "lines" as const,
+                          line: {
+                            color: ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#06b6d4", "#ec4899"][i % 7],
+                            width: 2,
+                            shape: "hv" as const,
+                          },
+                        })),
+                        {
+                          x: balanceHistory.total.map((d: BalancePoint) => d.date),
+                          y: balanceHistory.total.map((d: BalancePoint) => d.balance),
+                          name: "Total",
+                          type: "scatter" as const,
+                          mode: "lines" as const,
+                          line: { color: "#ffffff", width: 3, shape: "hv" as const },
+                        },
+                      ]}
+                      layout={{
+                        ...chartTheme,
+                        xaxis: { showgrid: false },
+                        yaxis: { gridcolor: "rgba(255,255,255,0.05)" },
+                        showlegend: true,
+                        legend: { orientation: "h", y: -0.12, font: { size: 10 } },
+                      }}
+                      style={{ width: "100%", height: "100%" }}
+                      config={plotlyConfig()}
+                    />
+                  ) : (
+                    <div className="h-full flex items-center justify-center text-[var(--text-muted)] text-sm">
+                      {t("investments.noBalanceHistory")}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Allocation Pie Chart */}
+              {portfolioAnalysis.allocation.filter((d: BalancePoint) => d.balance > 0).length > 0 && (
+                <div className="bg-[var(--surface)] rounded-2xl p-6 border border-[var(--surface-light)]">
+                  <h3 className="text-sm font-bold uppercase tracking-widest text-[var(--text-muted)] mb-4">
+                    {t("investments.portfolioAllocation")}
+                  </h3>
+                  <div className="h-[300px]">
+                    <Plot
+                      data={[
+                        {
+                          values: portfolioAnalysis.allocation.filter((d: BalancePoint) => d.balance > 0).map(
+                            (d: BalancePoint) => d.balance,
+                          ),
+                          labels: portfolioAnalysis.allocation.filter((d: BalancePoint) => d.balance > 0).map(
+                            (d: AllocationItem) => d.name,
+                          ),
+                          type: "pie",
+                          hole: 0.5,
+                          marker: {
+                            colors: [
+                              "#3b82f6",
+                              "#10b981",
+                              "#f59e0b",
+                              "#ef4444",
+                              "#8b5cf6",
+                            ],
+                          },
+                        },
+                      ]}
+                      layout={{
+                        ...chartTheme,
+                        margin: { t: 0, b: 0, l: 0, r: 0 },
+                        showlegend: true,
+                        legend: { orientation: "h" },
+                      }}
+                      style={{ width: "100%", height: "100%" }}
+                      config={plotlyConfig()}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+        </div>
       )}
 
       {/* Active Investments */}
@@ -638,12 +874,216 @@ export function Investments() {
 
       {/* Analysis Modal */}
       {selectedAnalysisId && (
-        <InvestmentAnalysisModal
-          investmentId={selectedAnalysisId}
-          investment={investments?.find((i: Investment) => i.id === selectedAnalysisId)}
-          onClose={() => setSelectedAnalysisId(null)}
-        />
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm animate-in fade-in duration-200">
+          <div className="bg-[var(--surface)] border border-[var(--surface-light)] rounded-2xl w-full max-w-4xl max-h-[90vh] overflow-y-auto shadow-2xl animate-in zoom-in-95 duration-200">
+            <div className="sticky top-0 z-10 bg-[var(--surface)]/95 backdrop-blur border-b border-[var(--surface-light)] p-6 flex justify-between items-center">
+              <h2 className="text-2xl font-bold flex items-center gap-3">
+                <BarChart2 className="text-[var(--primary)]" /> {t("investments.investmentAnalysis")}
+              </h2>
+              <button
+                onClick={() => setSelectedAnalysisId(null)}
+                className="p-2 hover:bg-[var(--surface-light)] rounded-full transition-colors"
+              >
+                <X size={24} />
+              </button>
+            </div>
+
+            <div className="p-8 space-y-8">
+              {selectedAnalysis ? (
+                <>
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                    <StatCard
+                      title={t("investments.currentBalance")}
+                      value={formatCurrency(
+                        selectedAnalysis.metrics.current_balance,
+                      )}
+                      icon={Wallet}
+                      color="bg-blue-500/10 text-blue-400"
+                    />
+                    <StatCard
+                      title={t("investments.profitLoss")}
+                      value={formatCurrency(
+                        selectedAnalysis.metrics.absolute_profit_loss,
+                      )}
+                      icon={DollarSign}
+                      color={
+                        selectedAnalysis.metrics.absolute_profit_loss >= 0
+                          ? "bg-emerald-500/10 text-emerald-400"
+                          : "bg-red-500/10 text-red-400"
+                      }
+                    />
+                    <StatCard
+                      title={t("investments.roi")}
+                      value={formatPercent(
+                        selectedAnalysis.metrics.roi_percentage,
+                      )}
+                      icon={Percent}
+                      color={
+                        selectedAnalysis.metrics.roi_percentage >= 0
+                          ? "bg-emerald-500/10 text-emerald-400"
+                          : "bg-red-500/10 text-red-400"
+                      }
+                    />
+                    <StatCard
+                      title={t("investments.cagr")}
+                      value={formatPercent(
+                        selectedAnalysis.metrics.cagr_percentage,
+                      )}
+                      icon={TrendingUp}
+                      color="bg-purple-500/10 text-purple-400"
+                    />
+                  </div>
+
+                  <div className="bg-[var(--surface-base)] rounded-2xl p-6 border border-[var(--surface-light)]">
+                    <h3 className="text-lg font-bold mb-6">{t("investments.balanceHistory")}</h3>
+                    <div className="h-[400px]">
+                      <Plot
+                        data={[
+                          {
+                            x: selectedAnalysis.history.map((d: BalancePoint) => d.date),
+                            y: selectedAnalysis.history.map(
+                              (d: BalancePoint) => d.balance,
+                            ),
+                            type: "scatter",
+                            mode: "lines",
+                            fill: "tozeroy",
+                            line: { color: "#3b82f6", width: 3 },
+                            fillcolor: "rgba(59, 130, 246, 0.1)",
+                          },
+                        ]}
+                        layout={{
+                          ...chartTheme,
+                          xaxis: { showgrid: false },
+                          yaxis: { gridcolor: "rgba(255,255,255,0.05)" },
+                        }}
+                        style={{ width: "100%", height: "100%" }}
+                        config={plotlyConfig()}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-3 gap-6 text-sm text-[var(--text-muted)] font-medium bg-[var(--surface-base)] p-6 rounded-2xl border border-[var(--surface-light)]">
+                    <div>
+                      <p className="uppercase text-[10px] tracking-widest font-bold mb-1">
+                        {t("investments.totalDeposits")}
+                      </p>
+                      <p className="text-white text-lg font-bold">
+                        {formatCurrency(
+                          selectedAnalysis.metrics.total_deposits,
+                        )}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="uppercase text-[10px] tracking-widest font-bold mb-1">
+                        {t("investments.totalWithdrawals")}
+                      </p>
+                      <p className="text-white text-lg font-bold">
+                        {formatCurrency(
+                          selectedAnalysis.metrics.total_withdrawals,
+                        )}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="uppercase text-[10px] tracking-widest font-bold mb-1">
+                        {t("investments.holdingPeriod")}
+                      </p>
+                      <p className="text-white text-lg font-bold">
+                        {selectedAnalysis.metrics.total_years.toFixed(1)} {t("investments.years")}
+                      </p>
+                    </div>
+                  </div>
+
+                  {/* Fixed-Rate Calculation */}
+                  {investments?.find((i: Investment) => i.id === selectedAnalysisId)
+                    ?.interest_rate_type === "fixed" &&
+                    !!investments?.find((i: Investment) => i.id === selectedAnalysisId)
+                      ?.interest_rate && (
+                    <div className="flex justify-end">
+                      <button
+                        onClick={() => calculateMutation.mutate(selectedAnalysisId!)}
+                        disabled={calculateMutation.isPending}
+                        className="px-4 py-2 bg-purple-500/10 text-purple-400 hover:bg-purple-500/20 rounded-xl text-sm font-bold transition-all disabled:opacity-50"
+                      >
+                        {calculateMutation.isPending
+                          ? t("investments.calculating")
+                          : t("investments.calculateFixedRate")}
+                      </button>
+                    </div>
+                  )}
+
+                  {/* Balance Snapshots */}
+                  {selectedSnapshots?.length > 0 && (
+                    <div className="bg-[var(--surface-base)] rounded-2xl p-6 border border-[var(--surface-light)]">
+                      <div className="flex items-center justify-between mb-4">
+                        <h3 className="text-lg font-bold">{t("investments.balanceSnapshots")}</h3>
+                        <span className="text-xs text-[var(--text-muted)]">
+                          {selectedSnapshots.length} entries
+                        </span>
+                      </div>
+                      <div className="overflow-x-auto">
+                        <table className="w-full text-sm">
+                          <thead>
+                            <tr className="text-[10px] uppercase tracking-widest text-[var(--text-muted)] border-b border-[var(--surface-light)]">
+                              <th className="text-start py-2 font-bold">{t("common.date")}</th>
+                              <th className="text-right py-2 font-bold">{t("investments.balance")}</th>
+                              <th className="text-center py-2 font-bold">{t("investments.source")}</th>
+                              <th className="text-right py-2 font-bold"></th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {selectedSnapshots.map((snap: Snapshot) => (
+                              <tr
+                                key={snap.id}
+                                className="border-b border-[var(--surface-light)]/50 hover:bg-[var(--surface-light)]/30"
+                              >
+                                <td className="py-2 text-white font-medium">
+                                  {snap.date}
+                                </td>
+                                <td className="py-2 text-right text-white font-bold">
+                                  {formatCurrency(snap.balance)}
+                                </td>
+                                <td className="py-2 text-center">
+                                  <span
+                                    className={`text-[10px] font-black uppercase px-2 py-0.5 rounded ${
+                                      snap.source === "manual"
+                                        ? "bg-blue-500/20 text-blue-400"
+                                        : snap.source === "calculated"
+                                          ? "bg-purple-500/20 text-purple-400"
+                                          : "bg-emerald-500/20 text-emerald-400"
+                                    }`}
+                                  >
+                                    {snap.source}
+                                  </span>
+                                </td>
+                                <td className="py-2 text-right">
+                                  <button
+                                    onClick={() =>
+                                      deleteSnapshotMutation.mutate({
+                                        investmentId: selectedAnalysisId!,
+                                        snapshotId: snap.id,
+                                      })
+                                    }
+                                    className="p-1 rounded hover:bg-red-500/20 text-[var(--text-muted)] hover:text-red-400 transition-all"
+                                  >
+                                    <Trash2 size={14} />
+                                  </button>
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="text-center py-20 text-[var(--text-muted)]">
+                  {t("investments.loadingAnalysis")}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
       )}
 
       {/* Update Balance Modal */}

--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -9,10 +9,7 @@ import {
   TrendingUp,
   Info,
   BarChart2,
-  X,
-  Wallet,
   DollarSign,
-  Percent,
   Pencil,
   Settings,
 } from "lucide-react";
@@ -20,8 +17,8 @@ import { investmentsApi, taggingApi } from "../services/api";
 import { SelectDropdown } from "../components/common/SelectDropdown";
 import { Skeleton } from "../components/common/Skeleton";
 import { Sparkline } from "../components/common/Sparkline";
-import Plot from "react-plotly.js";
-import { chartTheme, plotlyConfig } from "../utils/plotlyLocale";
+import { PortfolioOverview } from "../components/investments/PortfolioOverview";
+import { InvestmentAnalysisModal } from "../components/investments/InvestmentAnalysisModal";
 
 interface Investment {
   id: number;
@@ -60,43 +57,6 @@ interface BalancePoint {
   balance: number;
 }
 
-interface BalanceSeries {
-  name: string;
-  data: BalancePoint[];
-}
-
-interface Snapshot {
-  id: number;
-  date: string;
-  balance: number;
-  source: string;
-}
-
-function StatCard({
-  title,
-  value,
-  icon: Icon,
-  color,
-}: {
-  title: string;
-  value: string | number;
-  icon: React.ComponentType<{ size: number }>;
-  color: string;
-}) {
-  return (
-    <div className="bg-[var(--surface)] rounded-xl p-5 border border-[var(--surface-light)] flex items-center justify-between shadow-sm">
-      <div>
-        <p className="text-[var(--text-muted)] text-[10px] uppercase tracking-widest font-bold">
-          {title}
-        </p>
-        <p className="text-xl font-black mt-1 text-white">{value}</p>
-      </div>
-      <div className={`p-3 rounded-xl ${color}`}>
-        <Icon size={20} />
-      </div>
-    </div>
-  );
-}
 
 const RATE_TYPES = new Set(["bonds", "pension", "p2p_lending"]);
 
@@ -217,7 +177,7 @@ function InvestmentCard({
             </div>
           )}
         </div>
-        <div className="flex-shrink-0 ml-4">
+        <div className="flex-shrink-0 ms-4">
           {(analysisData?.history?.length ?? 0) >= 2 ? (
             <Sparkline
               data={analysisData!.history!.map(p => p.balance)}
@@ -315,7 +275,7 @@ function InvestmentCard({
               <div className="p-2 rounded-lg bg-[var(--surface-light)] text-[var(--text-muted)] cursor-help">
                 <Info size={16} />
               </div>
-              <div className="absolute bottom-full left-0 mb-2 w-48 p-2 rounded-lg bg-[var(--surface-light)] text-[10px] text-white opacity-0 group-hover/notes:opacity-100 transition-all pointer-events-none z-10 shadow-xl border border-white/5">
+              <div className="absolute bottom-full start-0 mb-2 w-48 p-2 rounded-lg bg-[var(--surface-light)] text-[10px] text-white opacity-0 group-hover/notes:opacity-100 transition-all pointer-events-none z-10 shadow-xl border border-white/5">
                 {inv.notes}
               </div>
             </div>
@@ -411,34 +371,6 @@ export function Investments() {
       investmentsApi.getPortfolioAnalysis().then((res) => res.data),
   });
 
-  const [chartIncludeClosed, setChartIncludeClosed] = useState(true);
-  const { data: balanceHistory } = useQuery({
-    queryKey: ["portfolio-balance-history", chartIncludeClosed],
-    queryFn: () =>
-      investmentsApi.getPortfolioBalanceHistory(chartIncludeClosed).then((res) => res.data),
-  });
-
-  const { data: selectedAnalysis } = useQuery({
-    queryKey: ["investment-analysis", selectedAnalysisId],
-    queryFn: () =>
-      selectedAnalysisId
-        ? investmentsApi
-            .getInvestmentAnalysis(selectedAnalysisId)
-            .then((res) => res.data)
-        : null,
-    enabled: !!selectedAnalysisId,
-  });
-
-  const { data: selectedSnapshots } = useQuery({
-    queryKey: ["investment-snapshots", selectedAnalysisId],
-    queryFn: () =>
-      selectedAnalysisId
-        ? investmentsApi
-            .getBalanceSnapshots(selectedAnalysisId)
-            .then((res) => res.data)
-        : null,
-    enabled: !!selectedAnalysisId,
-  });
 
   // Mutations
   const editMutation = useMutation({
@@ -523,27 +455,6 @@ export function Investments() {
     },
   });
 
-  const deleteSnapshotMutation = useMutation({
-    mutationFn: ({ investmentId, snapshotId }: { investmentId: number; snapshotId: number }) =>
-      investmentsApi.deleteBalanceSnapshot(investmentId, snapshotId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["investments"] });
-      queryClient.invalidateQueries({ queryKey: ["investment-snapshots"] });
-      queryClient.invalidateQueries({ queryKey: ["investment-analysis"] });
-      queryClient.invalidateQueries({ queryKey: ["portfolio-analysis"] });
-    },
-  });
-
-  const calculateMutation = useMutation({
-    mutationFn: (investmentId: number) =>
-      investmentsApi.calculateFixedRateSnapshots(investmentId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["investments"] });
-      queryClient.invalidateQueries({ queryKey: ["investment-snapshots"] });
-      queryClient.invalidateQueries({ queryKey: ["investment-analysis"] });
-      queryClient.invalidateQueries({ queryKey: ["portfolio-analysis"] });
-    },
-  });
 
   // Filtering logic for New Investment dropdowns
   const usedTagsSet = new Set(
@@ -563,15 +474,6 @@ export function Investments() {
           return obj;
         }, {} as Record<string, string[]>)
     : {};
-
-  const formatCurrency = (val: number) =>
-    new Intl.NumberFormat("he-IL", {
-      style: "currency",
-      currency: "ILS",
-    }).format(val);
-  const formatPercent = (val: number) =>
-    `${val > 0 ? "+" : ""}${val.toFixed(2)}%`;
-
 
   const activeInvestments =
     investments?.filter((inv: Investment) => !inv.is_closed) || [];
@@ -631,136 +533,7 @@ export function Investments() {
 
       {/* Portfolio Overview */}
       {portfolioAnalysis && (
-        <div className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <StatCard
-                title={t("investments.totalValue")}
-                value={formatCurrency(portfolioAnalysis.total_value)}
-                icon={Wallet}
-                color="bg-blue-500/10 text-blue-400"
-              />
-              <StatCard
-                title={t("investments.totalProfitLoss")}
-                value={formatCurrency(portfolioAnalysis.total_profit)}
-                icon={DollarSign}
-                color={
-                  portfolioAnalysis.total_profit >= 0
-                    ? "bg-emerald-500/10 text-emerald-400"
-                    : "bg-red-500/10 text-red-400"
-                }
-              />
-              <StatCard
-                title={t("investments.portfolioRoi")}
-                value={formatPercent(portfolioAnalysis.portfolio_roi)}
-                icon={Percent}
-                color={
-                  portfolioAnalysis.portfolio_roi >= 0
-                    ? "bg-emerald-500/10 text-emerald-400"
-                    : "bg-red-500/10 text-red-400"
-                }
-              />
-            </div>
-            {/* Charts: Balance Over Time + Allocation side-by-side */}
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              {/* Balance Over Time Chart */}
-              <div className="lg:col-span-2 bg-[var(--surface)] rounded-2xl p-6 border border-[var(--surface-light)]">
-                <div className="flex items-center justify-between mb-4">
-                  <h3 className="text-sm font-bold uppercase tracking-widest text-[var(--text-muted)]">
-                    {t("investments.balanceOverTime")}
-                  </h3>
-                  <button
-                    onClick={() => setChartIncludeClosed(!chartIncludeClosed)}
-                    className={`px-3 py-1.5 rounded-lg text-xs font-bold border transition-all ${chartIncludeClosed ? "bg-[var(--surface-light)] border-[var(--surface-light)] text-white" : "border-[var(--surface-light)] text-[var(--text-muted)] hover:text-white"}`}
-                  >
-                    {chartIncludeClosed ? t("investments.hideClosed") : t("investments.includeClosed")}
-                  </button>
-                </div>
-                <div className="h-[300px]">
-                  {balanceHistory?.series?.length > 0 ? (
-                    <Plot
-                      data={[
-                        ...balanceHistory.series.map((s: BalanceSeries, i: number) => ({
-                          x: s.data.map((d: BalancePoint) => d.date),
-                          y: s.data.map((d: BalancePoint) => d.balance),
-                          name: s.name,
-                          type: "scatter" as const,
-                          mode: "lines" as const,
-                          line: {
-                            color: ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#06b6d4", "#ec4899"][i % 7],
-                            width: 2,
-                            shape: "hv" as const,
-                          },
-                        })),
-                        {
-                          x: balanceHistory.total.map((d: BalancePoint) => d.date),
-                          y: balanceHistory.total.map((d: BalancePoint) => d.balance),
-                          name: "Total",
-                          type: "scatter" as const,
-                          mode: "lines" as const,
-                          line: { color: "#ffffff", width: 3, shape: "hv" as const },
-                        },
-                      ]}
-                      layout={{
-                        ...chartTheme,
-                        xaxis: { showgrid: false },
-                        yaxis: { gridcolor: "rgba(255,255,255,0.05)" },
-                        showlegend: true,
-                        legend: { orientation: "h", y: -0.12, font: { size: 10 } },
-                      }}
-                      style={{ width: "100%", height: "100%" }}
-                      config={plotlyConfig()}
-                    />
-                  ) : (
-                    <div className="h-full flex items-center justify-center text-[var(--text-muted)] text-sm">
-                      {t("investments.noBalanceHistory")}
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Allocation Pie Chart */}
-              {portfolioAnalysis.allocation.filter((d: BalancePoint) => d.balance > 0).length > 0 && (
-                <div className="bg-[var(--surface)] rounded-2xl p-6 border border-[var(--surface-light)]">
-                  <h3 className="text-sm font-bold uppercase tracking-widest text-[var(--text-muted)] mb-4">
-                    {t("investments.portfolioAllocation")}
-                  </h3>
-                  <div className="h-[300px]">
-                    <Plot
-                      data={[
-                        {
-                          values: portfolioAnalysis.allocation.filter((d: BalancePoint) => d.balance > 0).map(
-                            (d: BalancePoint) => d.balance,
-                          ),
-                          labels: portfolioAnalysis.allocation.filter((d: BalancePoint) => d.balance > 0).map(
-                            (d: AllocationItem) => d.name,
-                          ),
-                          type: "pie",
-                          hole: 0.5,
-                          marker: {
-                            colors: [
-                              "#3b82f6",
-                              "#10b981",
-                              "#f59e0b",
-                              "#ef4444",
-                              "#8b5cf6",
-                            ],
-                          },
-                        },
-                      ]}
-                      layout={{
-                        ...chartTheme,
-                        margin: { t: 0, b: 0, l: 0, r: 0 },
-                        showlegend: true,
-                        legend: { orientation: "h" },
-                      }}
-                      style={{ width: "100%", height: "100%" }}
-                      config={plotlyConfig()}
-                    />
-                  </div>
-                </div>
-              )}
-            </div>
-        </div>
+        <PortfolioOverview portfolioAnalysis={portfolioAnalysis} />
       )}
 
       {/* Active Investments */}
@@ -865,216 +638,12 @@ export function Investments() {
 
       {/* Analysis Modal */}
       {selectedAnalysisId && (
+        <InvestmentAnalysisModal
+          investmentId={selectedAnalysisId}
+          investment={investments?.find((i: Investment) => i.id === selectedAnalysisId)}
+          onClose={() => setSelectedAnalysisId(null)}
+        />
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/80 backdrop-blur-sm animate-in fade-in duration-200">
-          <div className="bg-[var(--surface)] border border-[var(--surface-light)] rounded-2xl w-full max-w-4xl max-h-[90vh] overflow-y-auto shadow-2xl animate-in zoom-in-95 duration-200">
-            <div className="sticky top-0 z-10 bg-[var(--surface)]/95 backdrop-blur border-b border-[var(--surface-light)] p-6 flex justify-between items-center">
-              <h2 className="text-2xl font-bold flex items-center gap-3">
-                <BarChart2 className="text-[var(--primary)]" /> {t("investments.investmentAnalysis")}
-              </h2>
-              <button
-                onClick={() => setSelectedAnalysisId(null)}
-                className="p-2 hover:bg-[var(--surface-light)] rounded-full transition-colors"
-              >
-                <X size={24} />
-              </button>
-            </div>
-
-            <div className="p-8 space-y-8">
-              {selectedAnalysis ? (
-                <>
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                    <StatCard
-                      title={t("investments.currentBalance")}
-                      value={formatCurrency(
-                        selectedAnalysis.metrics.current_balance,
-                      )}
-                      icon={Wallet}
-                      color="bg-blue-500/10 text-blue-400"
-                    />
-                    <StatCard
-                      title={t("investments.profitLoss")}
-                      value={formatCurrency(
-                        selectedAnalysis.metrics.absolute_profit_loss,
-                      )}
-                      icon={DollarSign}
-                      color={
-                        selectedAnalysis.metrics.absolute_profit_loss >= 0
-                          ? "bg-emerald-500/10 text-emerald-400"
-                          : "bg-red-500/10 text-red-400"
-                      }
-                    />
-                    <StatCard
-                      title={t("investments.roi")}
-                      value={formatPercent(
-                        selectedAnalysis.metrics.roi_percentage,
-                      )}
-                      icon={Percent}
-                      color={
-                        selectedAnalysis.metrics.roi_percentage >= 0
-                          ? "bg-emerald-500/10 text-emerald-400"
-                          : "bg-red-500/10 text-red-400"
-                      }
-                    />
-                    <StatCard
-                      title={t("investments.cagr")}
-                      value={formatPercent(
-                        selectedAnalysis.metrics.cagr_percentage,
-                      )}
-                      icon={TrendingUp}
-                      color="bg-purple-500/10 text-purple-400"
-                    />
-                  </div>
-
-                  <div className="bg-[var(--surface-base)] rounded-2xl p-6 border border-[var(--surface-light)]">
-                    <h3 className="text-lg font-bold mb-6">{t("investments.balanceHistory")}</h3>
-                    <div className="h-[400px]">
-                      <Plot
-                        data={[
-                          {
-                            x: selectedAnalysis.history.map((d: BalancePoint) => d.date),
-                            y: selectedAnalysis.history.map(
-                              (d: BalancePoint) => d.balance,
-                            ),
-                            type: "scatter",
-                            mode: "lines",
-                            fill: "tozeroy",
-                            line: { color: "#3b82f6", width: 3 },
-                            fillcolor: "rgba(59, 130, 246, 0.1)",
-                          },
-                        ]}
-                        layout={{
-                          ...chartTheme,
-                          xaxis: { showgrid: false },
-                          yaxis: { gridcolor: "rgba(255,255,255,0.05)" },
-                        }}
-                        style={{ width: "100%", height: "100%" }}
-                        config={plotlyConfig()}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="grid grid-cols-3 gap-6 text-sm text-[var(--text-muted)] font-medium bg-[var(--surface-base)] p-6 rounded-2xl border border-[var(--surface-light)]">
-                    <div>
-                      <p className="uppercase text-[10px] tracking-widest font-bold mb-1">
-                        {t("investments.totalDeposits")}
-                      </p>
-                      <p className="text-white text-lg font-bold">
-                        {formatCurrency(
-                          selectedAnalysis.metrics.total_deposits,
-                        )}
-                      </p>
-                    </div>
-                    <div>
-                      <p className="uppercase text-[10px] tracking-widest font-bold mb-1">
-                        {t("investments.totalWithdrawals")}
-                      </p>
-                      <p className="text-white text-lg font-bold">
-                        {formatCurrency(
-                          selectedAnalysis.metrics.total_withdrawals,
-                        )}
-                      </p>
-                    </div>
-                    <div>
-                      <p className="uppercase text-[10px] tracking-widest font-bold mb-1">
-                        {t("investments.holdingPeriod")}
-                      </p>
-                      <p className="text-white text-lg font-bold">
-                        {selectedAnalysis.metrics.total_years.toFixed(1)} {t("investments.years")}
-                      </p>
-                    </div>
-                  </div>
-
-                  {/* Fixed-Rate Calculation */}
-                  {investments?.find((i: Investment) => i.id === selectedAnalysisId)
-                    ?.interest_rate_type === "fixed" &&
-                    !!investments?.find((i: Investment) => i.id === selectedAnalysisId)
-                      ?.interest_rate && (
-                    <div className="flex justify-end">
-                      <button
-                        onClick={() => calculateMutation.mutate(selectedAnalysisId!)}
-                        disabled={calculateMutation.isPending}
-                        className="px-4 py-2 bg-purple-500/10 text-purple-400 hover:bg-purple-500/20 rounded-xl text-sm font-bold transition-all disabled:opacity-50"
-                      >
-                        {calculateMutation.isPending
-                          ? t("investments.calculating")
-                          : t("investments.calculateFixedRate")}
-                      </button>
-                    </div>
-                  )}
-
-                  {/* Balance Snapshots */}
-                  {selectedSnapshots?.length > 0 && (
-                    <div className="bg-[var(--surface-base)] rounded-2xl p-6 border border-[var(--surface-light)]">
-                      <div className="flex items-center justify-between mb-4">
-                        <h3 className="text-lg font-bold">{t("investments.balanceSnapshots")}</h3>
-                        <span className="text-xs text-[var(--text-muted)]">
-                          {selectedSnapshots.length} entries
-                        </span>
-                      </div>
-                      <div className="overflow-x-auto">
-                        <table className="w-full text-sm">
-                          <thead>
-                            <tr className="text-[10px] uppercase tracking-widest text-[var(--text-muted)] border-b border-[var(--surface-light)]">
-                              <th className="text-start py-2 font-bold">{t("common.date")}</th>
-                              <th className="text-right py-2 font-bold">{t("investments.balance")}</th>
-                              <th className="text-center py-2 font-bold">{t("investments.source")}</th>
-                              <th className="text-right py-2 font-bold"></th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {selectedSnapshots.map((snap: Snapshot) => (
-                              <tr
-                                key={snap.id}
-                                className="border-b border-[var(--surface-light)]/50 hover:bg-[var(--surface-light)]/30"
-                              >
-                                <td className="py-2 text-white font-medium">
-                                  {snap.date}
-                                </td>
-                                <td className="py-2 text-right text-white font-bold">
-                                  {formatCurrency(snap.balance)}
-                                </td>
-                                <td className="py-2 text-center">
-                                  <span
-                                    className={`text-[10px] font-black uppercase px-2 py-0.5 rounded ${
-                                      snap.source === "manual"
-                                        ? "bg-blue-500/20 text-blue-400"
-                                        : snap.source === "calculated"
-                                          ? "bg-purple-500/20 text-purple-400"
-                                          : "bg-emerald-500/20 text-emerald-400"
-                                    }`}
-                                  >
-                                    {snap.source}
-                                  </span>
-                                </td>
-                                <td className="py-2 text-right">
-                                  <button
-                                    onClick={() =>
-                                      deleteSnapshotMutation.mutate({
-                                        investmentId: selectedAnalysisId!,
-                                        snapshotId: snap.id,
-                                      })
-                                    }
-                                    className="p-1 rounded hover:bg-red-500/20 text-[var(--text-muted)] hover:text-red-400 transition-all"
-                                  >
-                                    <Trash2 size={14} />
-                                  </button>
-                                </td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                    </div>
-                  )}
-                </>
-              ) : (
-                <div className="text-center py-20 text-[var(--text-muted)]">
-                  {t("investments.loadingAnalysis")}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
       )}
 
       {/* Update Balance Modal */}

--- a/frontend/src/utils/plotlyLocale.ts
+++ b/frontend/src/utils/plotlyLocale.ts
@@ -19,6 +19,17 @@ const heLocale = {
   },
 };
 
+/** Shared Plotly layout theme for dark mode charts */
+export const chartTheme: Partial<Plotly.Layout> = {
+  paper_bgcolor: "rgba(0,0,0,0)",
+  plot_bgcolor: "rgba(0,0,0,0)",
+  font: { color: "#94a3b8", family: "Inter, sans-serif" },
+  margin: { t: 40, b: 40, l: 40, r: 20 },
+  hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
+  hovermode: "x unified",
+  xaxis: { showspikes: false },
+};
+
 /** Plotly config with locale-aware date formatting */
 export function plotlyConfig(
   extra?: Partial<Plotly.Config>,


### PR DESCRIPTION
…er tooltips

- Add secondary y-axis for cumulative line in individual net worth views (bank balance/investments/net worth) so bar deltas aren't dwarfed
- Color-code right y-axis title and ticks to match the series color
- Switch all charts to unified hover mode with dark theme tooltip
- Disable spike lines on x-axis for cleaner hover experience
- Apply same hover improvements to Investments page