### PR TITLE
fix(dashboard): keep inline tag panel open after category/tag selection

### DIFF
--- a/.claude/rules/frontend_components.md
+++ b/.claude/rules/frontend_components.md
@@ -86,6 +86,66 @@ const mutation = useMutation({
 ```
 **Always add `onSuccess` invalidation** — missing it means the UI won't refresh after mutations.
 
+#### Don't fan out invalidation in mutation hot paths
+
+`queryClient.invalidateQueries()` with no args marks every cached
+query stale and refetches every active observer. The dashboard alone
+has ~12 active queries; firing that on every keystroke or every
+dropdown change saturates the mobile HTTP/1.1 connection pool, makes
+the next user interaction feel frozen, and can leave subsequent
+mutations queued behind in-flight refetches (we hit this exact bug
+in the dashboard inline tag editor — a tap on the tag dropdown after
+a category change couldn't reach the backend until the previous
+invalidation cascade drained).
+
+When a mutation's effect on the UI is local and predictable, prefer:
+
+1. A narrow `setQueryData` / `setQueriesData` patch keyed by the
+   same identifier the row uses for its React key. The visible row
+   updates synchronously, no refetch needed.
+2. `invalidateQueries({ queryKey: [<specific key>] })` for the
+   handful of derived queries that genuinely changed (analytics,
+   aggregates, etc.).
+3. Reserve `invalidateQueries()` (no args) for explicit "I just
+   imported a backup, refresh everything" flows.
+
+The shared `MutationCache.onSuccess` in `queryClient.ts` already
+runs a debounced full invalidation on every mutation. **You do not
+need to add another one.** Anything you add on top is pure overhead
+on the hot path.
+
+### Multi-field inline editors: stage locally, commit on Done
+
+Inline editors with two or more correlated fields (e.g. category +
+tag, where the tag's options depend on the chosen category) **must
+not** fire a mutation per dropdown change. Treat each editing
+session as one atomic edit:
+
+- Hold the in-flight selections in local `useState`
+  (`stagedCategory`, `stagedTag`, …) initialised from the row's
+  current values when the editor opens.
+- Bind each `SelectDropdown`'s `value` and `onChange` to the staged
+  state, not to the underlying row data. Dependent dropdowns
+  (e.g. tag options) derive from the staged value, not the row.
+- The row underneath stays visually unchanged during the session —
+  no icon flips, no label rewrites, no progress bars jumping.
+- A primary "Done" / "Save" button fires a single mutation with
+  the staged values and closes the editor. If nothing changed,
+  skip the mutation entirely.
+- Re-opening the editor on a different row, or tapping the toggle
+  again, discards the staged values.
+
+`RecentTransactionsSection.tsx` is the canonical reference. The
+prior per-selection-mutation design was responsible for: the icon
+flipping mid-edit, the editor feeling laggy on mobile, the Done
+button occasionally eating taps, and the second mutation in a
+chained edit failing to reach the backend on HTTP/1.1.
+
+Per-field auto-commit is acceptable **only** for genuinely
+single-field controls — a toggle, a debounced search input, a
+standalone slider — where there's no dependent state and no
+"halfway through" intermediate state for the user to be in.
+
 ### Currency Formatting
 Always use the shared utility:
 ```tsx

--- a/.claude/rules/frontend_pitfalls.md
+++ b/.claude/rules/frontend_pitfalls.md
@@ -124,6 +124,25 @@ const mutation = useMutation({
 ```
 Missing `onSuccess` invalidation = UI doesn't refresh after the mutation.
 
+### But don't fan out — narrow keys + setQueryData patches
+The flip side: `queryClient.invalidateQueries()` with no args
+refetches every active query and saturates the mobile HTTP/1.1
+connection pool. Prefer narrow keys
+(`{ queryKey: ["specific"] }`) and synchronous `setQueriesData`
+patches for local effects. The shared `MutationCache.onSuccess`
+already runs a debounced global sweep — you don't need to add
+another one. See `frontend_components.md` →
+"Don't fan out invalidation in mutation hot paths".
+
+### Multi-field inline editors stage and commit on Done
+Editors with two or more correlated fields (category + tag,
+amount + currency, etc.) must NOT fire a mutation per dropdown
+change. Stage selections in local `useState` and commit once on
+Done. See `frontend_components.md` →
+"Multi-field inline editors: stage locally, commit on Done" for
+the canonical pattern and the list of bugs the
+per-selection-mutation design produced.
+
 ## Key Generation in Lists
 
 ### Stable, Unique Keys

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -162,4 +162,41 @@ poetry run pytest tests/backend/integration/           # integration tests only
 poetry run pytest -k "test_budget"                     # by keyword
 ```
 
+## Verifying UI patches with Playwright (REQUIRED)
+
+For any UI fix — **including small, "obvious" patches** like one-line state
+changes, focus tweaks, event handler edits, dropdown/modal behavior — do not
+ship the change with only type-checking and reasoning. Reasoning misses cases
+that a real browser surfaces immediately (stale closures, focus traps, layout
+shifts from the soft keyboard, click-outside handlers eating taps, query
+invalidations remounting components mid-interaction).
+
+**Before claiming a UI fix is resolved, you MUST:**
+
+1. Start the dev servers (`python .claude/scripts/with_server.py -- <cmd>`
+   or backend + frontend manually).
+2. Drive the actual user flow with the Playwright MCP — open the page,
+   enable Demo Mode (Settings → Demo Mode toggle, see CLAUDE.md), and
+   reproduce the exact interaction the user reported.
+3. Confirm the broken behavior **and** that your patch makes it work
+   end-to-end, not just that the affected component renders. Click through
+   every step of the original repro.
+4. Add a Playwright e2e spec under `frontend/e2e/` covering the flow so
+   the regression can't return silently. The spec uses Demo Mode and the
+   helpers in `frontend/e2e/helpers.ts`. Run it once locally
+   (`cd frontend && npx playwright test e2e/<file>.spec.ts`).
+
+**Never** mark a UI patch resolved on the strength of a one-line code change
+plus `tsc -b`. The bug, by definition, was something static analysis missed.
+
+**E2E test conventions:**
+- Place specs under `frontend/e2e/<feature>.spec.ts`.
+- Wrap related cases in `test.describe(...)`. Toggle Demo Mode in
+  `beforeAll` / `afterAll` using `enableDemoMode` / `disableDemoMode`.
+- Prefer role-based locators (`getByRole("button", { name: ... })`,
+  `getByRole("option")`) over CSS selectors — they survive markup churn.
+- For inline editors / popovers / dropdowns, assert that the panel stays
+  open across mutations when it should, and that the displayed value
+  updates after each selection.
+
 > When changing test structure, naming conventions, or global fixtures, update this rule file.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,11 +14,7 @@
       "Bash(until curl -fs http://localhost:8000/docs > /dev/null 2>&1)",
       "Bash(git add *)",
       "Bash(poetry run uvicorn backend.main:app --port 8000 *)",
-      "mcp__plugin_playwright_playwright__browser_navigate",
-      "mcp__plugin_playwright_playwright__browser_resize",
-      "mcp__plugin_playwright_playwright__browser_snapshot",
-      "mcp__plugin_playwright_playwright__browser_take_screenshot",
-      "mcp__plugin_playwright_playwright__browser_wait_for"
+      "mcp__plugin_playwright_playwright__*"
     ],
     "additionalDirectories": []
   },

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,8 @@ $RECYCLE.BIN/
 .claude/worktrees/
 .vercel
 .env*.local
+
+# Playwright artifacts (MCP screenshots, runner reports/traces)
+.playwright-mcp/
+frontend/playwright-report/
+frontend/test-results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,13 @@ Routes (FastAPI) -> Services (Business Logic) -> Repositories (Data Access) -> S
 
 When smoke-testing UI changes in the browser, **enable Demo Mode first** (toggle in the top-right header). Demo Mode switches the backend to a separate demo database with pre-built sample data, so real financial data is not accidentally modified. Remember to disable it when done.
 
+**REQUIRED for every UI patch (including small ones):** Drive the actual user
+flow with the Playwright MCP before marking the fix resolved, and add an e2e
+spec under `frontend/e2e/`. Type-checking and reasoning miss the bugs UI
+patches usually contain (focus traps, click-outside handlers, keyboard-induced
+reposition, query invalidation remounting). Full procedure in
+`.claude/rules/testing.md` → "Verifying UI patches with Playwright".
+
 ## Scraper Framework
 
 The `scraper/` package at the project root is a pure-Python scraper framework using Playwright and httpx, replacing the old Node.js integration. It provides:

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -43,21 +43,26 @@ test.describe("Dashboard", () => {
     await expect(page.getByText(/Budget Progress/i)).toBeVisible();
   });
 
-  test("inline tag editor stays open across category and tag selection", async ({ page }) => {
+  test("inline tag editor stages edits and commits on Done", async ({ page }) => {
     await page.goto("/");
     await page.waitForLoadState("networkidle");
     await expect(page.getByText(/Recent Transactions/i)).toBeVisible({ timeout: 15_000 });
 
     const editButtons = page.getByRole("button", { name: /Edit category \/ tag/i });
     await editButtons.first().waitFor();
+    const targetRow = editButtons.first().locator("xpath=ancestor::*[contains(@class,'cursor-pointer')][1]");
+    const rowTextBefore = (await targetRow.textContent())?.trim() ?? "";
     await editButtons.first().click();
 
     const panel = page.locator("text=CATEGORY").locator("..").locator("..");
     await expect(panel).toBeVisible();
 
     const categorySelect = panel.getByRole("button").nth(0);
+    const tagSelect = panel.getByRole("button").nth(1);
+    const doneBtn = panel.getByRole("button", { name: /done/i });
     const initialCategory = (await categorySelect.textContent())?.trim() ?? "";
 
+    // Pick a different category — staged, NOT committed yet.
     await categorySelect.click();
     const newCategory = page
       .getByRole("option")
@@ -66,17 +71,23 @@ test.describe("Dashboard", () => {
     const newCategoryName = (await newCategory.textContent())?.trim() ?? "";
     await newCategory.click();
 
+    // Editor reflects the staged value, but the row underneath has not changed.
     await expect(panel).toBeVisible();
     await expect(categorySelect).toHaveText(new RegExp(newCategoryName));
+    expect((await targetRow.textContent())?.trim()).toBe(rowTextBefore);
 
-    const tagSelect = panel.getByRole("button").nth(1);
+    // Pick a tag (also staged).
     await tagSelect.click();
     const tagOption = page.getByRole("option").first();
     const tagName = (await tagOption.textContent())?.trim() ?? "";
+    if (tagName) await tagOption.click();
+
+    // Done commits and closes the editor; row label now reflects the new
+    // category/tag and the panel is gone.
+    await doneBtn.click();
+    await expect(panel).toBeHidden();
     if (tagName) {
-      await tagOption.click();
-      await expect(panel).toBeVisible();
-      await expect(tagSelect).toHaveText(new RegExp(tagName));
+      await expect(targetRow).toContainText(new RegExp(`${newCategoryName} / ${tagName}`));
     }
   });
 });

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -42,4 +42,41 @@ test.describe("Dashboard", () => {
     await page.goto("/");
     await expect(page.getByText(/Budget Progress/i)).toBeVisible();
   });
+
+  test("inline tag editor stays open across category and tag selection", async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByText(/Recent Transactions/i)).toBeVisible({ timeout: 15_000 });
+
+    const editButtons = page.getByRole("button", { name: /Edit category \/ tag/i });
+    await editButtons.first().waitFor();
+    await editButtons.first().click();
+
+    const panel = page.locator("text=CATEGORY").locator("..").locator("..");
+    await expect(panel).toBeVisible();
+
+    const categorySelect = panel.getByRole("button").nth(0);
+    const initialCategory = (await categorySelect.textContent())?.trim() ?? "";
+
+    await categorySelect.click();
+    const newCategory = page
+      .getByRole("option")
+      .filter({ hasNotText: new RegExp(`^${initialCategory}$`) })
+      .first();
+    const newCategoryName = (await newCategory.textContent())?.trim() ?? "";
+    await newCategory.click();
+
+    await expect(panel).toBeVisible();
+    await expect(categorySelect).toHaveText(new RegExp(newCategoryName));
+
+    const tagSelect = panel.getByRole("button").nth(1);
+    await tagSelect.click();
+    const tagOption = page.getByRole("option").first();
+    const tagName = (await tagOption.textContent())?.trim() ?? "";
+    if (tagName) {
+      await tagOption.click();
+      await expect(panel).toBeVisible();
+      await expect(tagSelect).toHaveText(new RegExp(tagName));
+    }
+  });
 });

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,42 +1,45 @@
 import { type Page, expect } from "@playwright/test";
 
 /**
- * Enable Demo Mode via the UI toggle in the header.
- * Must be called at the start of each test suite to ensure
- * tests run against the demo database with sample data.
+ * Open the Settings popup (sidebar Settings button) and toggle Demo Mode.
+ * Used by both enable/disable helpers — Demo Mode lives inside the Settings
+ * popup, not directly in the sidebar, so we must open the popup first.
  */
