### PR TITLE
style: fix all existing lint issues across frontend and backend

### DIFF
--- a/backend/services/cash_balance_service.py
+++ b/backend/services/cash_balance_service.py
@@ -6,7 +6,6 @@ prior wealth calculations, and balance recalculation based on transactions.
 
 from typing import Optional
 import pandas as pd
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from backend.repositories.cash_balance_repository import CashBalanceRepository
@@ -210,9 +209,6 @@ class CashBalanceService:
             Sum of all cash transaction amounts for the account.
         """
         # Get cash transactions for this account
-        stmt = select(CashTransaction).where(
-            CashTransaction.account_name == account_name
-        )
         transactions_df = self.cash_repo.get_table()
 
         if transactions_df.empty:

--- a/backend/services/credentials_service.py
+++ b/backend/services/credentials_service.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
-from backend.config import AppConfig
 from backend.constants.providers import Fields, Services, bank_providers, cc_providers, insurance_providers
 from backend.repositories.credentials_repository import CredentialsRepository
 

--- a/backend/services/insurance_account_service.py
+++ b/backend/services/insurance_account_service.py
@@ -7,7 +7,7 @@ and derived calculations like total balances.
 
 from datetime import date, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from backend.models.insurance_account import InsuranceAccount

--- a/backend/services/retirement_service.py
+++ b/backend/services/retirement_service.py
@@ -66,7 +66,7 @@ class RetirementService:
 
     def upsert_goal(self, **fields) -> dict:
         """Create or update the retirement goal and return it as dict."""
-        goal = self.repo.upsert(**fields)
+        self.repo.upsert(**fields)
         return self.get_goal()
 
     def get_keren_hishtalmut_scraped_balance(self) -> float | None:

--- a/backend/services/scraping_service.py
+++ b/backend/services/scraping_service.py
@@ -250,7 +250,7 @@ class ScrapingService:
                 start_date = datetime.fromisoformat(last_scrape).date() - timedelta(
                     days=7
                 )
-            except:
+            except (ValueError, TypeError):
                 start_date = date.today() - timedelta(days=365)
         else:
             start_date = date.today() - timedelta(days=365)

--- a/backend/services/tagging_rules_service.py
+++ b/backend/services/tagging_rules_service.py
@@ -126,7 +126,7 @@ class TaggingRulesService:
         if isinstance(conditions, str):
             try:
                 conditions = json.loads(conditions)
-            except:
+            except (ValueError, TypeError):
                 # Fallback if invalid JSON string (shouldn't happen with JSON column)
                 return {
                     "type": "CONDITION",

--- a/frontend/src/components/common/MultiSelect.tsx
+++ b/frontend/src/components/common/MultiSelect.tsx
@@ -24,6 +24,11 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   const searchRef = useRef<HTMLInputElement>(null);
   const [pos, setPos] = useState({ top: 0, left: 0, width: 0 });
 
+  const closeDropdown = useCallback(() => {
+    setIsOpen(false);
+    setSearch("");
+  }, []);
+
   const updatePosition = useCallback(() => {
     if (!buttonRef.current) return;
     const rect = buttonRef.current.getBoundingClientRect();
@@ -37,10 +42,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   }, []);
 
   useEffect(() => {
-    if (!isOpen) {
-      setSearch("");
-      return;
-    }
+    if (!isOpen) return;
     updatePosition();
     requestAnimationFrame(() => searchRef.current?.focus());
     const onScroll = () => updatePosition();
@@ -61,11 +63,11 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
         dropdownRef.current?.contains(target)
       )
         return;
-      setIsOpen(false);
+      closeDropdown();
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
-  }, [isOpen]);
+  }, [isOpen, closeDropdown]);
 
   const filteredOptions = options.filter((opt) =>
     opt.toLowerCase().includes(search.toLowerCase()),
@@ -88,7 +90,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
     <div className="relative">
       <button
         ref={buttonRef}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => (isOpen ? closeDropdown() : setIsOpen(true))}
         type="button"
         className="w-full flex items-center justify-between px-2.5 py-1.5 text-xs bg-[var(--surface)] border border-[var(--surface-light)] rounded-lg hover:border-[var(--primary)]/50 transition-colors text-start"
       >

--- a/frontend/src/components/dataflow/DataFlowDiagram.tsx
+++ b/frontend/src/components/dataflow/DataFlowDiagram.tsx
@@ -9,6 +9,8 @@ interface Connection {
   to: string;
   color: string;
   path: string;
+  animDur: number;
+  animBegin: number;
 }
 
 export function DataFlowDiagram() {
@@ -67,10 +69,12 @@ export function DataFlowDiagram() {
         to: conn.to,
         color: conn.color,
         path: `M ${startX} ${startY} C ${cp1x} ${startY}, ${cp2x} ${endY}, ${endX} ${endY}`,
+        animDur: 2 + Math.random() * 2,
+        animBegin: Math.random() * 3,
       });
     }
     setConnections(newConnections);
-  }, []);
+  }, [connectionDefs]);
 
   useEffect(() => {
     // Draw after initial render
@@ -162,9 +166,9 @@ export function DataFlowDiagram() {
               {(conn.from === highlightedId || conn.to === highlightedId) && (
                 <circle r={2.5} fill={conn.color} opacity={0.9}>
                   <animateMotion
-                    dur={`${2 + Math.random() * 2}s`}
+                    dur={`${conn.animDur}s`}
                     repeatCount="indefinite"
-                    begin={`${Math.random() * 3}s`}
+                    begin={`${conn.animBegin}s`}
                     path={conn.path}
                   />
                 </circle>

--- a/index.py
+++ b/index.py
@@ -35,4 +35,6 @@ Base.metadata.create_all(bind=get_engine())
 
 # Vercel auto-detects this `app` variable as the FastAPI application.
 # lifespan is skipped (VERCEL env var guard) because it imports keyring.
-from backend.main import app  # noqa: E402, F401
+from backend.main import app  # noqa: E402
+
+__all__ = ["app"]

--- a/index.py
+++ b/index.py
@@ -35,3 +35,4 @@ Base.metadata.create_all(bind=get_engine())
 
 # Vercel auto-detects this `app` variable as the FastAPI application.
 # lifespan is skipped (VERCEL env var guard) because it imports keyring.
+from backend.main import app  # noqa: E402, F401

--- a/index.py
+++ b/index.py
@@ -23,7 +23,6 @@ if not os.path.exists(_demo_dst):
     shutil.copy2(_demo_src, _demo_dst)
 
 from backend.config import AppConfig  # noqa: E402
-from backend.main import app  # noqa: E402
 
 config = AppConfig()
 config.set_demo_mode(True)

--- a/scraper/__init__.py
+++ b/scraper/__init__.py
@@ -2,6 +2,16 @@ from scraper.base.base_scraper import BaseScraper, ScraperOptions
 from scraper.models.credentials import PROVIDER_CONFIGS, ProviderConfig
 from scraper.models.result import ScrapingResult
 
+__all__ = [
+    "BaseScraper",
+    "ScraperOptions",
+    "PROVIDER_CONFIGS",
+    "ProviderConfig",
+    "ScrapingResult",
+    "create_scraper",
+    "is_2fa_required",
+]
+
 
 def create_scraper(
     provider: str, credentials: dict, options: ScraperOptions | None = None

--- a/scraper/__main__.py
+++ b/scraper/__main__.py
@@ -16,8 +16,12 @@ import json
 import os
 import sys
 from datetime import date, timedelta
+from typing import TYPE_CHECKING
 
 from scraper.models.credentials import PROVIDER_CONFIGS
+
+if TYPE_CHECKING:
+    from scraper.models.result import ScrapingResult
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scraper/providers/credit_cards/isracard_amex_base.py
+++ b/scraper/providers/credit_cards/isracard_amex_base.py
@@ -16,7 +16,6 @@ from scraper.models.transaction import (
 )
 from scraper.utils import (
     fetch_get_within_page,
-    fetch_post_within_page,
     filter_old_transactions,
     fix_installments,
     get_all_months,

--- a/scraper/utils/__init__.py
+++ b/scraper/utils/__init__.py
@@ -32,3 +32,33 @@ from scraper.utils.transactions import (
     sort_transactions_by_date,
 )
 from scraper.utils.waiting import sleep, wait_until
+
+__all__ = [
+    "click_button",
+    "click_link",
+    "dropdown_elements",
+    "dropdown_select",
+    "element_present_on_page",
+    "fill_input",
+    "page_eval",
+    "page_eval_all",
+    "set_value",
+    "wait_until_element_disappear",
+    "wait_until_element_found",
+    "wait_until_iframe_found",
+    "get_all_months",
+    "fetch_get",
+    "fetch_get_within_page",
+    "fetch_graphql",
+    "fetch_post",
+    "fetch_post_within_page",
+    "get_current_url",
+    "wait_for_navigation",
+    "wait_for_redirect",
+    "wait_for_url",
+    "filter_old_transactions",
+    "fix_installments",
+    "sort_transactions_by_date",
+    "sleep",
+    "wait_until",
+]

--- a/scripts/fix_scraper_dates.py
+++ b/scripts/fix_scraper_dates.py
@@ -140,7 +140,7 @@ def print_summary(
     print(f"  Split txns to re-link:            {len(splits_to_relink)}")
 
     if duplicates:
-        print(f"\n  Sample duplicates (up to 5):")
+        print("\n  Sample duplicates (up to 5):")
         for old_txn, new_txn in duplicates[:5]:
             corrected = shift_date_forward(old_txn["date"])
             print(f"    OLD uid={old_txn['unique_id']} date={old_txn['date']}->{corrected} "

--- a/scripts/generate_demo_data.py
+++ b/scripts/generate_demo_data.py
@@ -10,7 +10,6 @@ Usage
 """
 
 import json
