### PR TITLE
test: align fixtures with current source behavior

### DIFF
--- a/tests/backend/routes/test_cash_balances_routes.py
+++ b/tests/backend/routes/test_cash_balances_routes.py
@@ -1,7 +1,5 @@
 """Tests for the /api/cash-balances API endpoints."""
 
-import pytest
-
 
 class TestCashBalancesRoutes:
     """Tests for cash balance API endpoints."""
@@ -28,17 +26,18 @@ class TestCashBalancesRoutes:
         assert "last_manual_update" in data
 
     def test_post_cash_balance_negative_rejected(self, test_client):
-        """POST /api/cash-balances/ rejects negative balance with ValueError.
+        """POST /api/cash-balances/ rejects negative balance with 400.
 
-        The service raises ValueError for negative balance. TestClient re-raises
-        this exception in tests, so we catch it with pytest.raises.
+        The service raises ValueError for negative balance; the route translates
+        that into an HTTP 400 with the error message in ``detail``.
         """
         payload = {
             "account_name": "Wallet",
             "balance": -100.0,
         }
-        with pytest.raises(ValueError, match="Balance must be >= 0"):
-            test_client.post("/api/cash-balances/", json=payload)
+        response = test_client.post("/api/cash-balances/", json=payload)
+        assert response.status_code == 400
+        assert "Balance must be >= 0" in response.json()["detail"]
 
     def test_get_cash_balances_after_create(self, test_client):
         """GET /api/cash-balances/ returns created record after POST."""

--- a/tests/backend/unit/services/test_analysis_service.py
+++ b/tests/backend/unit/services/test_analysis_service.py
@@ -623,7 +623,8 @@ class TestAnalysisServiceIncomeBySource:
 
         assert len(result) == 1
         sources = result[0]["sources"]
-        assert sources["Loans"] == 50000.0
+        # Positive Liabilities with a tag are labeled "Loans / {tag}"
+        assert sources["Loans / Mortgage"] == 50000.0
         assert sources["Salary"] == 8000.0
 
     def test_get_income_by_source_over_time_excludes_prior_wealth(

--- a/tests/backend/unit/services/test_credentials_service.py
+++ b/tests/backend/unit/services/test_credentials_service.py
@@ -280,15 +280,27 @@ class TestGetScraperCredentials:
 class TestSeedDemoCredentials:
     """Tests for demo credential seeding."""
 
-    def test_seeds_all_three_when_none_exist(self, mock_repo):
-        """Verify all three demo credentials are created when none exist."""
+    def test_seeds_all_when_none_exist(self, mock_repo):
+        """Verify every demo credential is created when none exist.
+
+        Seeds cover bank (hapoalim), credit cards (max, visa cal) and insurance
+        (hafenix) — four accounts in total. Each should trigger a save.
+        """
         from backend.errors import EntityNotFoundException
 
         mock_repo.get_credentials.side_effect = EntityNotFoundException("Not found")
         service = CredentialsService(MagicMock())
         service.seed_demo_credentials()
 
-        assert mock_repo.save_credentials.call_count == 3
+        assert mock_repo.save_credentials.call_count == 4
+        saved_targets = {
+            (call.args[0], call.args[1], call.args[2])
+            for call in mock_repo.save_credentials.call_args_list
+        }
+        assert ("banks", "hapoalim", "Main Account") in saved_targets
+        assert ("credit_cards", "max", "Family Card") in saved_targets
+        assert ("credit_cards", "visa cal", "Online Shopping") in saved_targets
+        assert ("insurances", "hafenix", "The Cohens") in saved_targets
 
     def test_skips_existing_credentials(self, mock_repo):
         """Verify existing demo credentials are not re-inserted."""
@@ -299,7 +311,11 @@ class TestSeedDemoCredentials:
         mock_repo.save_credentials.assert_not_called()
 
     def test_partial_seeding(self, mock_repo):
-        """Verify only missing demo credentials are created."""
+        """Verify only missing demo credentials are created.
+
+        The first credential already exists (returned by the repo); the
+        remaining three raise EntityNotFoundException and therefore get saved.
+        """
         from backend.errors import EntityNotFoundException
 
         call_count = 0
@@ -315,7 +331,7 @@ class TestSeedDemoCredentials:
         service = CredentialsService(MagicMock())
         service.seed_demo_credentials()
 
-        assert mock_repo.save_credentials.call_count == 2
+        assert mock_repo.save_credentials.call_count == 3
 
 
 class TestClearCache:


### PR DESCRIPTION
- Cash balance negative-balance route now returns HTTP 400 (not a raised
  ValueError); update the route test to assert the response.
- Income-by-source labels loans with their tag as "Loans / {tag}"; update
  the positive-liabilities test to match.
- Demo credential seeding now covers four accounts (bank, two credit
  cards, insurance); update call-count assertions and add a targets check.