### PR TITLE
feat(frontend): redesign auto-tagging rule editor for mobile

### DIFF
--- a/frontend/src/components/transactions/RuleBuilder.tsx
+++ b/frontend/src/components/transactions/RuleBuilder.tsx
@@ -82,10 +82,10 @@ export function RuleBuilder({ value, onChange, depth = 0, onRemove }: RuleBuilde
               overflow-hidden transition-all
           `}>
                 {/* Group Header */}
-                <div className="flex items-center gap-2 p-2 bg-[var(--surface-light)]/20 border-b border-[var(--surface-light)]">
-                    <div className="flex items-center gap-1">
-                        <Layers size={14} className="text-[var(--primary)]" />
-                        <div className="w-40">
+                <div className="flex flex-wrap items-center gap-2 p-2 bg-[var(--surface-light)]/20 border-b border-[var(--surface-light)]">
+                    <div className="flex items-center gap-1 flex-1 min-w-0">
+                        <Layers size={14} className="text-[var(--primary)] shrink-0" />
+                        <div className="flex-1 min-w-0 max-w-[180px]">
                         <SelectDropdown
                             options={[
                                 { label: t("ruleBuilder.andAllMatch"), value: "AND" },
@@ -98,26 +98,25 @@ export function RuleBuilder({ value, onChange, depth = 0, onRemove }: RuleBuilde
                         </div>
                     </div>
 
-                    <div className="flex-1" />
-
-                    <div className="flex gap-1">
+                    <div className="flex gap-1 shrink-0">
                         <button
                             onClick={() => addSubCondition("CONDITION")}
-                            className="flex items-center gap-1 px-2 py-1 rounded bg-[var(--surface)] hover:bg-[var(--surface-light)] text-[10px] font-bold border border-[var(--surface-light)]"
+                            className="flex items-center gap-1 px-2 py-1.5 rounded bg-[var(--surface)] hover:bg-[var(--surface-light)] text-[10px] font-bold border border-[var(--surface-light)]"
                         >
                             <Plus size={10} /> {t("ruleBuilder.condition")}
                         </button>
                         <button
                             onClick={() => addSubCondition("AND")}
-                            className="flex items-center gap-1 px-2 py-1 rounded bg-[var(--surface)] hover:bg-[var(--surface-light)] text-[10px] font-bold border border-[var(--surface-light)]"
+                            className="flex items-center gap-1 px-2 py-1.5 rounded bg-[var(--surface)] hover:bg-[var(--surface-light)] text-[10px] font-bold border border-[var(--surface-light)]"
                         >
                             <Plus size={10} /> {t("ruleBuilder.group")}
                         </button>
                         {depth > 0 && onRemove && (
                             <button
                                 onClick={onRemove}
-                                className="p-1 rounded hover:bg-red-500/10 text-red-400"
+                                className="p-1.5 rounded hover:bg-red-500/10 text-red-400"
                                 title={t("ruleBuilder.deleteGroup")}
+                                aria-label={t("ruleBuilder.deleteGroup")}
                             >
                                 <Trash2 size={12} />
                             </button>
@@ -161,12 +160,12 @@ export function RuleBuilder({ value, onChange, depth = 0, onRemove }: RuleBuilde
     const operators = OPERATORS[fieldDef.type] || OPERATORS.text;
 
     return (
-        <div className="flex items-center gap-2 p-2 rounded-lg bg-[var(--surface-base)] border border-[var(--surface-light)] hover:border-[var(--primary)]/30 transition-all">
-            <div className="p-1.5 rounded bg-[var(--surface)] text-[var(--text-muted)]">
+        <div className="grid grid-cols-[auto_1fr_auto] sm:flex sm:items-center gap-2 p-2 rounded-lg bg-[var(--surface-base)] border border-[var(--surface-light)] hover:border-[var(--primary)]/30 transition-all">
+            <div className="p-1.5 rounded bg-[var(--surface)] text-[var(--text-muted)] self-start sm:self-auto">
                 <FileText size={14} />
             </div>
 
-            <div className="w-32">
+            <div className="min-w-0 sm:w-32">
             <SelectDropdown
                 options={FIELDS.map(f => ({ label: t(`ruleBuilder.${f.labelKey}`), value: f.value }))}
                 value={value.field || "description"}
@@ -175,7 +174,7 @@ export function RuleBuilder({ value, onChange, depth = 0, onRemove }: RuleBuilde
             />
             </div>
 
-            <div className="w-32">
+            <div className="row-start-2 col-span-3 sm:row-auto sm:col-span-1 sm:w-32">
             <SelectDropdown
                 options={operators.map(op => ({ label: t(`ruleBuilder.${op.labelKey}`), value: op.value }))}
                 value={value.operator || "contains"}
@@ -185,43 +184,47 @@ export function RuleBuilder({ value, onChange, depth = 0, onRemove }: RuleBuilde
             </div>
 
             {value.operator === "between" ? (
-                <div className="flex items-center gap-1">
+                <div className="row-start-3 col-span-3 sm:row-auto sm:col-span-1 flex items-center gap-1 sm:flex-1">
                     <input
                         type="number"
+                        inputMode="decimal"
                         placeholder={t("ruleBuilder.min")}
                         value={Array.isArray(value.value) ? value.value[0] : ""}
                         onChange={(e) => onChange({
                             ...value,
                             value: [Number(e.target.value), Array.isArray(value.value) ? value.value[1] : 0]
                         })}
-                        className="w-20 bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1 text-xs outline-none focus:border-[var(--primary)]"
+                        className="flex-1 min-w-0 sm:w-20 sm:flex-initial bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1.5 text-sm sm:text-xs outline-none focus:border-[var(--primary)]"
                     />
                     <span className="text-xs text-[var(--text-muted)]">-</span>
                     <input
                         type="number"
+                        inputMode="decimal"
                         placeholder={t("ruleBuilder.max")}
                         value={Array.isArray(value.value) ? value.value[1] : ""}
                         onChange={(e) => onChange({
                             ...value,
                             value: [Array.isArray(value.value) ? value.value[0] : 0, Number(e.target.value)]
                         })}
-                        className="w-20 bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1 text-xs outline-none focus:border-[var(--primary)]"
+                        className="flex-1 min-w-0 sm:w-20 sm:flex-initial bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1.5 text-sm sm:text-xs outline-none focus:border-[var(--primary)]"
                     />
                 </div>
             ) : (
                 <input
                     type={inputType}
+                    inputMode={inputType === "number" ? "decimal" : undefined}
                     placeholder={t("ruleBuilder.value")}
                     value={value.value != null && typeof value.value !== "boolean" && !Array.isArray(value.value) ? value.value : ""}
                     onChange={(e) => onChange({ ...value, value: inputType === 'number' ? Number(e.target.value) : e.target.value })}
-                    className="flex-1 min-w-[100px] bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1 text-xs outline-none focus:border-[var(--primary)]"
+                    className="row-start-3 col-span-3 sm:row-auto sm:col-span-1 sm:flex-1 sm:min-w-[100px] bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1.5 text-sm sm:text-xs outline-none focus:border-[var(--primary)]"
                 />
             )}
 
             {onRemove && (
                 <button
                     onClick={onRemove}
-                    className="p-1 rounded hover:bg-red-500/10 text-red-400 transition-colors"
+                    className="row-start-1 col-start-3 sm:row-auto sm:col-start-auto p-1.5 rounded hover:bg-red-500/10 text-red-400 transition-colors self-start sm:self-auto justify-self-end"
+                    aria-label={t("common.delete")}
                 >
                     <Trash2 size={14} />
                 </button>

--- a/frontend/src/components/transactions/RuleEditorModal.tsx
+++ b/frontend/src/components/transactions/RuleEditorModal.tsx
@@ -37,6 +37,7 @@ export function RuleEditorModal({ isOpen, onClose, editingRule, onSaved }: RuleE
     const [tag, setTag] = useState("");
     const [conditions, setConditions] = useState<ConditionNode>(EMPTY_CONDITIONS);
     const [error, setError] = useState<string | null>(null);
+    const [mobileTab, setMobileTab] = useState<"rule" | "matches">("rule");
 
     const { data: categories } = useCategories() as { data: Record<string, string[]> | undefined };
     const { data: existingRules } = useTaggingRules();
@@ -80,8 +81,10 @@ export function RuleEditorModal({ isOpen, onClose, editingRule, onSaved }: RuleE
              
             setConditions(EMPTY_CONDITIONS);
         }
-         
+
         setError(null);
+
+        setMobileTab("rule");
     }, [editingRule, isOpen]);
 
     // Debounced conditions for preview
@@ -149,81 +152,130 @@ export function RuleEditorModal({ isOpen, onClose, editingRule, onSaved }: RuleE
 
     if (!isOpen) return null;
 
+    const ruleForm = (
+        <RuleForm
+            name={name}
+            category={category}
+            setCategory={(c) => { setCategory(c); setTag(""); }}
+            tag={tag}
+            setTag={setTag}
+            conditions={conditions}
+            setConditions={setConditions}
+            availableCategories={availableCategories}
+            availableTags={availableTags}
+            onCreateCategory={async (name) => {
+                const formatted = await createCategory(name);
+                setCategory(formatted);
+                setTag("");
+            }}
+            onCreateTag={async (name) => {
+                const formatted = await createTag(category, name);
+                setTag(formatted);
+            }}
+        />
+    );
+
+    const previewCount = preview?.count ?? 0;
+    const showPreviewBadge = !previewLoading && hasValidCondition(debouncedConditions);
+
     return (
-        <div className="modal-overlay fixed inset-0 z-50 flex items-center justify-center">
+        <div className="modal-overlay fixed inset-0 z-50 flex items-stretch sm:items-center justify-center">
             {/* Backdrop */}
             <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
 
             {/* Modal */}
-            <div role="dialog" aria-modal="true" aria-labelledby="rule-editor-title" className="relative w-[95vw] h-[90vh] bg-[var(--surface-base)] rounded-2xl shadow-2xl border border-[var(--surface-light)] flex flex-col overflow-hidden">
+            <div role="dialog" aria-modal="true" aria-labelledby="rule-editor-title" className="relative w-full h-dvh sm:w-[95vw] sm:h-[90vh] bg-[var(--surface-base)] sm:rounded-2xl shadow-2xl sm:border sm:border-[var(--surface-light)] flex flex-col overflow-hidden">
                 {/* Header */}
                 <div className="flex items-center justify-between px-4 md:px-6 py-3 md:py-4 border-b border-[var(--surface-light)] bg-[var(--surface)]">
-                    <h2 id="rule-editor-title" className="text-lg md:text-xl font-bold">
+                    <h2 id="rule-editor-title" className="text-lg md:text-xl font-bold truncate">
                         {editingRule ? t("transactions.autoTagging.editRule") : t("transactions.autoTagging.createRule")}
                     </h2>
                     <button
                         onClick={onClose}
                         aria-label={t("common.close")}
-                        className="p-2 hover:bg-[var(--surface-light)] rounded-lg transition-colors"
+                        className="p-2 hover:bg-[var(--surface-light)] rounded-lg transition-colors shrink-0"
                     >
                         <X size={20} />
                     </button>
                 </div>
 
-                {/* Content */}
-                <div className="flex-1 overflow-hidden">
+                {/* Mobile tabs */}
+                <div className="md:hidden flex border-b border-[var(--surface-light)] bg-[var(--surface)]">
+                    <button
+                        onClick={() => setMobileTab("rule")}
+                        className={`flex-1 px-4 py-3 text-sm font-bold transition-colors border-b-2 ${
+                            mobileTab === "rule"
+                                ? "border-[var(--primary)] text-[var(--primary)]"
+                                : "border-transparent text-[var(--text-muted)]"
+                        }`}
+                    >
+                        {t("transactions.autoTagging.tabRule")}
+                    </button>
+                    <button
+                        onClick={() => setMobileTab("matches")}
+                        className={`flex-1 px-4 py-3 text-sm font-bold transition-colors border-b-2 flex items-center justify-center gap-1.5 ${
+                            mobileTab === "matches"
+                                ? "border-[var(--primary)] text-[var(--primary)]"
+                                : "border-transparent text-[var(--text-muted)]"
+                        }`}
+                    >
+                        {t("transactions.autoTagging.tabMatches")}
+                        {showPreviewBadge && (
+                            <span className={`text-xs px-1.5 py-0.5 rounded-full ${
+                                mobileTab === "matches"
+                                    ? "bg-[var(--primary)]/20 text-[var(--primary)]"
+                                    : "bg-[var(--surface-light)] text-[var(--text-muted)]"
+                            }`} dir="ltr">{previewCount}</span>
+                        )}
+                    </button>
+                </div>
+
+                {/* Content - mobile (single panel based on tab) */}
+                <div className="md:hidden flex-1 overflow-hidden">
+                    {mobileTab === "rule" ? (
+                        <div className="h-full overflow-y-auto p-4">
+                            {ruleForm}
+                        </div>
+                    ) : (
+                        <TransactionPreview matches={(preview?.matches || []) as PreviewTransaction[]} loading={previewLoading} count={previewCount} showHeader={false} />
+                    )}
+                </div>
+
+                {/* Content - desktop (split pane) */}
+                <div className="hidden md:block flex-1 overflow-hidden">
                     <ResizableSplitPane
                         storageKey="rule-editor-split"
                         defaultLeftWidth={55}
                         minLeftWidth={30}
                         minRightWidth={25}
-                        left={<TransactionPreview matches={(preview?.matches || []) as PreviewTransaction[]} loading={previewLoading} count={preview?.count || 0} />}
+                        left={<TransactionPreview matches={(preview?.matches || []) as PreviewTransaction[]} loading={previewLoading} count={previewCount} />}
                         right={
                             <div className="h-full overflow-y-auto p-4 md:p-6">
-                                <RuleForm
-                                    name={name}
-                                    category={category}
-                                    setCategory={(c) => { setCategory(c); setTag(""); }}
-                                    tag={tag}
-                                    setTag={setTag}
-                                    conditions={conditions}
-                                    setConditions={setConditions}
-                                    availableCategories={availableCategories}
-                                    availableTags={availableTags}
-                                    onCreateCategory={async (name) => {
-                                        const formatted = await createCategory(name);
-                                        setCategory(formatted);
-                                        setTag("");
-                                    }}
-                                    onCreateTag={async (name) => {
-                                        const formatted = await createTag(category, name);
-                                        setTag(formatted);
-                                    }}
-                                />
+                                {ruleForm}
                             </div>
                         }
                     />
                 </div>
 
                 {/* Footer */}
-                <div className="flex items-center gap-3 px-4 md:px-6 py-3 md:py-4 border-t border-[var(--surface-light)] bg-[var(--surface)]">
+                <div className="flex flex-col sm:flex-row sm:items-center gap-3 px-4 md:px-6 py-3 md:py-4 border-t border-[var(--surface-light)] bg-[var(--surface)]">
                     {error && (
                         <div className="flex-1 flex items-center gap-2 p-2.5 bg-red-500/10 border border-red-500/20 rounded-xl text-red-400 text-sm animate-in slide-in-from-left-2 duration-200">
                             <AlertTriangle size={16} className="shrink-0" />
                             <span className="line-clamp-2">{error}</span>
                         </div>
                     )}
-                    <div className="flex items-center gap-3 ms-auto">
+                    <div className="flex items-center gap-3 sm:ms-auto">
                         <button
                             onClick={onClose}
-                            className="px-5 py-2.5 rounded-xl font-medium hover:bg-[var(--surface-light)] transition-colors"
+                            className="flex-1 sm:flex-initial px-5 py-2.5 rounded-xl font-medium hover:bg-[var(--surface-light)] transition-colors"
                         >
                             {t("common.cancel")}
                         </button>
                         <button
                             onClick={handleSave}
                             disabled={!category || !tag || isSaving}
-                            className={`px-6 py-2.5 text-white rounded-xl font-bold transition-all flex items-center gap-2 disabled:opacity-50 disabled:pointer-events-none ${
+                            className={`flex-1 sm:flex-initial px-6 py-2.5 text-white rounded-xl font-bold transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:pointer-events-none ${
                                 error ? "bg-red-500 hover:bg-red-600 animate-[shake_0.3s_ease-in-out]" : "bg-[var(--primary)] hover:bg-[var(--primary-dark)]"
                             }`}
                         >
@@ -259,7 +311,7 @@ interface PreviewTransaction {
     [key: string]: unknown;
 }
 
-function TransactionPreview({ matches, loading, count }: { matches: PreviewTransaction[]; loading: boolean; count: number }) {
+function TransactionPreview({ matches, loading, count, showHeader = true }: { matches: PreviewTransaction[]; loading: boolean; count: number; showHeader?: boolean }) {
     const { t } = useTranslation();
     const formatAmount = (amount: number) => {
         const formatted = Math.abs(amount).toLocaleString("he-IL", { style: "currency", currency: "ILS" });
@@ -268,16 +320,18 @@ function TransactionPreview({ matches, loading, count }: { matches: PreviewTrans
 
     return (
         <div className="h-full flex flex-col bg-[var(--surface)]">
-            <div className="px-4 py-3 border-b border-[var(--surface-light)] flex items-center justify-between">
-                <h3 className="font-bold text-[var(--text-muted)]">{t("transactions.autoTagging.matchingTransactions")}</h3>
-                <span className="text-sm text-[var(--text-muted)]">
-                    {loading ? t("common.loading") : `${count} ${t("transactions.autoTagging.matches")}`}
-                </span>
-            </div>
+            {showHeader && (
+                <div className="px-4 py-3 border-b border-[var(--surface-light)] flex items-center justify-between">
+                    <h3 className="font-bold text-[var(--text-muted)]">{t("transactions.autoTagging.matchingTransactions")}</h3>
+                    <span className="text-sm text-[var(--text-muted)]">
+                        {loading ? t("common.loading") : `${count} ${t("transactions.autoTagging.matches")}`}
+                    </span>
+                </div>
+            )}
 
             <div className="flex-1 overflow-auto">
                 {loading ? (
-                    <div className="flex items-center justify-center h-full text-[var(--text-muted)]">
+                    <div className="flex items-center justify-center h-full text-[var(--text-muted)] p-8">
                         <Loader2 size={24} className="animate-spin me-2" />
                         {t("transactions.autoTagging.loadingPreview")}
                     </div>
@@ -287,41 +341,73 @@ function TransactionPreview({ matches, loading, count }: { matches: PreviewTrans
                         {t("transactions.autoTagging.startTyping")}
                     </div>
                 ) : (
-                    <table className="w-full text-sm">
-                        <thead className="sticky top-0 bg-[var(--surface)] border-b border-[var(--surface-light)]">
-                            <tr className="text-start text-[var(--text-muted)]">
-                                <th className="px-4 py-2 font-medium">{t("common.date")}</th>
-                                <th className="px-4 py-2 font-medium">{t("common.description")}</th>
-                                <th className="px-4 py-2 font-medium text-end">{t("common.amount")}</th>
-                                <th className="px-4 py-2 font-medium">{t("transactions.autoTagging.currentTag")}</th>
-                            </tr>
-                        </thead>
-                        <tbody>
+                    <>
+                        {/* Mobile: card list */}
+                        <ul className="md:hidden divide-y divide-[var(--surface-light)]/50">
                             {matches.map((tx, i) => (
-                                <tr key={tx.unique_id || i} className="border-b border-[var(--surface-light)]/50 hover:bg-[var(--surface-light)]/20">
-                                    <td className="px-4 py-2 text-[var(--text-muted)] whitespace-nowrap">
-                                        {tx.date?.split("T")[0] || "—"}
-                                    </td>
-                                    <td className="px-4 py-2 truncate max-w-xs" title={tx.description}>
+                                <li key={tx.unique_id || i} className="px-4 py-3 hover:bg-[var(--surface-light)]/20">
+                                    <div className="flex items-start justify-between gap-3 mb-1">
+                                        <span className="text-xs text-[var(--text-muted)] whitespace-nowrap" dir="ltr">
+                                            {tx.date?.split("T")[0] || "—"}
+                                        </span>
+                                        <span className={`text-sm font-mono font-semibold whitespace-nowrap ${(tx.amount ?? 0) < 0 ? "text-red-400" : "text-green-400"}`} dir="ltr">
+                                            {formatAmount(tx.amount ?? 0)}
+                                        </span>
+                                    </div>
+                                    <div className="text-sm break-words" title={tx.description}>
                                         {tx.description}
-                                    </td>
-                                    <td className={`px-4 py-2 text-end whitespace-nowrap font-mono ${(tx.amount ?? 0) < 0 ? "text-red-400" : "text-green-400"}`}>
-                                        {formatAmount(tx.amount ?? 0)}
-                                    </td>
-                                    <td className="px-4 py-2">
+                                    </div>
+                                    <div className="mt-1.5">
                                         {tx.category ? (
-                                            <span className="inline-flex gap-1 text-xs">
+                                            <span className="inline-flex flex-wrap gap-1 text-xs">
                                                 <span className="px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400">{tx.category}</span>
                                                 {tx.tag && <span className="px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400">{tx.tag}</span>}
                                             </span>
                                         ) : (
                                             <span className="text-[var(--text-muted)] text-xs">{t("transactions.autoTagging.untagged")}</span>
                                         )}
-                                    </td>
-                                </tr>
+                                    </div>
+                                </li>
                             ))}
-                        </tbody>
-                    </table>
+                        </ul>
+
+                        {/* Desktop: table */}
+                        <table className="hidden md:table w-full text-sm">
+                            <thead className="sticky top-0 bg-[var(--surface)] border-b border-[var(--surface-light)]">
+                                <tr className="text-start text-[var(--text-muted)]">
+                                    <th className="px-4 py-2 font-medium text-start whitespace-nowrap">{t("common.date")}</th>
+                                    <th className="px-4 py-2 font-medium text-start">{t("common.description")}</th>
+                                    <th className="px-4 py-2 font-medium text-end whitespace-nowrap">{t("common.amount")}</th>
+                                    <th className="px-4 py-2 font-medium text-start whitespace-nowrap">{t("transactions.autoTagging.currentTag")}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {matches.map((tx, i) => (
+                                    <tr key={tx.unique_id || i} className="border-b border-[var(--surface-light)]/50 hover:bg-[var(--surface-light)]/20">
+                                        <td className="px-4 py-2 text-[var(--text-muted)] whitespace-nowrap">
+                                            {tx.date?.split("T")[0] || "—"}
+                                        </td>
+                                        <td className="px-4 py-2 truncate max-w-xs" title={tx.description}>
+                                            {tx.description}
+                                        </td>
+                                        <td className={`px-4 py-2 text-end whitespace-nowrap font-mono ${(tx.amount ?? 0) < 0 ? "text-red-400" : "text-green-400"}`}>
+                                            <span dir="ltr">{formatAmount(tx.amount ?? 0)}</span>
+                                        </td>
+                                        <td className="px-4 py-2">
+                                            {tx.category ? (
+                                                <span className="inline-flex gap-1 text-xs">
+                                                    <span className="px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400">{tx.category}</span>
+                                                    {tx.tag && <span className="px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400">{tx.tag}</span>}
+                                                </span>
+                                            ) : (
+                                                <span className="text-[var(--text-muted)] text-xs">{t("transactions.autoTagging.untagged")}</span>
+                                            )}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </>
                 )}
             </div>
         </div>
@@ -351,14 +437,14 @@ function RuleForm({
         <div className="space-y-6">
             {/* Basic Info */}
             <div className="space-y-4 p-4 bg-[var(--surface)] rounded-xl border border-[var(--surface-light)]">
-                <div className="flex items-center justify-between">
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
                     <h4 className="text-xs text-[var(--text-muted)] uppercase font-bold tracking-wide">{t("transactions.autoTagging.ruleDetails")}</h4>
                     {name && (
-                        <span className="text-xs text-[var(--text-muted)] font-mono">{name}</span>
+                        <span className="text-xs text-[var(--text-muted)] font-mono break-all">{name}</span>
                     )}
                 </div>
 
-                <div className="grid grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div>
                         <label className="text-xs text-[var(--text-muted)] uppercase font-bold">{t("common.category")}</label>
                         <div className="mt-1">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -228,6 +228,8 @@
       "untagged": "Untagged",
       "ruleDetails": "Rule Details",
       "conditions": "Conditions",
+      "tabRule": "Rule",
+      "tabMatches": "Matches",
       "confirmDeleteRule": "Delete rule?",
       "confirmDeleteNamedRule": "Delete rule \"{{name}}\"?"
     },

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -228,6 +228,8 @@
       "untagged": "ללא תגית",
       "ruleDetails": "פרטי כלל",
       "conditions": "תנאים",
+      "tabRule": "כלל",
+      "tabMatches": "התאמות",
       "confirmDeleteRule": "למחוק את הכלל?",
       "confirmDeleteNamedRule": "למחוק את הכלל \"{{name}}\"?"
     },


### PR DESCRIPTION
The Edit Rule modal previously rendered the desktop split-pane layout
verbatim on phones, leaving both panels squished off-screen with
horizontal overflow and unreadable form controls.

- Modal goes full-screen (h-dvh) on phones, keeps the centered card on
  tablet+ widths.
- Mobile uses a Rule / Matches tab switcher with a count badge instead
  of the resizable split pane; desktop split pane is preserved.
- TransactionPreview renders a card list on mobile (date + amount on
  the same row, full description, category/tag pills) and keeps the
  table on desktop.
- RuleBuilder condition row stacks field/operator/value vertically on
  narrow widths via grid layout; group header wraps so the AND/OR
  selector and add-buttons no longer collide.
- Footer Cancel/Save become full-width buttons on mobile.

Adds tabRule / tabMatches keys to en.json and he.json.

https://claude.ai/code/session_017oEL9A6t5t5uJixVb8rXqN