-import os
 import random
 import sys
 from datetime import date, datetime, timedelta
@@ -22,12 +21,12 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import NullPool  # noqa: E402
 
-from backend.models.base import Base
-from backend.models import (
+from backend.models.base import Base  # noqa: E402
+from backend.models import (  # noqa: E402
     BankBalance,
     BankTransaction,
     BudgetRule,
@@ -1331,11 +1330,6 @@ def create_investment_snapshots(session, stock_fund, savings_plan, bond):
         cumulative_deposits += 2000.0
         # Base growth: 8% annual, compounded monthly
         months_elapsed = i + 1
-        base_growth = cumulative_deposits * (1 + 0.085 / 12) ** months_elapsed / (
-            (1 + 0.085 / 12) ** months_elapsed
-            if months_elapsed > 0
-            else 1
-        )
         # Simpler: cumulative deposits + growth with monthly variance
         growth_factor = 1 + (0.085 * months_elapsed / 12) + random.uniform(-0.03, 0.05) * (months_elapsed / len(months))
         balance = round(cumulative_deposits * growth_factor, 2)
@@ -1387,7 +1381,6 @@ def create_investment_snapshots(session, stock_fund, savings_plan, bond):
         ))
 
     # --- Corporate Bond: 6 monthly snapshots before closure, then 0 ---