-export async function enableDemoMode(page: Page) {
-  // Navigate to the app
+async function toggleDemoMode(page: Page, expectedAfter: "on" | "off") {
   await page.goto("/");
   await page.waitForLoadState("networkidle");
-
-  // Check if demo mode is already active
-  const demoIndicator = page.locator("text=Demo Mode");
-  if (await demoIndicator.isVisible().catch(() => false)) {
-    return; // Already in demo mode
+  await page.getByRole("button", { name: /^settings$/i }).click();
+  const toggleRow = page.getByText(/^Demo Mode$/);
+  await toggleRow.waitFor();
+  // Read current state from background color of the inner switch indicator
+  const isOn = await page.evaluate(() => {
+    const labels = Array.from(document.querySelectorAll("*"));
+    const row = labels.find((el) => el.textContent?.trim() === "Demo Mode");
+    if (!row) return null;
+    const switchEl = row.parentElement?.querySelector('[class*="amber"]');
+    return !!switchEl;
+  });
+  if ((expectedAfter === "on" && !isOn) || (expectedAfter === "off" && isOn)) {
+    await toggleRow.click();
   }
+  // Click somewhere else to dismiss the settings popup, then wait for reload.
+  await page.keyboard.press("Escape");
+  await page.waitForLoadState("networkidle");
+}
 
-  // Find and click the demo mode toggle in the header
-  const demoToggle = page.getByRole("button", { name: /demo/i });
-  if (await demoToggle.isVisible().catch(() => false)) {
-    await demoToggle.click();
-    // Wait for the page to reload with demo data
-    await page.waitForLoadState("networkidle");
-  }
+/**
+ * Enable Demo Mode via the Settings popup. Must be called at the start of
+ * each test suite to ensure tests run against the demo database.
+ */
+export async function enableDemoMode(page: Page) {
+  await toggleDemoMode(page, "on");
 }
 
 /**
  * Disable Demo Mode after tests complete.
  */
 export async function disableDemoMode(page: Page) {
-  await page.goto("/");
-  await page.waitForLoadState("networkidle");
-
-  const demoToggle = page.getByRole("button", { name: /demo/i });
-  if (await demoToggle.isVisible().catch(() => false)) {
-    await demoToggle.click();
-    await page.waitForLoadState("networkidle");
-  }
+  await toggleDemoMode(page, "off");
 }
 
 /**

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -29,7 +29,12 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+          ? { launchOptions: { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH } }
+          : {}),
+      },
     },
   ],
 });

--- a/frontend/src/components/common/SelectDropdown.tsx
+++ b/frontend/src/components/common/SelectDropdown.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { createPortal } from "react-dom";
 import { ChevronDown, Check, Search, Plus, X } from "lucide-react";
+import { isTouchDevice } from "../../utils/plotlyLocale";
 
 interface SelectDropdownProps {
   options: { label: string; value: string }[];
@@ -75,7 +76,7 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
     }
     updatePosition();
     requestAnimationFrame(() => {
-      if (showSearch) {
+      if (showSearch && !isTouchDevice) {
         searchRef.current?.focus();
       } else {
         dropdownRef.current?.focus();

--- a/frontend/src/components/dashboard/RecentTransactionsSection.tsx
+++ b/frontend/src/components/dashboard/RecentTransactionsSection.tsx
@@ -46,9 +46,36 @@ export function RecentTransactionsFeed({
   const [visibleCount, setVisibleCount] = useState(TRANSACTIONS_PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [editingTxKey, setEditingTxKey] = useState<string | null>(null);
+  const [stagedCategory, setStagedCategory] = useState<string>("");
+  const [stagedTag, setStagedTag] = useState<string>("");
   const [mobileActionsTxKey, setMobileActionsTxKey] = useState<string | null>(null);
   const [splittingTransaction, setSplittingTransaction] = useState<Transaction | null>(null);
   const [linkingTransaction, setLinkingTransaction] = useState<Transaction | null>(null);
+
+  const txKeyOf = (tx: Transaction) =>
+    `${tx.source}_${tx.unique_id ?? tx.id ?? `${tx.date}-${tx.amount}`}`;
+
+  const openEditor = (tx: Transaction) => {
+    setStagedCategory(tx.category || "");
+    setStagedTag(tx.tag || "");
+    setEditingTxKey(txKeyOf(tx));
+  };
+
+  const closeEditor = () => {
+    setEditingTxKey(null);
+    setStagedCategory("");
+    setStagedTag("");
+  };
+
+  const commitEdit = (tx: Transaction) => {
+    const currentTag = tx.tag || "";
+    const changed =
+      stagedCategory !== (tx.category || "") || stagedTag !== currentTag;
+    if (changed) {
+      tagMutation.mutate({ tx, category: stagedCategory, tag: stagedTag });
+    }
+    closeEditor();
+  };
 
   // Categories for inline tag editing
   const { data: categories } = useCategories({ enabled: !!editingTxKey });
@@ -162,15 +189,12 @@ export function RecentTransactionsFeed({
     return groups;
   }, [visible]);
 
-  const getTxKey = (tx: Transaction) =>
-    `${tx.source}_${tx.unique_id ?? tx.id ?? `${tx.date}-${tx.amount}`}`;
-
   // Precompute which tagging rule matches each visible transaction
   const ruleMatchMap = useMemo(() => {
     if (!taggingRules || !visible.length) return new Map<string, TaggingRule>();
     const map = new Map<string, TaggingRule>();
     for (const tx of visible) {
-      const key = getTxKey(tx);
+      const key = txKeyOf(tx);
       const match = findMatchingRule(taggingRules, tx);
       if (match) map.set(key, match);
     }
@@ -215,7 +239,7 @@ export function RecentTransactionsFeed({
               {group.items.map((tx) => {
                 const icon = tx.category ? categoryIcons?.[tx.category] ?? "" : "";
                 const isPositive = tx.amount >= 0;
-                const txKey = getTxKey(tx);
+                const txKey = txKeyOf(tx);
                 const isEditing = editingTxKey === txKey;
                 const matchedRule = ruleMatchMap.get(txKey);
 
@@ -257,7 +281,7 @@ export function RecentTransactionsFeed({
                         <button
                           className={`w-[32px] h-[32px] flex items-center justify-center rounded-md transition-colors ${isEditing ? "bg-[var(--primary)]/20 text-[var(--primary)]" : "text-[var(--text-muted)]/40 hover:text-white hover:bg-[var(--surface-light)]"}`}
                           title={t("tooltips.editCategoryTag")}
-                          onClick={() => setEditingTxKey(isEditing ? null : txKey)}
+                          onClick={() => (isEditing ? closeEditor() : openEditor(tx))}
                         >
                           <Tag size={13} />
                         </button>
@@ -308,7 +332,7 @@ export function RecentTransactionsFeed({
                       <div className="sm:hidden flex items-center gap-1.5 mx-2 mb-1 ms-9 p-1.5 rounded-lg bg-[var(--surface-light)]/40 border border-[var(--surface-light)] animate-in fade-in slide-in-from-top-1 duration-150">
                         <button
                           className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium transition-colors ${isEditing ? "bg-[var(--primary)]/20 text-[var(--primary)]" : "text-[var(--text-muted)] hover:text-white hover:bg-[var(--surface-light)]"}`}
-                          onClick={(e) => { e.stopPropagation(); setEditingTxKey(isEditing ? null : txKey); }}
+                          onClick={(e) => { e.stopPropagation(); if (isEditing) closeEditor(); else openEditor(tx); }}
                         >
                           <Tag size={13} className="shrink-0" />
                           {t("common.tag")}
@@ -348,7 +372,10 @@ export function RecentTransactionsFeed({
                       </div>
                     )}
 
-                    {/* Inline tag editing panel */}
+                    {/* Inline tag editing panel — selections are staged in
+                        local state and only committed when the user taps Done.
+                        This keeps the row's icon/label stable during editing
+                        and avoids firing a mutation per dropdown change. */}
                     {isEditing && categories && (
                       <div className="mx-2 mb-2 ms-11 rounded-lg border border-[var(--surface-light)] bg-[var(--surface-light)]/20 overflow-hidden">
                         <div className="flex items-center gap-3 px-3 py-2">
@@ -356,8 +383,13 @@ export function RecentTransactionsFeed({
                             <label className="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1 block">{t("common.category")}</label>
                             <SelectDropdown
                               options={Object.keys(categories).map((c) => ({ label: c, value: c }))}
-                              value={tx.category || ""}
-                              onChange={(cat) => tagMutation.mutate({ tx, category: cat, tag: "" })}
+                              value={stagedCategory}
+                              onChange={(cat) => {
+                                setStagedCategory(cat);
+                                if (stagedTag && !(categories[cat] || []).includes(stagedTag)) {
+                                  setStagedTag("");
+                                }
+                              }}
                               placeholder={t("common.select")}
                               size="sm"
                               onCreateNew={async (name) => { await createCategory(name); }}
@@ -367,24 +399,24 @@ export function RecentTransactionsFeed({
                             <label className="text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1 block">{t("common.tag")}</label>
                             <SelectDropdown
                               options={
-                                tx.category && categories[tx.category]
-                                  ? categories[tx.category].map((tagName: string) => ({ label: tagName, value: tagName }))
+                                stagedCategory && categories[stagedCategory]
+                                  ? categories[stagedCategory].map((tagName: string) => ({ label: tagName, value: tagName }))
                                   : []
                               }
-                              value={tx.tag || ""}
-                              onChange={(tag) => tagMutation.mutate({ tx, category: tx.category || "", tag })}
+                              value={stagedTag}
+                              onChange={setStagedTag}
                               placeholder={t("common.select")}
                               size="sm"
                               onCreateNew={
-                                tx.category
-                                  ? async (name) => { await createTag(tx.category!, name); }
+                                stagedCategory
+                                  ? async (name) => { await createTag(stagedCategory, name); }
                                   : undefined
                               }
                             />
                           </div>
                           <button
-                            className="self-end mb-0.5 px-2.5 py-1 text-[11px] font-medium rounded-md bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-white hover:bg-[var(--surface-light)]/80 transition-colors"
-                            onClick={() => setEditingTxKey(null)}
+                            className="self-end mb-0.5 px-2.5 py-1 text-[11px] font-medium rounded-md bg-[var(--primary)] text-white hover:bg-[var(--primary)]/90 transition-colors"
+                            onClick={() => commitEdit(tx)}
                           >
                             {t("dashboard.done")}
                           </button>

--- a/frontend/src/components/dashboard/RecentTransactionsSection.tsx
+++ b/frontend/src/components/dashboard/RecentTransactionsSection.tsx
@@ -77,7 +77,6 @@ export function RecentTransactionsFeed({
       queryClient.invalidateQueries({ queryKey: ["transactions"] });
       queryClient.invalidateQueries({ queryKey: ["categories"] });
       invalidateAnalytics();
-      setEditingTxKey(null);
     },
   });
 

--- a/frontend/src/components/dashboard/RecentTransactionsSection.tsx
+++ b/frontend/src/components/dashboard/RecentTransactionsSection.tsx
@@ -64,7 +64,13 @@ export function RecentTransactionsFeed({
     queryClient.invalidateQueries({ queryKey: ["budget-analysis"] });
   }, [queryClient]);
 
-  // Tag update mutation
+  // Tag update mutation. We patch every cached transactions list synchronously
+  // so the inline editor reflects the new category/tag immediately. Refetches
+  // can be delayed or coalesced by React Query's debounced global invalidator
+  // when many queries are active, leaving the row visibly stale despite a
+  // successful API call. The patch is keyed by (source, unique_id ?? id) which
+  // matches the row's React key, so the SelectDropdown re-renders with the new
+  // value without waiting for the network round-trip.
   const tagMutation = useMutation({
     mutationFn: ({ tx, category, tag }: { tx: Transaction; category: string; tag: string }) =>
       transactionsApi.updateTag(
@@ -73,8 +79,14 @@ export function RecentTransactionsFeed({
         tag,
         tx.source || "",
       ),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["transactions"] });
+    onSuccess: (_data, { tx, category, tag }) => {
+      const sameRow = (t: Transaction) =>
+        t.source === tx.source &&
+        (t.unique_id ?? t.id) === (tx.unique_id ?? tx.id);
+      const patchList = (old: Transaction[] | undefined) =>
+        old?.map((t) => (sameRow(t) ? { ...t, category, tag: tag || undefined } : t)) ?? old;
+      queryClient.setQueriesData<Transaction[]>({ queryKey: ["all-transactions"] }, patchList);
+      queryClient.setQueriesData<Transaction[]>({ queryKey: ["transactions"] }, patchList);
       queryClient.invalidateQueries({ queryKey: ["categories"] });
       invalidateAnalytics();
     },


### PR DESCRIPTION
The recent-transactions card auto-closed the inline edit panel on every
successful tag mutation, so users could never select a category followed
by a tag — picking the category collapsed the panel before the tag
dropdown could be opened. The "Done" button and the Tag-toggle button
already provide explicit ways to dismiss the panel.