### PR TITLE
feat(budget): in-app budget alerts with sidebar bell

### DIFF
--- a/backend/demo_setup.py
+++ b/backend/demo_setup.py
@@ -1,0 +1,186 @@
+"""
+Demo database preparation helpers.
+
+Both the ``/api/testing/toggle_demo_mode`` route and the Vercel serverless
+entrypoint (``index.py``) need to copy the frozen demo SQLite, apply any
+schema deltas the ORM has accrued since the file was built, and shift every
+stored date relative to today so the demo data tracks the current month.
+
+Keeping this in one module ensures the toggle path and the cold-start path
+stay in lockstep — diverging implementations were how the Vercel preview
+ended up with budget rules pinned to ``DEMO_REFERENCE_DATE``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from datetime import date, timedelta
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+
+from backend import database
+from backend.config import AppConfig
+from backend.models import Base
+
+
+# Reference date used when generating ``backend/resources/demo_data.db``.
+# Every date column in that file is anchored to this point; on copy we apply
+# ``date.today() - DEMO_REFERENCE_DATE`` to every shiftable column.
+DEMO_REFERENCE_DATE = date(2026, 2, 25)
+
+
+def _source_db_path() -> str:
+    """Resolve the path to the frozen demo DB shipped in the repo."""
+    return os.path.join(
+        os.path.dirname(__file__), "resources", "demo_data.db"
+    )
+
+
+def sync_missing_columns(engine: Engine) -> None:
+    """Add ORM-defined columns that are missing from the physical DB.
+
+    SQLite has no full ``ALTER TABLE`` support and ``create_all`` only handles
+    new tables, so columns added to existing models drift from the frozen demo
+    file. This bridges the gap with explicit ``ADD COLUMN`` statements.
+    """
+    inspector = inspect(engine)
+    for table_name, table in Base.metadata.tables.items():
+        if not inspector.has_table(table_name):
+            continue
+        existing = {col["name"] for col in inspector.get_columns(table_name)}
+        for column in table.columns:
+            if column.name in existing:
+                continue
+            col_type = column.type.compile(engine.dialect)
+            with engine.connect() as conn:
+                conn.execute(
+                    text(
+                        f"ALTER TABLE {table_name} ADD COLUMN {column.name} {col_type}"
+                    )
+                )
+                conn.commit()
+
+
+def _shift_dates(engine: Engine, offset_days: int) -> None:
+    """Shift every shiftable date column by ``offset_days`` days."""
+    if offset_days == 0:
+        return
+
+    offset_str = (
+        f"+{offset_days} days" if offset_days > 0 else f"{offset_days} days"
+    )
+
+    with engine.connect() as conn:
+        for table in [
+            "bank_transactions",
+            "credit_card_transactions",
+            "cash_transactions",
+            "manual_investment_transactions",
+            "insurance_transactions",
+        ]:
+            conn.execute(
+                text(f"UPDATE {table} SET date = date(date, :offset)"),
+                {"offset": offset_str},
+            )
+
+        # Order avoids UNIQUE collisions on (investment_id, date) snapshots.
+        order = "DESC" if offset_days > 0 else "ASC"
+        snapshot_ids = conn.execute(
+            text(
+                f"SELECT id FROM investment_balance_snapshots ORDER BY date {order}"
+            )
+        ).fetchall()
+        for (sid,) in snapshot_ids:
+            conn.execute(
+                text(
+                    "UPDATE investment_balance_snapshots SET date = date(date, :offset) WHERE id = :id"
+                ),
+                {"offset": offset_str, "id": sid},
+            )
+
+        for col in [
+            "created_date",
+            "closed_date",
+            "liquidity_date",
+            "maturity_date",
+        ]:
+            conn.execute(
+                text(
+                    f"UPDATE investments SET {col} = date({col}, :offset) WHERE {col} IS NOT NULL"
+                ),
+                {"offset": offset_str},
+            )
+
+        conn.execute(
+            text("UPDATE scraping_history SET date = date(date, :offset)"),
+            {"offset": offset_str},
+        )
+
+        for col in ["start_date", "paid_off_date", "created_date"]:
+            conn.execute(
+                text(
+                    f"UPDATE liabilities SET {col} = date({col}, :offset) WHERE {col} IS NOT NULL"
+                ),
+                {"offset": offset_str},
+            )
+
+        conn.execute(
+            text(
+                "UPDATE liability_transactions SET date = date(date, :offset) WHERE date IS NOT NULL"
+            ),
+            {"offset": offset_str},
+        )
+
+        for col in ["balance_date", "liquidity_date"]:
+            conn.execute(
+                text(
+                    f"UPDATE insurance_accounts SET {col} = date({col}, :offset) WHERE {col} IS NOT NULL"
+                ),
+                {"offset": offset_str},
+            )
+
+        rows = conn.execute(
+            text(
+                "SELECT DISTINCT id, year, month FROM budget_rules WHERE year IS NOT NULL"
+            )
+        ).fetchall()
+        for row in rows:
+            old_date = date(row[1], row[2], 1)
+            new_date = old_date + timedelta(days=offset_days)
+            conn.execute(
+                text(
+                    "UPDATE budget_rules SET year = :year, month = :month WHERE id = :id"
+                ),
+                {"year": new_date.year, "month": new_date.month, "id": row[0]},
+            )
+
+        conn.commit()
+
+
+def prepare_demo_database() -> None:
+    """Copy the frozen demo DB into the demo-mode location and shift dates.
+
+    Resets the SQLAlchemy engine, copies ``backend/resources/demo_data.db``
+    over the configured demo DB path, applies any missing schema deltas, then
+    shifts every date column so the dataset is anchored to today.
+
+    Safe to call repeatedly — each call yields a fresh copy with dates
+    re-anchored to ``date.today()``.
+    """
+    config = AppConfig()
+    demo_db_path = config.get_db_path()
+    source = _source_db_path()
+
+    if os.path.exists(source):
+        os.makedirs(os.path.dirname(demo_db_path), exist_ok=True)
+        shutil.copy2(source, demo_db_path)
+
+    database.reset_engine()
+    engine = database.get_engine()
+    Base.metadata.create_all(bind=engine)
+    sync_missing_columns(engine)
+
+    offset_days = (date.today() - DEMO_REFERENCE_DATE).days
+    _shift_dates(engine, offset_days)

--- a/backend/routes/budget.py
+++ b/backend/routes/budget.py
@@ -4,6 +4,7 @@ Budget API routes.
 Provides endpoints for budget rule management, analysis, and project management.
 """
 