-    bond_created = START_DATE + timedelta(days=30)
     bond_deposit_date = REFERENCE_DATE - timedelta(days=365)
     bond_closed_date = REFERENCE_DATE - timedelta(days=180)
 
@@ -1887,7 +1880,6 @@ def create_pending_refunds(session, cc_txns, bank_txns):
 
 def create_scraping_history(session):
     """Create 5 scraping history records."""
-    now = datetime.now()
     recent = REFERENCE_DATE - timedelta(days=1)
     older = REFERENCE_DATE - timedelta(days=21)
 
@@ -2163,7 +2155,7 @@ def main():
 
         # 4. Untagged transactions (updates monthly_cc_totals for bill consistency)
         print("  Generating untagged transactions...")
-        untagged_txns = generate_untagged_transactions(session, monthly_cc_totals)
+        generate_untagged_transactions(session, monthly_cc_totals)
 
         # 5. Bank transactions (uses CC totals for bill amounts)
         print("  Generating bank transactions...")

--- a/tests/backend/integration/test_budget_pipeline.py
+++ b/tests/backend/integration/test_budget_pipeline.py
@@ -12,7 +12,6 @@ import pytest
 from sqlalchemy.orm import Session
 
 from backend.constants.budget import ALL_TAGS, TOTAL_BUDGET
