### PR TITLE
fix(layout): scroll to top on route change

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
 import { GlobalSearch } from "./GlobalSearch";
 import { useAppStore } from "../../stores/appStore";
 
 export function Layout() {
   const { sidebarOpen, searchOpen, setSearchOpen } = useAppStore();
+  const { pathname } = useLocation();
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -17,6 +18,10 @@ export function Layout() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [setSearchOpen]);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
 
   return (
     <div className="min-h-dvh bg-[var(--background)]">


### PR DESCRIPTION
Navigating via react-router Link preserved the window scroll position, so
clicking 'View All' or 'View All Budget Rules' from the bottom of the
dashboard landed users at the bottom of the destination page. Reset
window scroll in Layout whenever the pathname changes.