### PR TITLE
feat(frontend): inline category/tag create-on-the-fly across remaining forms

### DIFF
--- a/docs/next-features.md
+++ b/docs/next-features.md
@@ -106,10 +106,25 @@ For recurring rent, salary, subscriptions — let the user mark them, and
 forecasting / budget rules can use the flag to project forward
 deterministically rather than statistically.
 
-### 10. Inline category create-on-the-fly
-Many forms use `SelectDropdown.onCreateNew` already. Audit the remaining
-modals (split, bulk-tag, refunds) and ensure they all support
-"+ New category" / "+ New tag" without leaving the modal.
+### 10. Inline category create-on-the-fly — DONE
+`SelectDropdown.onCreateNew` is now wired across the remaining
+category/tag forms:
+
+- `RuleManager` (auto-tagging quick-rule modal) — category + tag
+- `Liabilities` new-debt form — Liabilities-scoped tag (chained into
+  `handleTagChange` so receipt detection still fires after create)
+- `Investments` new-investment form — Investments-scoped tag (the
+  category field is intentionally pinned to `Investments`, so only the
+  tag dropdown takes inline create)
+
+Already had it before this pass: `SplitTransactionModal`,
+`BulkActionsBar`, `TransactionFormModal`, `TransactionEditorModal`,
+`BudgetRuleModal`, `RuleEditorModal`, `RecentTransactionsSection`.
+
+Deferred: `ProjectModal` — its category dropdown is fed by a derived
+"categories not yet used as a project" backend list, so wiring inline
+create there needs coordinated cache invalidation and is a different
+shape than the others.
 
 ### 11. Dark / light theme toggle
 Today the UI is dark-only via CSS custom properties. Adding a `light`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.4.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.4.0",
+      "version": "1.7.0",
       "dependencies": {
         "@tanstack/react-query": "^5.90.12",
         "axios": "^1.13.2",

--- a/frontend/src/components/modals/RuleManager.tsx
+++ b/frontend/src/components/modals/RuleManager.tsx
@@ -6,6 +6,7 @@ import { taggingApi, type TaggingRule } from "../../services/api";
 import { SelectDropdown } from "../common/SelectDropdown";
 import { useScrollLock } from "../../hooks/useScrollLock";
 import { useCategories } from "../../hooks/useCategories";
+import { useCategoryTagCreate } from "../../hooks/useCategoryTagCreate";
 import { useTaggingRules } from "../../hooks/useTaggingRules";
 
 interface RuleManagerProps {
@@ -28,6 +29,7 @@ export function RuleManager({ onClose }: RuleManagerProps) {
 
   const { data: rules, isLoading } = useTaggingRules();
   const { data: categories } = useCategories();
+  const { createCategory, createTag } = useCategoryTagCreate();
 
   const createMutation = useMutation({
     mutationFn: (rule: { name?: string; description_contains: string; category: string; tag: string }) => {
@@ -208,6 +210,10 @@ export function RuleManager({ onClose }: RuleManagerProps) {
                   }
                   placeholder={t("modals.transactionForm.selectCategory")}
                   size="sm"
+                  onCreateNew={async (name) => {
+                    const formatted = await createCategory(name);
+                    setNewRule({ ...newRule, category: formatted, tag: "" });
+                  }}
                 />
               </div>
               <div className="space-y-1.5 text-start">
@@ -223,6 +229,10 @@ export function RuleManager({ onClose }: RuleManagerProps) {
                   placeholder={t("modals.transactionForm.selectTag")}
                   disabled={!newRule.category}
                   size="sm"
+                  onCreateNew={async (name) => {
+                    const formatted = await createTag(newRule.category, name);
+                    setNewRule({ ...newRule, tag: formatted });
+                  }}
                 />
               </div>
             </div>

--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -21,6 +21,7 @@ import { InfoTooltip } from "../components/common/InfoTooltip";
 import { PortfolioOverview } from "../components/investments/PortfolioOverview";
 import { InvestmentAnalysisModal } from "../components/investments/InvestmentAnalysisModal";
 import { useCategories } from "../hooks/useCategories";
+import { useCategoryTagCreate } from "../hooks/useCategoryTagCreate";
 import { useConfirm } from "../context/DialogContext";
 import { formatCurrency } from "../utils/numberFormatting";
 
@@ -362,6 +363,7 @@ export function Investments() {
   });
 
   const { data: categories } = useCategories();
+  const { createTag } = useCategoryTagCreate();
 
   const { data: portfolioAnalysis } = useQuery({
     queryKey: ["portfolio-analysis"],
@@ -911,6 +913,10 @@ export function Investments() {
                   }
                   placeholder={t("investments.selectTag")}
                   disabled={!newInvestment.category}
+                  onCreateNew={async (name) => {
+                    const formatted = await createTag(newInvestment.category, name);
+                    setNewInvestment({ ...newInvestment, tag: formatted });
+                  }}
                 />
               </div>
               <div>

--- a/frontend/src/pages/Liabilities.tsx
+++ b/frontend/src/pages/Liabilities.tsx
@@ -21,6 +21,7 @@ import { SelectDropdown } from "../components/common/SelectDropdown";
 import { Skeleton } from "../components/common/Skeleton";
 import { formatCurrency } from "../utils/numberFormatting";
 import { useCategories } from "../hooks/useCategories";
+import { useCategoryTagCreate } from "../hooks/useCategoryTagCreate";
 import { useConfirm } from "../context/DialogContext";
 
 interface Liability {
@@ -342,6 +343,7 @@ export function Liabilities() {
   });
 
   const { data: categories } = useCategories();
+  const { createTag } = useCategoryTagCreate();
 
   const { data: analysisData } = useQuery<AnalysisData>({
     queryKey: ["liabilities", analysisModalId, "analysis"],
@@ -739,6 +741,10 @@ export function Liabilities() {
                   value={newLiability.tag}
                   onChange={handleTagChange}
                   placeholder={t("liabilities.selectTag")}
+                  onCreateNew={async (name) => {
+                    const formatted = await createTag("Liabilities", name);
+                    await handleTagChange(formatted);
+                  }}
                 />
                 {tagDetection && !tagDetection.has_receipt && (
                   <div className="flex items-start gap-2 mt-2 p-3 bg-amber-500/10 border border-amber-500/30 rounded-xl text-sm">


### PR DESCRIPTION
Audit and extend `SelectDropdown.onCreateNew` coverage so users no longer
have to leave a modal/form to create a new category or tag. Adds the
inline create flow to:

- Auto-tagging RuleManager (category + tag)
- Liabilities new-debt form (Liabilities-scoped tag)
- Investments new-investment form (Investments-scoped tag)

Also picks up an incidental package-lock version sync to 1.7.0.