-from backend.models.budget import BudgetRule
 from backend.models.transaction import CreditCardTransaction
 from backend.services.budget_service import (
     MonthlyBudgetService,

--- a/tests/backend/integration/test_cash_balance_integration.py
+++ b/tests/backend/integration/test_cash_balance_integration.py
@@ -5,7 +5,6 @@ Integration tests for cash balance with transaction lifecycle.
 from datetime import datetime
 
 import pytest
-from sqlalchemy.orm import Session
 
 from backend.services.cash_balance_service import CashBalanceService
 from backend.services.transactions_service import TransactionsService

--- a/tests/backend/routes/test_bank_balance_routes.py
+++ b/tests/backend/routes/test_bank_balance_routes.py
@@ -1,6 +1,5 @@
 """Tests for the /api/bank-balances API endpoints."""
 
-import pytest
 
 
 class TestBankBalanceRoutes:

--- a/tests/backend/routes/test_budget_routes_errors.py
+++ b/tests/backend/routes/test_budget_routes_errors.py
@@ -4,7 +4,6 @@ Covers validation errors, not-found scenarios, and duplicate detection
 for budget rules and project budget endpoints.
 """
 
-from unittest.mock import patch, MagicMock
 
 import pytest
 

--- a/tests/backend/routes/test_investments_routes.py
+++ b/tests/backend/routes/test_investments_routes.py
@@ -1,6 +1,5 @@
 """Tests for the /api/investments API endpoints."""
 
-import pytest
 
 
 class TestInvestmentsRoutes:

--- a/tests/backend/routes/test_investments_routes_errors.py
+++ b/tests/backend/routes/test_investments_routes_errors.py
@@ -4,7 +4,6 @@ Covers 404 responses for non-existent investments, Pydantic validation
 errors, and exception propagation from the service layer.
 """
 
-import pytest
 
 
 class TestInvestmentNotFoundErrors:

--- a/tests/backend/routes/test_pending_refunds_routes.py
+++ b/tests/backend/routes/test_pending_refunds_routes.py
@@ -1,6 +1,5 @@
 """Tests for the /api/pending-refunds API endpoints."""
 
-import pytest
 
 
 class TestPendingRefundsRoutes:

--- a/tests/backend/test_vercel_entry.py
+++ b/tests/backend/test_vercel_entry.py
@@ -1,0 +1,38 @@
+"""Tests for the Vercel serverless entry point (index.py).
+
+Vercel's FastAPI runtime auto-detects a module-level ``app`` binding as the
+ASGI application. If that binding is accidentally removed (e.g. a lint
+cleanup flags the import as unused), preview and production deployments
+fail. This test enforces the contract.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+class TestVercelEntry:
+    """Tests protecting the ``index.app`` contract relied on by Vercel."""
+
+    def test_index_exposes_app_as_fastapi_instance(self):
+        """Verify ``import index`` produces a FastAPI ``app`` attribute.
+
+        Runs in a subprocess so the env vars and demo-mode side effects in
+        ``index.py`` do not leak into the current pytest session.
+        """
+        project_root = Path(__file__).resolve().parents[2]
+        script = (
+            "import index; "
+            "from fastapi import FastAPI; "
+            "assert isinstance(index.app, FastAPI), type(index.app)"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"index.py no longer exposes a FastAPI `app` binding — Vercel "
+            f"will fail to deploy.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )

--- a/tests/backend/unit/repositories/test_cash_balance_repository.py
+++ b/tests/backend/unit/repositories/test_cash_balance_repository.py
@@ -4,7 +4,6 @@ Unit tests for CashBalanceRepository operations.
 
 from sqlalchemy.orm import Session
 
-from backend.models.cash_balance import CashBalance
 from backend.repositories.cash_balance_repository import CashBalanceRepository
 
 

--- a/tests/backend/unit/repositories/test_investment_snapshots_repository.py
+++ b/tests/backend/unit/repositories/test_investment_snapshots_repository.py
@@ -7,7 +7,6 @@ from sqlalchemy.orm import Session
 
 from backend.errors import EntityNotFoundException
 from backend.models.investment import Investment
-from backend.models.investment_balance_snapshot import InvestmentBalanceSnapshot
 from backend.repositories.investment_snapshots_repository import (
     InvestmentSnapshotsRepository,
 )

--- a/tests/backend/unit/repositories/test_transactions_repository.py
+++ b/tests/backend/unit/repositories/test_transactions_repository.py
@@ -7,9 +7,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from backend.models.transaction import (
-    BankTransaction,
     CashTransaction,
-    CreditCardTransaction,
 )
 from backend.repositories.transactions_repository import (
     TransactionsRepository,

--- a/tests/backend/unit/services/test_budget_service.py
+++ b/tests/backend/unit/services/test_budget_service.py
@@ -13,7 +13,6 @@ from backend.constants.budget import (
     YEAR,
 )
 from backend.constants.tables import TransactionsTableFields
-from backend.models.budget import BudgetRule
 from backend.services.budget_service import (
     BudgetService,
     MonthlyBudgetService,

--- a/tests/backend/unit/services/test_cash_balance_service.py
+++ b/tests/backend/unit/services/test_cash_balance_service.py
@@ -1,7 +1,6 @@
 """Unit tests for CashBalanceService functionality."""
 
 import pytest
-from unittest.mock import MagicMock
 from sqlalchemy.orm import Session
 
 from backend.services.cash_balance_service import CashBalanceService

--- a/tests/backend/unit/services/test_credentials_service.py
+++ b/tests/backend/unit/services/test_credentials_service.py
@@ -323,7 +323,7 @@ class TestClearCache:
 
     def test_clear_cache_sets_none(self, mock_repo, monkeypatch):
         """Verify clear_cache sets module-level cache to None."""
-        service = CredentialsService(MagicMock())
+        CredentialsService(MagicMock())
         assert cs._credentials_cache is not None
 
         CredentialsService.clear_cache()

--- a/tests/backend/unit/services/test_investments_service.py
+++ b/tests/backend/unit/services/test_investments_service.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 
 from backend.models.investment import Investment as InvestmentModel
-from backend.models.investment_balance_snapshot import InvestmentBalanceSnapshot
 from backend.models.transaction import ManualInvestmentTransaction
 from backend.services.investments_service import InvestmentsService
 

--- a/tests/backend/unit/services/test_investments_snapshot_service.py
+++ b/tests/backend/unit/services/test_investments_snapshot_service.py
@@ -5,7 +5,6 @@ Unit tests for InvestmentsService snapshot-related methods.
 from unittest.mock import MagicMock
 
 import pandas as pd
-import pytest
 from sqlalchemy.orm import Session
 
 from backend.models.investment import Investment

--- a/tests/backend/unit/services/test_liabilities_service.py
+++ b/tests/backend/unit/services/test_liabilities_service.py
@@ -1,6 +1,5 @@
 """Tests for LiabilitiesService using real in-memory SQLite database."""
 
-import pytest
 from datetime import date
 from unittest.mock import patch
 

--- a/tests/backend/unit/services/test_pending_refunds_service.py
+++ b/tests/backend/unit/services/test_pending_refunds_service.py
@@ -320,7 +320,7 @@ class TestGetAllPendingEnrichment:
     def test_graceful_on_missing_source_transaction(self, db_session):
         """Verify enrichment gracefully handles nonexistent source transaction IDs."""
         service = PendingRefundsService(db_session)
-        pending = service.mark_as_pending_refund(
+        service.mark_as_pending_refund(
             "transaction", 99999, "banks", 100.0,
         )
 

--- a/tests/backend/unit/services/test_tagging_rules_service.py
+++ b/tests/backend/unit/services/test_tagging_rules_service.py
@@ -85,12 +85,6 @@ class TestTaggingRulesService:
 
     def test_check_conflicts_no_conflict(self, service, setup_transactions):
         """Test adding a non-conflicting rule."""
-        conditions = {
-            "type": "CONDITION",
-            "field": "description",
-            "operator": "contains",
-            "value": "Azure",
-        }
         # Transaction is AWS, so Azure should not match, so no conflict check needed really
         # But let's add a rule that MATCHES AWS first
 

--- a/tests/backend/unit/services/test_transactions_service.py
+++ b/tests/backend/unit/services/test_transactions_service.py
@@ -65,7 +65,6 @@ class TestTransactionsServiceDataRetrieval:
         # The split transactions fixture has 5 children total (3 CC + 2 bank).
         # Verify specific split amounts are present to confirm children are included.
         amount_col = TransactionsTableFields.AMOUNT.value
-        category_col = TransactionsTableFields.CATEGORY.value
 
         # CC splits: -150 (Food/Groceries), -100 (Home/Cleaning), -50 (Other)
         cc_split_amounts = {-150.0, -100.0, -50.0}
@@ -750,7 +749,6 @@ class TestTransactionsServicePriorWealth:
 
     def test_sync_prior_wealth_skips_manual_investments(self, db_session):
         """Verify sync_prior_wealth_offset does not create offset for manual_investments."""
-        from backend.models.transaction import ManualInvestmentTransaction
         from backend.constants.categories import PRIOR_WEALTH_TAG
         inv_tx = ManualInvestmentTransaction(
             id="test_inv_1",

--- a/tests/backend/unit/test_rename_category_tag.py
+++ b/tests/backend/unit/test_rename_category_tag.py
@@ -5,7 +5,6 @@ including protection checks, collision detection, title-casing, and cascade
 to all dependent repositories.
 """
 
-import pytest
 from unittest.mock import MagicMock, patch
 
 from backend.services.tagging_service import CategoriesTagsService

--- a/tests/backend/unit/test_scraper/test_scraper_base.py
+++ b/tests/backend/unit/test_scraper/test_scraper_base.py
@@ -1,8 +1,6 @@
 """Tests for scraper adapter, factory function, and 2FA requirement checks."""
 
-import asyncio
 
-import pytest
 
 from scraper.models.result import ScrapingResult
 from scraper.models.account import AccountResult

--- a/tests/backend/unit/utils/test_text_utils.py
+++ b/tests/backend/unit/utils/test_text_utils.py
@@ -2,7 +2,6 @@
 Unit tests for text_utils module.
 """
 
-import pytest
 
 from backend.utils.text_utils import INITIALISMS, to_title_case
 


### PR DESCRIPTION
Frontend (ESLint):
- MultiSelect: clear search via close handler instead of setState in effect
- DataFlowDiagram: precompute random animation values at connection build time
  instead of calling Math.random during render

Backend (Ruff):
- Remove 29 unused imports across tests, services, and scripts
- Remove 10 unused variable assignments
- Replace bare except with explicit (ValueError, TypeError) in scraping_service
  and tagging_rules_service
- Add __all__ exports for scraper and scraper.utils packages to declare their
  public API
- Fix undefined ScrapingResult in scraper/__main__.py via TYPE_CHECKING import
- Mark intentional post-sys.path imports in scripts/generate_demo_data.py with
  noqa: E402