### PR TITLE
feat(backup): add manual database backup and restore via settings UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from backend.errors import (
 from backend.models import Base
 from backend.routes import (
     analytics,
+    backup,
     bank_balances,
     budget,
     cash_balances,
@@ -176,6 +177,7 @@ app.include_router(tagging.router, prefix="/api/tagging", tags=["Tagging"])
 app.include_router(investments.router, prefix="/api/investments", tags=["Investments"])
 app.include_router(liabilities.router, prefix="/api/liabilities", tags=["Liabilities"])
 app.include_router(analytics.router, prefix="/api/analytics", tags=["Analytics"])
+app.include_router(backup.router, prefix="/api/backups", tags=["Backups"])
 app.include_router(
     pending_refunds.router, prefix="/api/pending-refunds", tags=["Pending Refunds"]
 )

--- a/backend/routes/backup.py
+++ b/backend/routes/backup.py
@@ -1,0 +1,68 @@
+"""
+Backup management API routes.
+
+Provides endpoints for creating, listing, and restoring database backups.
+"""
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from backend.utils.backup import backup_db, list_backups, restore_backup
+
+router = APIRouter()
+
+
+class BackupInfo(BaseModel):
+    """Single backup file info."""
+
+    filename: str
+    created_at: str
+    size_bytes: int
+
+
+class RestoreRequest(BaseModel):
+    """Request body for restoring a backup."""
+
+    filename: str
+
+
+@router.get("/", response_model=list[BackupInfo])
+def get_backups():
+    """List all available database backups."""
+    return list_backups()
+
+
+@router.post("/", response_model=BackupInfo)
+def create_backup():
+    """Create a new database backup."""
+    path = backup_db()
+    if path is None:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=500, detail="Backup failed")
+
+    stat = path.stat()
+    from datetime import datetime
+
+    return BackupInfo(
+        filename=path.name,
+        created_at=datetime.fromtimestamp(stat.st_mtime).isoformat(),
+        size_bytes=stat.st_size,
+    )
+
+
+@router.post("/restore")
+def restore_from_backup(request: RestoreRequest):
+    """Restore database from a backup file.
+
+    Creates a safety backup of the current database before restoring.
+    Resets the DB engine so subsequent queries use the restored data.
+    """
+    try:
+        restore_backup(request.filename)
+    except FileNotFoundError as e:
+        from backend.errors import EntityNotFoundException
+
+        raise EntityNotFoundException(str(e))
+
+    return {"status": "restored", "filename": request.filename}

--- a/backend/utils/backup.py
+++ b/backend/utils/backup.py
@@ -1,0 +1,143 @@
+"""
+Database backup utility.
+
+Creates and restores backups of the SQLite database using Python's sqlite3.backup()
+API, which is safe to run while the database is in use.
+"""
+
+import logging
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from backend.config import AppConfig
+
+logger = logging.getLogger(__name__)
+
+MAX_BACKUPS = 5
+
+
+def get_backup_dir() -> Path:
+    """Get the backup directory path."""
+    return Path(AppConfig().get_user_dir()) / "backups"
+
+
+def backup_db(max_backups: int = MAX_BACKUPS) -> Path | None:
+    """Create a backup of the SQLite database.
+
+    Uses SQLite's online backup API which is safe during concurrent access.
+
+    Parameters
+    ----------
+    max_backups : int
+        Maximum number of backups to keep. When exceeded, the oldest is deleted.
+        Set to 0 to disable pruning.
+
+    Returns
+    -------
+    Path or None
+        Path to the created backup file, or None if backup failed.
+    """
+    config = AppConfig()
+    src = Path(config.get_db_path())
+    if not src.exists():
+        logger.warning("Database file not found at %s, skipping backup", src)
+        return None
+
+    backup_dir = get_backup_dir()
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    dest = backup_dir / f"data_{timestamp}.db"
+
+    try:
+        src_conn = sqlite3.connect(str(src))
+        dst_conn = sqlite3.connect(str(dest))
+        src_conn.backup(dst_conn)
+        dst_conn.close()
+        src_conn.close()
+        logger.info("Database backed up to %s", dest)
+    except Exception:
+        logger.exception("Database backup failed")
+        return None
+
+    # Prune oldest backups beyond the limit
+    if max_backups > 0:
+        backups = sorted(backup_dir.glob("data_*.db"), key=lambda f: f.stat().st_mtime)
+        while len(backups) > max_backups:
+            old = backups.pop(0)
+            old.unlink()
+            logger.info("Pruned old backup %s", old.name)
+
+    return dest
+
+
+def list_backups() -> list[dict]:
+    """List available backup files.
+
+    Returns
+    -------
+    list of dict
+        Each dict has ``filename``, ``created_at`` (ISO string), and ``size_bytes``.
+        Sorted by creation time, newest first.
+    """
+    backup_dir = get_backup_dir()
+    if not backup_dir.exists():
+        return []
+
+    backups = []
+    for f in backup_dir.glob("data_*.db"):
+        stat = f.stat()
+        backups.append({
+            "filename": f.name,
+            "created_at": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+            "size_bytes": stat.st_size,
+        })
+
+    backups.sort(key=lambda b: b["created_at"], reverse=True)
+    return backups
+
+
+def restore_backup(filename: str) -> None:
+    """Restore the database from a backup file.
+
+    Backs up the current database before restoring, then replaces
+    the active database with the selected backup. The DB engine is
+    disposed before overwriting so no stale connections interfere.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the backup file to restore (e.g. ``data_20260330_120000.db``).
+
+    Raises
+    ------
+    FileNotFoundError
+        If the backup file does not exist.
+    """
+    backup_dir = get_backup_dir()
+    backup_path = backup_dir / filename
+
+    if not backup_path.exists():
+        raise FileNotFoundError(f"Backup file not found: {filename}")
+
+    config = AppConfig()
+    db_path = Path(config.get_db_path())
+
+    # Safety: backup current DB before restoring (no pruning, to avoid
+    # deleting the backup we're about to restore)
+    backup_db(max_backups=0)
+
+    # Dispose the SQLAlchemy engine so no connections hold the DB file open
+    from backend.database import reset_engine
+
+    reset_engine()
+
+    # Restore: copy backup over the active database
+    src_conn = sqlite3.connect(str(backup_path))
+    dst_conn = sqlite3.connect(str(db_path))
+    src_conn.backup(dst_conn)
+    dst_conn.close()
+    src_conn.close()
+
+    logger.info("Database restored from %s", filename)

--- a/frontend/src/components/layout/SettingsPopup.tsx
+++ b/frontend/src/components/layout/SettingsPopup.tsx
@@ -1,10 +1,23 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDemoMode } from "../../context/DemoModeContext";
+import { backupApi } from "../../services/api";
 
 interface SettingsPopupProps {
   isOpen: boolean;
   onClose: () => void;
+}
+
+interface BackupEntry {
+  filename: string;
+  created_at: string;
+  size_bytes: number;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 export function SettingsPopup({
@@ -14,6 +27,9 @@ export function SettingsPopup({
   const { t, i18n } = useTranslation();
   const popupRef = useRef<HTMLDivElement>(null);
   const { isDemoMode, toggleDemoMode } = useDemoMode();
+  const [backups, setBackups] = useState<BackupEntry[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [restoringFile, setRestoringFile] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -26,10 +42,42 @@ export function SettingsPopup({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
 
+  useEffect(() => {
+    if (isOpen) {
+      backupApi.list().then((res) => setBackups(res.data));
+    }
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const changeLanguage = (lng: string) => {
     i18n.changeLanguage(lng);
+  };
+
+  const handleCreateBackup = async () => {
+    setCreating(true);
+    try {
+      await backupApi.create();
+      const res = await backupApi.list();
+      setBackups(res.data);
+    } catch {
+      alert(t("settings.backupFailed"));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleRestore = async (filename: string) => {
+    if (!confirm(t("settings.restoreConfirm"))) return;
+    setRestoringFile(filename);
+    try {
+      await backupApi.restore(filename);
+      alert(t("settings.backupRestored"));
+      window.location.reload();
+    } catch {
+      alert(t("settings.restoreFailed"));
+      setRestoringFile(null);
+    }
   };
 
   return (
@@ -41,7 +89,7 @@ export function SettingsPopup({
     >
       <div
         ref={popupRef}
-        className="w-full max-w-[calc(100vw-2rem)] sm:max-w-80 bg-[var(--surface)] border border-[var(--surface-light)] rounded-2xl shadow-2xl p-4 sm:p-6 space-y-5 animate-in zoom-in-95 duration-200"
+        className="w-full max-w-[calc(100vw-2rem)] sm:max-w-96 bg-[var(--surface)] border border-[var(--surface-light)] rounded-2xl shadow-2xl p-4 sm:p-6 space-y-5 animate-in zoom-in-95 duration-200 max-h-[90vh] overflow-y-auto"
       >
         {/* Language Toggle */}
         <div>
@@ -98,6 +146,63 @@ export function SettingsPopup({
               />
             </div>
           </div>
+        </div>
+
+        {/* Database Backup */}
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <label className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+              {t("settings.backup")}
+            </label>
+            <button
+              onClick={handleCreateBackup}
+              disabled={creating}
+              className="text-xs font-medium px-3 py-1.5 rounded-lg bg-[var(--primary)] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              {creating ? t("settings.creatingBackup") : t("settings.createBackup")}
+            </button>
+          </div>
+
+          {backups.length === 0 ? (
+            <p className="text-xs text-[var(--text-muted)] text-center py-3">
+              {t("settings.noBackups")}
+            </p>
+          ) : (
+            <div className="space-y-1.5 max-h-48 overflow-y-auto">
+              {backups.map((b) => (
+                <div
+                  key={b.filename}
+                  className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg bg-[var(--surface-light)]/50 text-xs"
+                >
+                  <div className="min-w-0">
+                    <div className="text-[var(--text)] truncate" dir="ltr">
+                      {new Date(b.created_at).toLocaleString(
+                        i18n.language === "he" ? "he-IL" : "en-US",
+                        {
+                          month: "short",
+                          day: "numeric",
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        },
+                      )}
+                    </div>
+                    <div className="text-[var(--text-muted)]" dir="ltr">
+                      {formatBytes(b.size_bytes)}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => handleRestore(b.filename)}
+                    disabled={restoringFile !== null}
+                    className="shrink-0 text-xs font-medium px-2.5 py-1 rounded-md bg-[var(--surface-light)] text-[var(--text)] hover:bg-[var(--surface-light)]/80 transition-colors disabled:opacity-50"
+                  >
+                    {restoringFile === b.filename
+                      ? t("settings.restoring")
+                      : t("settings.restoreBackup")}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -63,7 +63,18 @@
     "language": "Language",
     "english": "English",
     "hebrew": "עברית",
-    "demoMode": "Demo Mode"
+    "demoMode": "Demo Mode",
+    "backup": "Database Backup",
+    "createBackup": "Create Backup",
+    "restoreBackup": "Restore",
+    "creatingBackup": "Creating...",
+    "restoring": "Restoring...",
+    "noBackups": "No backups yet",
+    "restoreConfirm": "Restore this backup? A safety backup of the current database will be created first.",
+    "backupCreated": "Backup created successfully",
+    "backupRestored": "Backup restored successfully. Refreshing...",
+    "backupFailed": "Backup failed",
+    "restoreFailed": "Restore failed"
   },
   "globalSearch": {
     "placeholder": "Search transactions, categories, or tags...",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -63,7 +63,18 @@
     "language": "שפה",
     "english": "English",
     "hebrew": "עברית",
-    "demoMode": "מצב הדגמה"
+    "demoMode": "מצב הדגמה",
+    "backup": "גיבוי מסד נתונים",
+    "createBackup": "צור גיבוי",
+    "restoreBackup": "שחזר",
+    "creatingBackup": "יוצר...",
+    "restoring": "משחזר...",
+    "noBackups": "אין גיבויים עדיין",
+    "restoreConfirm": "לשחזר גיבוי זה? גיבוי בטיחות של מסד הנתונים הנוכחי ייווצר תחילה.",
+    "backupCreated": "גיבוי נוצר בהצלחה",
+    "backupRestored": "גיבוי שוחזר בהצלחה. מרענן...",
+    "backupFailed": "הגיבוי נכשל",
+    "restoreFailed": "השחזור נכשל"
   },
   "globalSearch": {
     "placeholder": "חיפוש תנועות, קטגוריות או תגיות...",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -523,6 +523,21 @@ export const retirementApi = {
     ),
 };
 
+export const backupApi = {
+  list: () =>
+    api.get<
+      { filename: string; created_at: string; size_bytes: number }[]
+    >("/backups/"),
+  create: () =>
+    api.post<{ filename: string; created_at: string; size_bytes: number }>(
+      "/backups/",
+    ),
+  restore: (filename: string) =>
+    api.post<{ status: string; filename: string }>("/backups/restore", {
+      filename,
+    }),
+};
+
 export const testingApi = {
   toggleDemoMode: (enabled: boolean) =>
     api.post<{ status: string; demo_mode: boolean }>(


### PR DESCRIPTION
Add a backup section to the settings popup that lets users create SQLite backups and restore from previous ones. Keeps up to 5 backups by default, deleting the oldest when the limit is exceeded. Restore disposes the DB engine first and creates a safety backup (without pruning) to prevent data loss.