### PR TITLE
fix(security): harden path handling, CORS, headers, and backup restore

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -54,12 +54,23 @@ def create_db_engine(db_path: str = None, echo: bool = False):
     if db_path is None:
         db_path = AppConfig().get_db_path()
 
-    # Ensure the directory exists
-    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    # Ensure the directory exists with owner-only permissions. The DB
+    # holds financial data; other users on a shared host should not be
+    # able to list backups or read the DB file.
+    db_dir = os.path.dirname(db_path)
+    os.makedirs(db_dir, exist_ok=True)
+    try:
+        os.chmod(db_dir, 0o700)
+    except OSError:
+        pass
 
     # Create the database file if it doesn't exist
     if not os.path.exists(db_path):
         with open(db_path, "w"):
+            pass
+        try:
+            os.chmod(db_path, 0o600)
+        except OSError:
             pass
 
     return create_engine(

--- a/backend/main.py
+++ b/backend/main.py
@@ -148,24 +148,85 @@ async def lifespan(app: FastAPI):
     print("Shutting down Finance Analysis API...")
 
 
+# Only expose OpenAPI/Swagger docs outside of production. ``ENVIRONMENT=production``
+# (or ``DISABLE_DOCS=1``) disables ``/docs``, ``/redoc`` and ``/openapi.json``
+# so attackers cannot enumerate the API surface from a public deployment.
+_environment = os.getenv("ENVIRONMENT", "development").lower()
+_docs_disabled = _environment == "production" or os.getenv("DISABLE_DOCS") == "1"
+
 app = FastAPI(
     title="Finance Analysis API",
     description="API for personal finance tracking and analysis",
     version="1.0.0",
     lifespan=lifespan,
+    docs_url=None if _docs_disabled else "/docs",
+    redoc_url=None if _docs_disabled else "/redoc",
+    openapi_url=None if _docs_disabled else "/openapi.json",
 )
 
-# Configure CORS
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=os.getenv(
+# Configure CORS. A wildcard origin (``*``) may never be combined with
+# ``allow_credentials=True`` — browsers reject such responses, and the
+# combination would also permit any site to read authenticated responses.
+_cors_origins = [
+    origin.strip()
+    for origin in os.getenv(
         "CORS_ORIGINS",
         "http://localhost:5173,http://127.0.0.1:5173",
-    ).split(","),
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    ).split(",")
+    if origin.strip()
+]
+_cors_allow_credentials = "*" not in _cors_origins
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_cors_origins,
+    allow_credentials=_cors_allow_credentials,
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization", "X-Requested-With"],
 )
+
+
+# Cap request body size to mitigate memory-exhaustion DoS. 10 MB comfortably
+# covers any JSON payload this app exchanges while blocking multi-GB bodies.
+_MAX_REQUEST_BYTES = int(os.getenv("MAX_REQUEST_BYTES", str(10 * 1024 * 1024)))
+
+
+@app.middleware("http")
+async def limit_request_size(request: Request, call_next):
+    """Reject requests whose declared body exceeds ``MAX_REQUEST_BYTES``."""
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            if int(content_length) > _MAX_REQUEST_BYTES:
+                return JSONResponse(
+                    status_code=413,
+                    content={"detail": "Request body too large"},
+                )
+        except ValueError:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "Invalid Content-Length header"},
+            )
+    return await call_next(request)
+
+
+@app.middleware("http")
+async def add_security_headers(request: Request, call_next):
+    """Apply conservative security headers to every response."""
+    response = await call_next(request)
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("Referrer-Policy", "no-referrer")
+    response.headers.setdefault(
+        "Permissions-Policy",
+        "geolocation=(), microphone=(), camera=(), payment=()",
+    )
+    # HSTS is only meaningful over HTTPS; emit it when the request was TLS.
+    if request.url.scheme == "https":
+        response.headers.setdefault(
+            "Strict-Transport-Security",
+            "max-age=31536000; includeSubDomains",
+        )
+    return response
 
 
 # Include routers
@@ -214,11 +275,18 @@ try:
 except ImportError:
     pass
 
