### PR TITLE
refactor: remove page titles and subtitles from all pages

### DIFF
--- a/frontend/src/pages/Budget.tsx
+++ b/frontend/src/pages/Budget.tsx
@@ -11,13 +11,6 @@ export const Budget: React.FC = () => {
   return (
     <div className="container mx-auto max-w-7xl animate-in fade-in duration-500">
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">{t("budget.title")}</h1>
-          <p className="text-[var(--text-muted)] mt-1">
-            {t("budget.subtitle")}
-          </p>
-        </div>
-
         {/* Tab Switcher */}
         <div className="flex bg-[var(--surface-light)] p-1 rounded-xl">
           <button

--- a/frontend/src/pages/Categories.tsx
+++ b/frontend/src/pages/Categories.tsx
@@ -706,13 +706,7 @@ export function Categories() {
 
   return (
     <div className="space-y-4 md:space-y-8 animate-in fade-in duration-500">
-      <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-3 md:gap-0">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">{t("categories.title")}</h1>
-          <p className="text-[var(--text-muted)] mt-1">
-            {t("categories.subtitle")}
-          </p>
-        </div>
+      <div className="flex items-center justify-end gap-3">
         <button
           onClick={() => setIsAddCategoryOpen(true)}
           className="flex items-center gap-2 px-4 md:px-6 py-2.5 bg-[var(--primary)] text-white rounded-xl font-bold shadow-lg shadow-[var(--primary)]/20 hover:bg-[var(--primary-dark)] transition-all text-sm md:text-base"

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -388,11 +388,6 @@ export function Dashboard() {
 
   return (
     <div className="space-y-4 md:space-y-8 animate-in fade-in duration-500">
-      <div>
-        <h1 className="text-2xl md:text-3xl font-bold">📊 {t("dashboard.title")}</h1>
-        <p className="text-[var(--text-muted)] mt-1 text-sm md:text-base">✨ {t("dashboard.subtitle")}</p>
-      </div>
-
       {/* Section 1: Financial Health Header */}
       <FinancialHealthHeader
         netWorthData={netWorthData}

--- a/frontend/src/pages/DataSources.tsx
+++ b/frontend/src/pages/DataSources.tsx
@@ -275,14 +275,7 @@ export function DataSources() {
 
   return (
     <div className="space-y-4 md:space-y-8 animate-in fade-in duration-500">
-      <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-3 md:gap-0">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">{t("dataSources.title")}</h1>
-          <p className="text-[var(--text-muted)] mt-1">
-            {t("dataSources.subtitle")}
-          </p>
-        </div>
-        <div className="flex flex-wrap items-center gap-2 md:gap-3">
+      <div className="flex flex-wrap items-center justify-end gap-2 md:gap-3">
           <div className="relative">
             <select
               value={scrapingPeriodDays ?? "auto"}
@@ -312,7 +305,6 @@ export function DataSources() {
           >
             <Plus size={18} /> {t("dataSources.connectAccount")}
           </button>
-        </div>
       </div>
 
       <div className="grid grid-cols-1 gap-4">

--- a/frontend/src/pages/EarlyRetirement.tsx
+++ b/frontend/src/pages/EarlyRetirement.tsx
@@ -58,15 +58,6 @@ export function EarlyRetirement() {
 
   return (
     <div className="flex flex-col gap-4 md:gap-6 p-4 md:p-6">
-      <header>
-        <h1 className="text-xl md:text-2xl font-bold text-[var(--text-primary)]">
-          {t("earlyRetirement.title")}
-        </h1>
-        <p className="text-sm text-[var(--text-muted)] mt-1">
-          {t("earlyRetirement.subtitle")}
-        </p>
-      </header>
-
       {/* Section 1: Current Status */}
       <Section
         icon={<Activity size={18} className="text-emerald-400" />}

--- a/frontend/src/pages/Insurances.tsx
+++ b/frontend/src/pages/Insurances.tsx
@@ -63,18 +63,6 @@ export function Insurances() {
 
   return (
     <div className="flex flex-col gap-3 md:gap-6 p-4 md:p-6">
-      <header className="flex items-center gap-3">
-        <div className="p-2.5 rounded-xl bg-emerald-500/10 text-emerald-400">
-          <Shield size={24} />
-        </div>
-        <div>
-          <h1 className="text-2xl font-bold text-white">Insurance</h1>
-          <p className="text-sm text-[var(--text-muted)]">
-            Pension, Keren Hishtalmut & Gemel data verification
-          </p>
-        </div>
-      </header>
-
       {isLoading ? (
         <div className="space-y-4">
           <Skeleton className="h-24 w-full" />

--- a/frontend/src/pages/InsurancesPrototype.tsx
+++ b/frontend/src/pages/InsurancesPrototype.tsx
@@ -444,19 +444,6 @@ export function InsurancesPrototype() {
 
   return (
     <div className="flex flex-col gap-6 p-6">
-      {/* Header */}
-      <header className="flex items-center gap-3">
-        <div className="p-2.5 rounded-xl bg-emerald-500/10 text-emerald-400">
-          <Shield size={24} />
-        </div>
-        <div>
-          <h1 className="text-2xl font-bold text-white">{t("insurance.title")}</h1>
-          <p className="text-sm text-[var(--text-muted)]">
-            {t("insurance.subtitle")}
-          </p>
-        </div>
-      </header>
-
       {/* KPI Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
         <StatCard title={t("insurance.totalBalance")} value={fmt(totalBalance)} icon={Landmark} color="bg-blue-500/10 text-blue-400" />

--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -503,13 +503,7 @@ export function Investments() {
 
   return (
     <div className="space-y-4 md:space-y-8 animate-in fade-in duration-500 pb-20">
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-0">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">{t("investments.title")}</h1>
-          <p className="text-[var(--text-muted)] mt-1">
-            {t("investments.subtitle")}
-          </p>
-        </div>
+      <div className="flex items-center justify-end gap-3">
         <div className="flex gap-3 md:gap-4">
           <button
             onClick={() => setIsAddOpen(true)}

--- a/frontend/src/pages/Liabilities.tsx
+++ b/frontend/src/pages/Liabilities.tsx
@@ -488,13 +488,7 @@ export function Liabilities() {
   return (
     <div className="space-y-6 md:space-y-8 animate-in fade-in duration-500 pb-20">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">{t("liabilities.title")}</h1>
-          <p className="text-[var(--text-muted)] mt-1">
-            {t("liabilities.subtitle")}
-          </p>
-        </div>
+      <div className="flex items-center justify-end gap-3">
         <button
           onClick={() => setIsAddOpen(true)}
           disabled={!canAdd}

--- a/frontend/src/pages/Transactions.tsx
+++ b/frontend/src/pages/Transactions.tsx
@@ -311,13 +311,6 @@ export function Transactions() {
     <div className="flex relative">
       <div className="space-y-4 md:space-y-6 min-w-0 flex-1 transition-all duration-300">
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-3">
-          <div>
-            <h1 className="text-2xl md:text-3xl font-bold">{t("transactions.title")}</h1>
-            <p className="text-[var(--text-muted)] text-sm md:text-base">
-              {t("transactions.subtitle")}
-            </p>
-          </div>
-
           <div className="flex items-center gap-2 md:gap-4 overflow-x-auto scrollbar-auto-hide pb-1">
             <div className="flex gap-1.5 md:gap-2 items-center">
               {services.map(({ value, label }) => (


### PR DESCRIPTION
The top navigation bar already shows the page name, making the h1 titles redundant. Subtitles were generic filler text that didn't add value. This reclaims vertical space and gives a cleaner, more app-like feel.