+from datetime import date
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -164,6 +165,63 @@ async def get_monthly_analysis(
     """
     service = MonthlyBudgetService(db)
     return service.get_monthly_analysis(year, month, include_split_parents)
+
+
+# --- Alert Endpoints ---
+
+
+@router.get("/alerts")
+async def get_current_month_alerts(
+    threshold: float = Query(0.8, ge=0.0, le=1.0),
+    db: Session = Depends(get_database),
+) -> dict[str, Any]:
+    """Return budget alerts for the current calendar month.
+
+    Parameters
+    ----------
+    threshold : float, optional
+        Fraction of the budget at which an alert fires. Default is ``0.8``
+        (80%). Constrained to ``[0.0, 1.0]``.
+
+    Returns
+    -------
+    dict
+        ``{"year": Y, "month": M, "alerts": [...]}``. Each alert has
+        ``rule_id``, ``name``, ``category``, ``tags``, ``amount``, ``spent``,
+        ``percentage``, and ``severity`` (``"warning"`` or ``"critical"``).
+    """
+    today = date.today()
+    service = MonthlyBudgetService(db)
+    alerts = service.get_alerts(today.year, today.month, warning_threshold=threshold)
+    return {"year": today.year, "month": today.month, "alerts": alerts}
+
+
+@router.get("/alerts/{year}/{month}")
+async def get_month_alerts(
+    year: int,
+    month: int,
+    threshold: float = Query(0.8, ge=0.0, le=1.0),
+    db: Session = Depends(get_database),
+) -> dict[str, Any]:
+    """Return budget alerts for a specific calendar month.
+
+    Parameters
+    ----------
+    year : int
+        Calendar year.
+    month : int
+        Calendar month (1–12).
+    threshold : float, optional
+        Fraction of the budget at which an alert fires. Default is ``0.8``.
+
+    Returns
+    -------
+    dict
+        ``{"year": year, "month": month, "alerts": [...]}``.
+    """
+    service = MonthlyBudgetService(db)
+    alerts = service.get_alerts(year, month, warning_threshold=threshold)
+    return {"year": year, "month": month, "alerts": alerts}
 
 
 # --- Project Endpoints ---

--- a/backend/routes/testing.py
+++ b/backend/routes/testing.py
@@ -6,145 +6,21 @@ to an isolated environment (separate DB, credentials, and categories) to
 allow safe testing without affecting production data.
 """
 
-import os
-import shutil
-from datetime import date, timedelta
-
-from sqlalchemy import inspect, text
-
 from fastapi import APIRouter
 from pydantic import BaseModel
 
 from backend.config import AppConfig
 from backend import database
 from backend.database import get_db_context
+from backend.demo_setup import DEMO_REFERENCE_DATE, prepare_demo_database
 from backend.services.credentials_service import CredentialsService
 from backend.services.tagging_service import CategoriesTagsService
-from backend.models import Base
 
 router = APIRouter()
 
-# Reference date used when generating demo_data.db.
-# All dates in the DB are relative to this date.
-DEMO_REFERENCE_DATE = date(2026, 2, 25)
-
-
-def _sync_missing_columns(engine) -> None:
-    """Add columns present in ORM models but missing from the physical DB.
-
-    ``create_all`` only creates new tables; it does not alter existing ones.
-    This fills the gap for SQLite (which has no full ALTER support) by
-    running ``ALTER TABLE ... ADD COLUMN`` for each missing column.
-    """
-    inspector = inspect(engine)
-    for table_name, table in Base.metadata.tables.items():
-        if not inspector.has_table(table_name):
-            continue
-        existing = {col["name"] for col in inspector.get_columns(table_name)}
-        for column in table.columns:
-            if column.name not in existing:
-                col_type = column.type.compile(engine.dialect)
-                with engine.connect() as conn:
-                    conn.execute(
-                        text(f"ALTER TABLE {table_name} ADD COLUMN {column.name} {col_type}")
-                    )
-                    conn.commit()
-
-
-def _prepare_demo_database() -> None:
-    """Copy the pre-built demo DB and shift all dates to be relative to today.
-
-    Copies ``backend/resources/demo_data.db`` to the demo environment directory
-    and runs SQL UPDATE statements to shift every date column by the offset
-    between the reference date (when the DB was generated) and today.
-    """
-    config = AppConfig()
-    demo_db_path = config.get_db_path()
-    source_db = os.path.join(
-        os.path.dirname(__file__), "..", "resources", "demo_data.db"
-    )
-
-    # Copy pre-built DB (overwrites any previous demo data)
-    if os.path.exists(source_db):
-        shutil.copy2(source_db, demo_db_path)
-
-    # Ensure schema is up-to-date (create missing tables, add missing columns)
-    database.reset_engine()
-    engine = database.get_engine()
-    Base.metadata.create_all(bind=engine)
-    _sync_missing_columns(engine)
-
-    # Shift dates
-    offset_days = (date.today() - DEMO_REFERENCE_DATE).days
-    if offset_days == 0:
-        return
-
-    engine = database.get_engine()
-    with engine.connect() as conn:
-        offset_str = f"+{offset_days} days" if offset_days > 0 else f"{offset_days} days"
-
-        # Shift date columns in transaction tables
-        for table in [
-            "bank_transactions",
-            "credit_card_transactions",
-            "cash_transactions",
-            "manual_investment_transactions",
-            "insurance_transactions",
-        ]:
-            conn.execute(text(
-                f"UPDATE {table} SET date = date(date, :offset)"
-            ), {"offset": offset_str})
-
-        # Shift investment balance snapshots (order avoids UNIQUE collisions)
-        order = "DESC" if offset_days > 0 else "ASC"
-        snapshot_ids = conn.execute(text(
-            f"SELECT id FROM investment_balance_snapshots ORDER BY date {order}"
-        )).fetchall()
-        for (sid,) in snapshot_ids:
-            conn.execute(text(
-                "UPDATE investment_balance_snapshots SET date = date(date, :offset) WHERE id = :id"
-            ), {"offset": offset_str, "id": sid})
-
-        # Shift investment date fields
-        for col in ["created_date", "closed_date", "liquidity_date", "maturity_date"]:
-            conn.execute(text(
-                f"UPDATE investments SET {col} = date({col}, :offset) WHERE {col} IS NOT NULL"
-            ), {"offset": offset_str})
-
-        # Shift scraping history
-        conn.execute(text(
-            "UPDATE scraping_history SET date = date(date, :offset)"
-        ), {"offset": offset_str})
-
-        # Shift liability date fields
-        for col in ["start_date", "paid_off_date", "created_date"]:
-            conn.execute(text(
-                f"UPDATE liabilities SET {col} = date({col}, :offset) WHERE {col} IS NOT NULL"
-            ), {"offset": offset_str})
-
-        # Shift liability transaction dates
-        conn.execute(text(
-            "UPDATE liability_transactions SET date = date(date, :offset) WHERE date IS NOT NULL"
-        ), {"offset": offset_str})
-
-        # Shift insurance account date fields
-        for col in ["balance_date", "liquidity_date"]:
-            conn.execute(text(
-                f"UPDATE insurance_accounts SET {col} = date({col}, :offset) WHERE {col} IS NOT NULL"
-            ), {"offset": offset_str})
-
-        # Shift budget rules year/month
-        rows = conn.execute(text(
-            "SELECT DISTINCT id, year, month FROM budget_rules WHERE year IS NOT NULL"
-        )).fetchall()
-        for row in rows:
-            old_date = date(row[1], row[2], 1)
-            new_date = old_date + timedelta(days=offset_days)
-            conn.execute(text(
-                "UPDATE budget_rules SET year = :year, month = :month WHERE id = :id"
-            ), {"year": new_date.year, "month": new_date.month, "id": row[0]})
-
-        conn.commit()
+# Re-exported for backwards compatibility with tests/integrations that
+# import this constant from the route module.
+__all__ = ["DEMO_REFERENCE_DATE", "router"]
 
 
 class DemoModeRequest(BaseModel):
@@ -187,7 +63,7 @@ async def toggle_demo_mode(
 
         # If enabling demo mode, copy source DB then ensure schema is up-to-date
         if request.enabled:
-            _prepare_demo_database()
+            prepare_demo_database()
 
             with get_db_context() as demo_db:
                 creds_service = CredentialsService(demo_db)

--- a/backend/services/budget_service.py
+++ b/backend/services/budget_service.py
@@ -915,6 +915,78 @@ class MonthlyBudgetService(BudgetService):
             "total_spent": float(project_txns[amount_col].sum() * -1),
         }
 
+    def get_alerts(
+        self,
+        year: int,
+        month: int,
+        warning_threshold: float = 0.8,
+    ) -> list[dict]:
+        """
+        Identify monthly budget rules whose spend has reached a warning threshold.
+
+        A rule is "tripped" when ``current_amount / amount`` is at or above
+        ``warning_threshold``. The "Total Budget" rule and the auto-generated
+        "Other Expenses" pseudo-rule are excluded — Total Budget is a roll-up
+        and would double-count, and "Other Expenses" has no user-set amount.
+
+        Parameters
+        ----------
+        year : int
+            Calendar year.
+        month : int
+            Calendar month (1–12).
+        warning_threshold : float, optional
+            Fraction of the budget at which an alert starts firing. Default is
+            ``0.8`` (80%). Rules at 100% or above are tagged with severity
+            ``"critical"``; rules between the warning threshold and 100% are
+            tagged ``"warning"``.
+
+        Returns
+        -------
+        list[dict]
+            One entry per tripped rule, each with keys ``rule_id``, ``name``,
+            ``category``, ``tags`` (list), ``amount`` (budget), ``spent``,
+            ``percentage`` (0.0–∞, where 1.0 = exactly at budget), and
+            ``severity`` (``"warning"`` or ``"critical"``). Empty list when
+            no rules are tripped or no rules exist for the month.
+        """
+        view = self.get_monthly_budget_view(year, month)
+        if view is None:
+            return []
+
+        alerts = []
+        for entry in view:
+            rule = entry["rule"]
+            category = rule.get(CATEGORY)
+            if category in (TOTAL_BUDGET, "Other Expenses"):
+                continue
+
+            amount = float(rule.get(AMOUNT) or 0)
+            if amount <= 0:
+                continue
+
+            spent = float(entry.get("current_amount") or 0)
+            percentage = spent / amount
+            if percentage < warning_threshold:
+                continue
+
+            severity = "critical" if percentage >= 1.0 else "warning"
+            alerts.append(
+                {
+                    "rule_id": int(rule[ID]),
+                    "name": str(rule.get(NAME) or ""),
+                    "category": str(category),
+                    "tags": list(rule.get(TAGS) or []),
+                    "amount": amount,
+                    "spent": spent,
+                    "percentage": percentage,
+                    "severity": severity,
+                }
+            )
+
+        alerts.sort(key=lambda a: a["percentage"], reverse=True)
+        return alerts
+
 
 class ProjectBudgetService(BudgetService):
     """Service for managing project-based budget rules."""

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.7.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.7.0",
+      "version": "1.8.1",
       "dependencies": {
         "@tanstack/react-query": "^5.90.12",
         "axios": "^1.13.2",

--- a/frontend/src/components/layout/BudgetAlertsBell.tsx
+++ b/frontend/src/components/layout/BudgetAlertsBell.tsx
@@ -1,0 +1,52 @@
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Bell } from "lucide-react";
+import { BudgetAlertsPopup } from "./BudgetAlertsPopup";
+import { useBudgetAlerts } from "../../hooks/useBudgetAlerts";
+import { useBudgetAlertDismissals } from "../../hooks/useBudgetAlertDismissals";
+
+interface BudgetAlertsBellProps {
+  variant?: "sidebar" | "compact";
+  expanded?: boolean;
+}
+
+export function BudgetAlertsBell({
+  variant = "sidebar",
+  expanded = true,
+}: BudgetAlertsBellProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const { data } = useBudgetAlerts();
+  const { isDismissed } = useBudgetAlertDismissals(data?.year, data?.month);
+
+  const visibleCount = useMemo(
+    () => (data?.alerts ?? []).filter((a) => !isDismissed(a.rule_id)).length,
+    [data?.alerts, isDismissed],
+  );
+
+  const baseClasses =
+    variant === "compact"
+      ? "p-1.5 -ms-1.5 rounded-lg hover:bg-[var(--surface-light)] transition-colors"
+      : `relative flex items-center gap-3 px-4 py-3 rounded-lg transition-all w-full text-[var(--text-muted)] hover:bg-[var(--surface-light)] hover:text-white`;
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        className={`relative ${baseClasses}`}
+        aria-label={t("budgetAlerts.title")}
+      >
+        <Bell size={variant === "compact" ? 20 : 20} />
+        {variant === "sidebar" && expanded && (
+          <span className="text-sm font-medium">{t("budgetAlerts.title")}</span>
+        )}
+        {visibleCount > 0 && (
+          <span className="absolute -top-1 -end-1 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-rose-500 text-white text-[10px] font-bold px-1">
+            {visibleCount > 99 ? "99+" : visibleCount}
+          </span>
+        )}
+      </button>
+      <BudgetAlertsPopup isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  );
+}