-try:
-    from backend.routes import testing
-    app.include_router(testing.router, prefix="/api/testing", tags=["Testing"])
-except ImportError:
-    pass
+# Testing routes expose demo-mode toggling and DB reset helpers. They must
+# never be reachable in production: ``ENABLE_TESTING_ROUTES=1`` or a non-
+# production ``ENVIRONMENT`` is required to mount them.
+_enable_testing_routes = (
+    os.getenv("ENABLE_TESTING_ROUTES") == "1" or _environment != "production"
+)
+if _enable_testing_routes:
+    try:
+        from backend.routes import testing
+        app.include_router(testing.router, prefix="/api/testing", tags=["Testing"])
+    except ImportError:
+        pass
 
 
 @app.exception_handler(EntityNotFoundException)
@@ -263,13 +331,31 @@ _frontend_dist = Path(__file__).parent.parent / "frontend" / "dist"
 if _frontend_dist.is_dir():
     app.mount("/assets", StaticFiles(directory=_frontend_dist / "assets"), name="static-assets")
 
+    _frontend_dist_resolved = _frontend_dist.resolve()
+
     @app.exception_handler(404)
     async def spa_fallback(request: Request, exc):
-        """Serve the React SPA for non-API 404s (client-side routing)."""
+        """Serve the React SPA for non-API 404s (client-side routing).
+
+        Resolves the requested path and verifies it lives inside the frontend
+        dist directory before serving to prevent path traversal (e.g.
+        ``GET /../../etc/passwd``).
+        """
         if request.url.path.startswith("/api/"):
             detail = getattr(exc, "detail", "Not found")
             return JSONResponse(status_code=404, content={"detail": detail})
-        file_path = _frontend_dist / request.url.path.lstrip("/")
-        if file_path.is_file():
-            return FileResponse(file_path)
-        return FileResponse(_frontend_dist / "index.html")
+
+        index_html = _frontend_dist_resolved / "index.html"
+        requested = request.url.path.lstrip("/")
+        if not requested:
+            return FileResponse(index_html)
+
+        candidate = (_frontend_dist_resolved / requested).resolve()
+        try:
+            candidate.relative_to(_frontend_dist_resolved)
+        except ValueError:
+            return FileResponse(index_html)
+
+        if candidate.is_file():
+            return FileResponse(candidate)
+        return FileResponse(index_html)

--- a/backend/utils/backup.py
+++ b/backend/utils/backup.py
@@ -6,6 +6,8 @@ API, which is safe to run while the database is in use.
 """
 
 import logging
+import os
+import re
 import sqlite3
 from datetime import datetime
 from pathlib import Path
@@ -15,6 +17,11 @@ from backend.config import AppConfig
 logger = logging.getLogger(__name__)
 
 MAX_BACKUPS = 5
+
+# Backup filenames always follow ``data_YYYYMMDD_HHMMSS.db``. Restrict restore
+# input to this shape so a malicious filename cannot traverse out of the
+# backup directory (e.g. ``../../etc/passwd``) or point at arbitrary files.
+_BACKUP_FILENAME_RE = re.compile(r"^data_\d{8}_\d{6}\.db$")
 
 
 def get_backup_dir() -> Path:
@@ -56,6 +63,10 @@ def backup_db(max_backups: int = MAX_BACKUPS) -> Path | None:
         src_conn.backup(dst_conn)
         dst_conn.close()
         src_conn.close()
+        try:
+            os.chmod(dest, 0o600)
+        except OSError:
+            logger.debug("Unable to chmod backup %s", dest)
         logger.info("Database backed up to %s", dest)
     except Exception:
         logger.exception("Database backup failed")
@@ -114,12 +125,35 @@ def restore_backup(filename: str) -> None:
     ------
     FileNotFoundError
         If the backup file does not exist.
+    ValueError
+        If the filename is not a valid backup name, escapes the backup
+        directory, or the file is not a readable SQLite database.
     """
-    backup_dir = get_backup_dir()
-    backup_path = backup_dir / filename
+    # Reject anything that isn't a plain backup filename — no slashes, no
+    # traversal, no symlinks pointing elsewhere.
+    if not _BACKUP_FILENAME_RE.match(filename):
+        raise ValueError(f"Invalid backup filename: {filename}")
 
-    if not backup_path.exists():
+    backup_dir = get_backup_dir().resolve()
+    backup_path = (backup_dir / filename).resolve()
+    try:
+        backup_path.relative_to(backup_dir)
+    except ValueError as exc:
+        raise ValueError(f"Backup path escapes backup directory: {filename}") from exc
+
+    if not backup_path.is_file():
         raise FileNotFoundError(f"Backup file not found: {filename}")
