### PR TITLE
fix(investments): align icon row heights on investment card

### DIFF
--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -275,7 +275,7 @@ function InvestmentCard({
             <Trash2 size={16} />
           </button>
           {inv.notes && (
-            <div className="p-2 rounded-lg bg-[var(--surface-light)]">
+            <div className="p-2 rounded-lg bg-[var(--surface-light)] flex items-center">
               <InfoTooltip text={inv.notes} iconSize={16} width={192} />
             </div>
           )}


### PR DESCRIPTION
The info-tooltip wrapper was a block <div>, so its height grew to the
surrounding line-height (~40px) instead of matching the sibling action
buttons (~32px). Under the parent flex's default align-items: stretch,
this stretched the entire left icon group taller than the right group.

Add `flex items-center` to the wrapper so it sizes to its icon content,
matching the button siblings.