--- a/frontend/src/components/layout/BudgetAlertsPopup.tsx
+++ b/frontend/src/components/layout/BudgetAlertsPopup.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react";
+import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle, X } from "lucide-react";
@@ -43,9 +44,12 @@ export function BudgetAlertsPopup({ isOpen, onClose }: BudgetAlertsPopupProps) {
     navigate("/budget");
   };
 
-  return (
+  // Portal to document.body so the overlay isn't trapped inside the mobile top
+  // bar's transformed ancestor (which would clip `fixed inset-0` to the top
+  // bar's containing block instead of the viewport).
+  return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 backdrop-blur-md sm:backdrop-blur-sm animate-in fade-in duration-200 modal-overlay pt-16 sm:pt-24 px-4"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/30 backdrop-blur-2xl sm:bg-black/60 sm:backdrop-blur-sm animate-in fade-in duration-200 modal-overlay pt-16 sm:pt-24 px-4"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -164,6 +168,7 @@ export function BudgetAlertsPopup({ isOpen, onClose }: BudgetAlertsPopupProps) {
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/frontend/src/components/layout/BudgetAlertsPopup.tsx
+++ b/frontend/src/components/layout/BudgetAlertsPopup.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, X } from "lucide-react";
 import { formatCurrency } from "../../utils/numberFormatting";
 import { useBudgetAlerts } from "../../hooks/useBudgetAlerts";
 import { useBudgetAlertDismissals } from "../../hooks/useBudgetAlertDismissals";
+import { useScrollLock } from "../../hooks/useScrollLock";
 
 interface BudgetAlertsPopupProps {
   isOpen: boolean;
@@ -19,6 +20,7 @@ export function BudgetAlertsPopup({ isOpen, onClose }: BudgetAlertsPopupProps) {
     data?.year,
     data?.month,
   );
+  useScrollLock(isOpen);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -43,7 +45,7 @@ export function BudgetAlertsPopup({ isOpen, onClose }: BudgetAlertsPopupProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 backdrop-blur-sm animate-in fade-in duration-200 modal-overlay pt-16 sm:pt-24 px-4"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 backdrop-blur-md sm:backdrop-blur-sm animate-in fade-in duration-200 modal-overlay pt-16 sm:pt-24 px-4"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}

--- a/frontend/src/components/layout/BudgetAlertsPopup.tsx
+++ b/frontend/src/components/layout/BudgetAlertsPopup.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { AlertTriangle, X } from "lucide-react";
+import { formatCurrency } from "../../utils/numberFormatting";
+import { useBudgetAlerts } from "../../hooks/useBudgetAlerts";
+import { useBudgetAlertDismissals } from "../../hooks/useBudgetAlertDismissals";
+
+interface BudgetAlertsPopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function BudgetAlertsPopup({ isOpen, onClose }: BudgetAlertsPopupProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { data, isLoading } = useBudgetAlerts();
+  const { isDismissed, dismiss, dismissAll } = useBudgetAlertDismissals(
+    data?.year,
+    data?.month,
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  const visibleAlerts = useMemo(
+    () => (data?.alerts ?? []).filter((a) => !isDismissed(a.rule_id)),
+    [data?.alerts, isDismissed],
+  );
+
+  if (!isOpen) return null;
+
+  const handleOpenBudget = () => {
+    onClose();
+    navigate("/budget");
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 backdrop-blur-sm animate-in fade-in duration-200 modal-overlay pt-16 sm:pt-24 px-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-[calc(100vw-2rem)] sm:max-w-md bg-[var(--surface)] border border-[var(--surface-light)] rounded-2xl shadow-2xl animate-in zoom-in-95 duration-200 max-h-[80vh] flex flex-col">
+        <div className="flex items-center justify-between px-4 sm:px-6 py-4 border-b border-[var(--surface-light)]">
+          <div className="flex items-center gap-2">
+            <AlertTriangle size={18} className="text-amber-400" />
+            <h2 className="font-semibold text-[var(--text-default)]">
+              {t("budgetAlerts.title")}
+            </h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label={t("common.close")}
+            className="p-2 rounded-lg hover:bg-[var(--surface-light)] transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6 space-y-3">
+          {isLoading ? (
+            <p className="text-sm text-[var(--text-muted)] text-center py-6">
+              {t("budgetAlerts.loading")}
+            </p>
+          ) : visibleAlerts.length === 0 ? (
+            <p className="text-sm text-[var(--text-muted)] text-center py-6">
+              {t("budgetAlerts.empty")}
+            </p>
+          ) : (
+            visibleAlerts.map((alert) => {
+              const percent = Math.min(alert.percentage * 100, 100);
+              const isCritical = alert.severity === "critical";
+              const colorClass = isCritical ? "bg-rose-500" : "bg-amber-500";
+              const badgeClass = isCritical
+                ? "bg-rose-500/15 text-rose-400 border-rose-500/30"
+                : "bg-amber-500/15 text-amber-400 border-amber-500/30";
+              const severityLabel = isCritical
+                ? t("budgetAlerts.severityCritical")
+                : t("budgetAlerts.severityWarning");
+              return (
+                <div
+                  key={alert.rule_id}
+                  className="rounded-xl border border-[var(--surface-light)] bg-[var(--surface-light)]/30 p-3 sm:p-4"
+                >
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <div className="min-w-0">
+                      <div className="font-semibold text-sm text-[var(--text-default)] truncate">
+                        {alert.name || alert.category}
+                      </div>
+                      <div className="text-xs text-[var(--text-muted)] truncate">
+                        {alert.category}
+                      </div>
+                    </div>
+                    <span
+                      className={`shrink-0 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-md border ${badgeClass}`}
+                    >
+                      {severityLabel}
+                    </span>
+                  </div>
+
+                  <div className="w-full bg-[var(--surface-light)] rounded-full h-2 overflow-hidden mb-2">
+                    <div
+                      className={`h-2 rounded-full ${colorClass} transition-all duration-500 ease-out`}
+                      style={{ width: `${percent}%` }}
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="text-[var(--text-muted)]">
+                      <span dir="ltr">
+                        {formatCurrency(alert.spent)} /{" "}
+                        {formatCurrency(alert.amount)}
+                      </span>
+                    </span>
+                    <span className="flex items-center gap-2">
+                      <span
+                        className={`font-bold font-mono ${
+                          isCritical ? "text-rose-400" : "text-amber-400"
+                        }`}
+                        dir="ltr"
+                      >
+                        {(alert.percentage * 100).toFixed(0)}%
+                      </span>
+                      <button
+                        onClick={() => dismiss(alert.rule_id)}
+                        className="text-[var(--text-muted)] hover:text-[var(--text-default)] underline-offset-2 hover:underline transition-colors"
+                      >
+                        {t("budgetAlerts.dismiss")}
+                      </button>
+                    </span>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div className="px-4 sm:px-6 py-3 border-t border-[var(--surface-light)] flex items-center justify-between gap-2">
+          <button
+            onClick={() => {
+              if (visibleAlerts.length === 0) return;
+              dismissAll(visibleAlerts.map((a) => a.rule_id));
+            }}
+            disabled={visibleAlerts.length === 0}
+            className="text-xs font-medium text-[var(--text-muted)] hover:text-[var(--text-default)] disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {t("budgetAlerts.dismissAll")}
+          </button>
+          <button
+            onClick={handleOpenBudget}
+            className="text-xs font-medium px-3 py-1.5 rounded-lg bg-[var(--primary)] text-white hover:opacity-90 transition-opacity"
+          >
+            {t("budgetAlerts.openBudget")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from "react-i18next";
 import { useAppStore } from "../../stores/appStore";
 import { transactionsApi, scrapingApi } from "../../services/api";
 import { SettingsPopup } from "./SettingsPopup";
+import { BudgetAlertsBell } from "./BudgetAlertsBell";
 
 const navItems = [
   { path: "/", icon: LayoutDashboard, key: "dashboard" },
@@ -166,6 +167,7 @@ export function Sidebar() {
 
       {/* Settings & Data Flow */}
       <div className="absolute bottom-0 inset-inline-start-0 inset-inline-end-0 p-4 border-t border-[var(--surface-light)] space-y-1">
+        <BudgetAlertsBell variant="sidebar" expanded={sidebarOpen || mobileSidebarOpen} />
         <button
           onClick={() => setSettingsOpen(!settingsOpen)}
           className={`flex items-center gap-3 px-4 py-3 rounded-lg transition-all w-full ${
@@ -208,7 +210,7 @@ export function Sidebar() {
         <span className="text-sm font-bold bg-gradient-to-r from-blue-400 to-emerald-400 bg-clip-text text-transparent">
           {currentPageLabel || t("sidebar.logo")}
         </span>
-        <div className="w-8" />
+        <BudgetAlertsBell variant="compact" />
       </div>
 
       {/* Desktop sidebar */}

--- a/frontend/src/hooks/useBudgetAlertDismissals.ts
+++ b/frontend/src/hooks/useBudgetAlertDismissals.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from "react";
+import { useDemoMode } from "../context/DemoModeContext";
+
+const STORAGE_KEY_BASE = "fa.budgetAlertsDismissed";
+
+function storageKey(isDemoMode: boolean, year?: number, month?: number): string {
+  const mode = isDemoMode ? "demo" : "real";
+  return `${STORAGE_KEY_BASE}.${mode}.${year ?? "x"}-${month ?? "x"}`;
+}
+
+function readSet(key: string): Set<number> {
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((v): v is number => typeof v === "number"));
+  } catch {
+    return new Set();
+  }
+}
+
+function writeSet(key: string, value: Set<number>): void {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(Array.from(value)));
+  } catch {
+    // localStorage unavailable (private mode, quota) — fail silently
+  }
+}
+
+/**
+ * Tracks which budget-alert rule_ids the user has dismissed for a given month.
+ * Persisted in localStorage, scoped by demo-vs-real mode and year/month so:
+ * - dismissing in demo mode doesn't carry over to real data,
+ * - dismissals expire naturally once the calendar moves to a new month.
+ */
+export function useBudgetAlertDismissals(year?: number, month?: number) {
+  const { isDemoMode } = useDemoMode();
+  const key = storageKey(isDemoMode, year, month);
+  const [dismissed, setDismissed] = useState<Set<number>>(() => readSet(key));
+
+  useEffect(() => {
+    setDismissed(readSet(key));
+  }, [key]);
+
+  const isDismissed = useCallback(
+    (ruleId: number) => dismissed.has(ruleId),
+    [dismissed],
+  );
+
+  const dismiss = useCallback(
+    (ruleId: number) => {
+      setDismissed((prev) => {
+        if (prev.has(ruleId)) return prev;
+        const next = new Set(prev);
+        next.add(ruleId);
+        writeSet(key, next);
+        return next;
+      });
+    },
+    [key],
+  );
+
+  const dismissAll = useCallback(
+    (ruleIds: number[]) => {
+      setDismissed((prev) => {
+        const next = new Set(prev);
+        for (const id of ruleIds) next.add(id);
+        writeSet(key, next);
+        return next;
+      });
+    },
+    [key],
+  );
+
+  return { isDismissed, dismiss, dismissAll };
+}

--- a/frontend/src/hooks/useBudgetAlertDismissals.ts
+++ b/frontend/src/hooks/useBudgetAlertDismissals.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { useDemoMode } from "../context/DemoModeContext";
 
 const STORAGE_KEY_BASE = "fa.budgetAlertsDismissed";
@@ -28,20 +28,50 @@ function writeSet(key: string, value: Set<number>): void {
   }
 }
 
+// Module-level cache + pub-sub. The bell badge and the popup both subscribe
+// here, so dismissing in one updates the other immediately. Without this they
+// each held their own useState copy of the dismissed set and the bell's badge
+// stayed stale until a remount.
+const cache = new Map<string, Set<number>>();
+const subscribers = new Set<() => void>();
+
+function getCachedSet(key: string): Set<number> {
+  let value = cache.get(key);
+  if (!value) {
+    value = readSet(key);
+    cache.set(key, value);
+  }
+  return value;
+}
+
+function setCachedSet(key: string, value: Set<number>): void {
+  cache.set(key, value);
+  writeSet(key, value);
+  subscribers.forEach((fn) => fn());
+}
+
+function subscribe(onChange: () => void): () => void {
+  subscribers.add(onChange);
+  return () => {
+    subscribers.delete(onChange);
+  };
+}
+
 /**
  * Tracks which budget-alert rule_ids the user has dismissed for a given month.
  * Persisted in localStorage, scoped by demo-vs-real mode and year/month so:
  * - dismissing in demo mode doesn't carry over to real data,
  * - dismissals expire naturally once the calendar moves to a new month.
+ *
+ * Backed by a module-level cache + pub-sub so all callers (bell badge,
+ * popup) reflect the same dismissed set in real time.
  */
 export function useBudgetAlertDismissals(year?: number, month?: number) {
   const { isDemoMode } = useDemoMode();
   const key = storageKey(isDemoMode, year, month);
-  const [dismissed, setDismissed] = useState<Set<number>>(() => readSet(key));
 
-  useEffect(() => {
-    setDismissed(readSet(key));
-  }, [key]);
+  const getSnapshot = useCallback(() => getCachedSet(key), [key]);
+  const dismissed = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   const isDismissed = useCallback(
     (ruleId: number) => dismissed.has(ruleId),
@@ -50,25 +80,27 @@ export function useBudgetAlertDismissals(year?: number, month?: number) {
 
   const dismiss = useCallback(
     (ruleId: number) => {
-      setDismissed((prev) => {
-        if (prev.has(ruleId)) return prev;
-        const next = new Set(prev);
-        next.add(ruleId);
-        writeSet(key, next);
-        return next;
-      });
+      const current = getCachedSet(key);
+      if (current.has(ruleId)) return;
+      const next = new Set(current);
+      next.add(ruleId);
+      setCachedSet(key, next);
     },
     [key],
   );
 
   const dismissAll = useCallback(
     (ruleIds: number[]) => {
-      setDismissed((prev) => {
-        const next = new Set(prev);
-        for (const id of ruleIds) next.add(id);
-        writeSet(key, next);
-        return next;
-      });
+      const current = getCachedSet(key);
+      let changed = false;
+      const next = new Set(current);
+      for (const id of ruleIds) {
+        if (!next.has(id)) {
+          next.add(id);
+          changed = true;
+        }
+      }
+      if (changed) setCachedSet(key, next);
     },
     [key],
   );

--- a/frontend/src/hooks/useBudgetAlerts.ts
+++ b/frontend/src/hooks/useBudgetAlerts.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { budgetApi, type BudgetAlertsResponse } from "../services/api";
+
+/**
+ * Fetch the current month's budget alerts (rules at >=80% spend by default).
+ * Used by the sidebar bell badge and the alerts popup.
+ */
+export function useBudgetAlerts() {
+  return useQuery<BudgetAlertsResponse>({
+    queryKey: ["budgetAlerts", "current"],
+    queryFn: () => budgetApi.getCurrentAlerts().then((res) => res.data),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -341,6 +341,16 @@
     "pendingRefundsFooter": "These are expenses you marked as expecting a refund",
     "addRule": "Add Rule"
   },
+  "budgetAlerts": {
+    "title": "Budget Alerts",
+    "loading": "Loading alerts...",
+    "empty": "You're on track. No budgets are over the warning threshold.",
+    "severityWarning": "Warning",
+    "severityCritical": "Over Budget",
+    "dismiss": "Dismiss",
+    "dismissAll": "Dismiss all",
+    "openBudget": "Open Budget"
+  },
   "categories": {
     "title": "Categories",
     "subtitle": "Manage your categories and tags",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -341,6 +341,16 @@
     "pendingRefundsFooter": "אלו הוצאות שסימנת כמצפות להחזר",
     "addRule": "הוסף כלל"
   },
+  "budgetAlerts": {
+    "title": "התראות תקציב",
+    "loading": "טוען התראות...",
+    "empty": "הכל תחת שליטה. אין תקציב מעל סף האזהרה.",
+    "severityWarning": "אזהרה",
+    "severityCritical": "חריגה",
+    "dismiss": "הסר",
+    "dismissAll": "הסר הכל",
+    "openBudget": "פתח תקציב"
+  },
   "categories": {
     "title": "קטגוריות",
     "subtitle": "נהל את הקטגוריות והתגיות שלך",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -90,7 +90,28 @@ export const budgetApi = {
     }),
   deleteProject: (name: string) =>
     api.delete(`/budget/projects/${encodeURIComponent(name)}`),
+  getCurrentAlerts: (threshold?: number) =>
+    api.get("/budget/alerts", {
+      params: threshold !== undefined ? { threshold } : undefined,
+    }),
 };
+
+export interface BudgetAlert {
+  rule_id: number;
+  name: string;
+  category: string;
+  tags: string[];
+  amount: number;
+  spent: number;
+  percentage: number;
+  severity: "warning" | "critical";
+}
+
+export interface BudgetAlertsResponse {
+  year: number;
+  month: number;
+  alerts: BudgetAlert[];
+}
 
 // Tagging API
 export type Operator =

--- a/index.py
+++ b/index.py
@@ -1,12 +1,12 @@
 """Vercel serverless entry point for Finance Analysis API.
 
 Vercel natively supports FastAPI — it auto-detects the `app` variable.
-No Mangum adapter needed. Seeds the demo database into /tmp on cold start
-and forces demo mode so preview deployments use sample data.
+No Mangum adapter needed. On cold start we seed the demo database into /tmp,
+shift its dates so the data tracks today, and force demo mode so preview
+deployments are stocked with sample data.
 """
 
 import os
-import shutil
 
 # CRITICAL: Set env vars BEFORE any backend imports.
 # AppConfig._base_user_dir is evaluated at class-definition time from FAD_USER_DIR.
@@ -27,61 +27,26 @@ else:
     )
 os.environ.setdefault("VERCEL", "1")
 
-# Seed demo DB into /tmp before app startup
-_demo_src = os.path.join(os.path.dirname(__file__), "backend", "resources", "demo_data.db")
-_demo_dst = "/tmp/finance-analysis/demo_env/demo_data.db"
-if not os.path.exists(_demo_dst):
-    os.makedirs(os.path.dirname(_demo_dst), exist_ok=True)
-    shutil.copy2(_demo_src, _demo_dst)
-
 from backend.config import AppConfig  # noqa: E402
+from backend.demo_setup import prepare_demo_database  # noqa: E402
 
 config = AppConfig()
 config.set_demo_mode(True)
 
-# Create any missing tables in the demo DB (e.g. insurance_transactions
-# added after the demo DB was built). Safe — only creates missing tables.
-from backend.database import get_engine  # noqa: E402
-from backend.models import Base  # noqa: E402
-
-_engine = get_engine()
-Base.metadata.create_all(bind=_engine)
-
-
-def _ensure_columns(engine, table: str, columns: dict[str, str]) -> None:
-    """Add columns to ``table`` if they are absent.
-
-    The demo DB is a frozen binary shipped in the repo. When a migration adds
-    a new column to an existing table, ``create_all`` above does not touch
-    it, so reads fail with ``no such column``. This helper bridges the gap
-    for each cold start.
-    """
-    from sqlalchemy import inspect, text
-
-    inspector = inspect(engine)
-    if table not in inspector.get_table_names():
-        return
-    existing = {c["name"] for c in inspector.get_columns(table)}
-    with engine.begin() as conn:
-        for name, ddl in columns.items():
-            if name not in existing:
-                conn.execute(text(f"ALTER TABLE {table} ADD COLUMN {name} {ddl}"))
-
-
-_ensure_columns(_engine, "investments", {"insurance_policy_id": "VARCHAR"})
-_ensure_columns(_engine, "insurance_accounts", {"custom_name": "VARCHAR"})
+# Copy the frozen demo DB into /tmp, sync any missing schema, and shift every
+# date column to be relative to today. Without this step the demo data stays
+# anchored to DEMO_REFERENCE_DATE (Feb 2026) — current-month features like
+# budget alerts then have nothing to fire against.
+prepare_demo_database()
 
 # Backfill hishtalmut investments. The frozen demo DB was built before the
 # auto-sync from insurance accounts existed, so its three hishtalmut policies
 # have no linked Investment records. Idempotent (matches by policy_id).
-from backend.config import AppConfig as _AppConfig  # noqa: E402
+from backend.database import get_db_context  # noqa: E402
+from backend.services.investments_service import InvestmentsService  # noqa: E402
 
-if _AppConfig().is_demo_mode:
-    from backend.database import get_db_context  # noqa: E402
-    from backend.services.investments_service import InvestmentsService  # noqa: E402
-
-    with get_db_context() as _db:
-        InvestmentsService(_db).backfill_from_insurance_accounts()
+with get_db_context() as _db:
+    InvestmentsService(_db).backfill_from_insurance_accounts()
 
 # Vercel auto-detects this `app` variable as the FastAPI application.
 # lifespan is skipped (VERCEL env var guard) because it imports keyring.

--- a/tests/backend/routes/test_budget_routes.py
+++ b/tests/backend/routes/test_budget_routes.py
@@ -159,6 +159,64 @@ class TestBudgetRoutes:
         assert isinstance(data["rules"], list)
         assert len(data["rules"]) > 0
 
+    def test_get_month_alerts(
+        self, test_client, seed_base_transactions, monkeypatch
+    ):
+        """GET /api/budget/alerts/{year}/{month} returns alerts payload."""
+        monkeypatch.setattr(
+            "backend.services.tagging_service._categories_cache",
+            SAMPLE_CATEGORIES,
+        )
+        # Seed a tight Food budget that will be tripped by Jan 2024 transactions.
+        test_client.post(
+            "/api/budget/rules",
+            json={
+                "name": "Total Budget",
+                "amount": 10000.0,
+                "category": "Total Budget",
+                "tags": ["all_tags"],
+                "year": 2024,
+                "month": 1,
+            },
+        )
+        test_client.post(
+            "/api/budget/rules",
+            json={
+                "name": "Food",
+                "amount": 200.0,
+                "category": "Food",
+                "tags": ["all_tags"],
+                "year": 2024,
+                "month": 1,
+            },
+        )
+
+        response = test_client.get("/api/budget/alerts/2024/1")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["year"] == 2024
+        assert data["month"] == 1
+        assert isinstance(data["alerts"], list)
+        assert len(data["alerts"]) == 1
+        food_alert = data["alerts"][0]
+        assert food_alert["category"] == "Food"
+        assert food_alert["severity"] == "critical"
+
+    def test_get_current_month_alerts_returns_payload(
+        self, test_client, monkeypatch
+    ):
+        """GET /api/budget/alerts returns current-month payload, even when empty."""
+        monkeypatch.setattr(
+            "backend.services.tagging_service._categories_cache",
+            SAMPLE_CATEGORIES,
+        )
+        response = test_client.get("/api/budget/alerts")
+        assert response.status_code == 200
+        data = response.json()
+        assert "year" in data
+        assert "month" in data
+        assert data["alerts"] == []
+
     def test_get_projects(self, test_client, seed_project_transactions):
         """GET /api/budget/projects returns project names."""
         response = test_client.get("/api/budget/projects")

--- a/tests/backend/unit/services/test_budget_service.py
+++ b/tests/backend/unit/services/test_budget_service.py
@@ -410,6 +410,148 @@ class TestMonthlyBudgetService:
         assert jan_rules_after.empty
 
 
+class TestMonthlyBudgetServiceAlerts:
+    """Tests for MonthlyBudgetService.get_alerts (in-app budget alerts)."""
+
+    def _seed_food_only(self, service, food_amount: float) -> None:
+        service.add_rule(
+            name=TOTAL_BUDGET,
+            amount=10000.0,
+            category=TOTAL_BUDGET,
+            tags=[ALL_TAGS],
+            month=1,
+            year=2024,
+        )
+        service.add_rule(
+            name="Food",
+            amount=food_amount,
+            category="Food",
+            tags=[ALL_TAGS],
+            month=1,
+            year=2024,
+        )
+
+    def test_get_alerts_returns_empty_when_no_rules(self, db_session):
+        """Verify empty list when the month has no budget rules."""
+        service = MonthlyBudgetService(db_session)
+        assert service.get_alerts(2024, 1) == []
+
+    def test_get_alerts_below_threshold_returns_empty(
+        self, db_session, seed_base_transactions
+    ):
+        """Verify rules under the warning threshold do not appear."""
+        service = MonthlyBudgetService(db_session)
+        # Jan 2024 Food spend is 245.0; against a 5000 budget that's 4.9%.
+        self._seed_food_only(service, food_amount=5000.0)
+        assert service.get_alerts(2024, 1) == []
+
+    def test_get_alerts_warning_severity(
+        self, db_session, seed_base_transactions
+    ):
+        """Verify rules between threshold and 100% are tagged as 'warning'."""
+        service = MonthlyBudgetService(db_session)
+        # Jan 2024 Food spend is 245.0; budget 280 -> 87.5% -> warning.
+        self._seed_food_only(service, food_amount=280.0)
+        alerts = service.get_alerts(2024, 1)
+        assert len(alerts) == 1
+        food = alerts[0]
+        assert food["category"] == "Food"
+        assert food["spent"] == 245.0
+        assert food["amount"] == 280.0
+        assert food["severity"] == "warning"
+        assert 0.8 <= food["percentage"] < 1.0
+
+    def test_get_alerts_critical_severity(
+        self, db_session, seed_base_transactions
+    ):
+        """Verify rules at or above 100% spend are tagged as 'critical'."""
+        service = MonthlyBudgetService(db_session)
+        # Jan 2024 Food spend 245.0; budget 200 -> 122.5% -> critical.
+        self._seed_food_only(service, food_amount=200.0)
+        alerts = service.get_alerts(2024, 1)
+        assert len(alerts) == 1
+        assert alerts[0]["severity"] == "critical"
+        assert alerts[0]["percentage"] >= 1.0
+
+    def test_get_alerts_excludes_total_budget_and_other_expenses(
+        self, db_session, seed_base_transactions
+    ):
+        """Verify Total Budget and the 'Other Expenses' pseudo-rule are excluded.
+
+        Total Budget rolls up other categories (would double-count) and
+        Other Expenses has no user-set amount.
+        """
+        service = MonthlyBudgetService(db_session)
+        # Tiny Total Budget so it would otherwise be tripped.
+        service.add_rule(
+            name=TOTAL_BUDGET,
+            amount=100.0,
+            category=TOTAL_BUDGET,
+            tags=[ALL_TAGS],
+            month=1,
+            year=2024,
+        )
+        service.add_rule(
+            name="Food",
+            amount=10000.0,  # well under threshold so Food is not tripped
+            category="Food",
+            tags=[ALL_TAGS],
+            month=1,
+            year=2024,
+        )
+        alerts = service.get_alerts(2024, 1)
+        assert all(a["category"] not in (TOTAL_BUDGET, "Other Expenses") for a in alerts)
+
+    def test_get_alerts_sorted_by_percentage_desc(
+        self, db_session, seed_base_transactions
+    ):
+        """Verify alerts are returned sorted by severity (most over first)."""
+        service = MonthlyBudgetService(db_session)
+        service.add_rule(
+            name=TOTAL_BUDGET,
+            amount=10000.0,
+            category=TOTAL_BUDGET,
+            tags=[ALL_TAGS],
+            month=1,
+            year=2024,
+        )
+        # Food: 245 / 250 = 98% (warning)
+        service.add_rule(
+            name="Food",
+            amount=250.0,
+            category="Food",
+            tags=[ALL_TAGS],
+            month=1,
+            year=2024,
+        )
+        # Home: 3000 / 1500 = 200% (critical)
+        service.add_rule(
+            name="Home",
+            amount=1500.0,
+            category="Home",
+            tags=[ALL_TAGS],
+            month=1,
+            year=2024,
+        )
+        alerts = service.get_alerts(2024, 1)
+        assert len(alerts) == 2
+        assert alerts[0]["category"] == "Home"
+        assert alerts[1]["category"] == "Food"
+
+    def test_get_alerts_custom_threshold(
+        self, db_session, seed_base_transactions
+    ):
+        """Verify the threshold parameter overrides the 80% default."""
+        service = MonthlyBudgetService(db_session)
+        # Food: 245 / 500 = 49%. With default 80% threshold -> no alert.
+        # With threshold 0.4 -> alert.
+        self._seed_food_only(service, food_amount=500.0)
+        assert service.get_alerts(2024, 1) == []
+        alerts = service.get_alerts(2024, 1, warning_threshold=0.4)
+        assert len(alerts) == 1
+        assert alerts[0]["category"] == "Food"
+
+
 class TestProjectBudgetService:
     """Tests for ProjectBudgetService functionality."""
 


### PR DESCRIPTION
Adds a passive bell icon in the sidebar (desktop bottom area + mobile top bar)
that surfaces budget rules at >=80% spend for the current month. Clicking opens
a popup listing tripped budgets with severity (warning / over-budget), a
progress bar, and per-alert and bulk dismiss buttons.

Backend: new MonthlyBudgetService.get_alerts() reuses get_monthly_budget_view,
excluding the Total Budget rule (would double-count) and the auto-generated
"Other Expenses" pseudo-rule. Exposed via GET /api/budget/alerts (current
month) and GET /api/budget/alerts/{year}/{month}.

Frontend: alerts query is shared via useBudgetAlerts; dismissals are stored in
localStorage scoped by demo-vs-real mode and year/month, so dismissing in demo
mode doesn't bleed into real data and dismissals expire naturally each month.
This is what keeps Vercel PR-preview QA pleasant: alerts are reachable for
testing in demo mode but a single "Dismiss all" hides them for the rest of the
QA session.

Tests: 7 new unit tests for get_alerts (severity tiers, threshold, exclusions,
sort order) and 2 new route tests.