+
+    # Validate the file is actually a readable SQLite database before we
+    # overwrite the live DB — prevents restoring a corrupt or hostile file.
+    try:
+        test_conn = sqlite3.connect(f"file:{backup_path}?mode=ro", uri=True)
+        try:
+            test_conn.execute("PRAGMA schema_version").fetchone()
+        finally:
+            test_conn.close()
+    except sqlite3.DatabaseError as exc:
+        raise ValueError(f"Backup file is not a valid SQLite database: {filename}") from exc
 
     config = AppConfig()
     db_path = Path(config.get_db_path())
@@ -139,5 +173,10 @@ def restore_backup(filename: str) -> None:
     src_conn.backup(dst_conn)
     dst_conn.close()
     src_conn.close()
+
+    try:
+        os.chmod(db_path, 0o600)
+    except OSError:
+        logger.debug("Unable to chmod restored DB %s", db_path)
 
     logger.info("Database restored from %s", filename)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,15 +4,19 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), "");
+  // Restrict loadEnv to VITE_-prefixed variables so a stray secret in `.env`
+  // (DB_PASSWORD, API_KEY, etc.) cannot accidentally be pulled into the
+  // client bundle or logged via this config.
+  const viteEnv = loadEnv(mode, process.cwd(), "VITE_");
+  const port = parseInt(process.env.PORT || "", 10) || 5173;
 
   return {
     plugins: [react(), tailwindcss()],
     server: {
-      port: parseInt(env.PORT) || 5173,
+      port,
       proxy: {
         "/api": {
-          target: env.VITE_BACKEND_URL || "http://127.0.0.1:8000",
+          target: viteEnv.VITE_BACKEND_URL || "http://127.0.0.1:8000",
           changeOrigin: true,
         },
       },

--- a/index.py
+++ b/index.py
@@ -12,7 +12,15 @@ import shutil
 # AppConfig._base_user_dir is evaluated at class-definition time from FAD_USER_DIR.
 # CORS_ORIGINS is read at middleware init time during `from backend.main import app`.
 os.environ["FAD_USER_DIR"] = "/tmp/finance-analysis"
-os.environ["CORS_ORIGINS"] = "*"
+# Default to the deployed Vercel URL when available; only fall back to the
+# wildcard (no credentials) so browsers cannot read authenticated responses
+# from arbitrary origins. Override via the ``CORS_ORIGINS`` env var in Vercel
+# project settings to pin a specific domain.
+_vercel_url = os.environ.get("VERCEL_URL")
+if _vercel_url and "CORS_ORIGINS" not in os.environ:
+    os.environ["CORS_ORIGINS"] = f"https://{_vercel_url}"
+else:
+    os.environ.setdefault("CORS_ORIGINS", "*")
 os.environ.setdefault("VERCEL", "1")
 
 # Seed demo DB into /tmp before app startup


### PR DESCRIPTION
- Prevent path traversal in SPA 404 fallback: resolve requested paths
  and verify they stay inside the frontend dist directory before serving
- Prevent path traversal + arbitrary-file restore in backup API: restrict
  filenames to the ``data_YYYYMMDD_HHMMSS.db`` pattern, resolve against
  the backup dir, and validate the file is a readable SQLite database
  before overwriting the live DB
- Tighten CORS: drop ``allow_credentials`` when origins contain ``*``,
  narrow methods/headers to what the app actually uses, and pin the
  Vercel CORS origin to ``VERCEL_URL`` when available
- Gate Swagger/ReDoc/OpenAPI and testing routes behind
  ``ENVIRONMENT``/``ENABLE_TESTING_ROUTES`` so production deployments
  do not leak API schema or expose demo-mode toggling
- Add request-size cap (``MAX_REQUEST_BYTES``, default 10 MB) and
  default security headers (X-Content-Type-Options, X-Frame-Options,
  Referrer-Policy, Permissions-Policy, HSTS on HTTPS)
- Chmod the SQLite DB and backup files to 0600 (and user dir to 0700)
  so other users on a shared host cannot read financial data
- Restrict Vite ``loadEnv`` to the ``VITE_`` prefix to avoid pulling
  stray secrets from ``.env`` into the dev-server config

https://claude.ai/code/session_01E1evDYAY4wPjTTZD26hDun