### PR TITLE
fix(investments): resolve Sparkline NaN crash and RTL bidi-flipped percent deltas

### DIFF
--- a/.claude/rules/frontend_i18n.md
+++ b/.claude/rules/frontend_i18n.md
@@ -46,6 +46,55 @@ Wrap numeric values with `dir="ltr"` to keep them left-to-right inside RTL text:
 <span dir="ltr">{formatCurrency(amount)}</span>
 ```
 
+**This applies to every signed-number node, not just deltas.** A common
+miss: a feed row or table cell renders
+`{isPositive ? "+" : ""}{formatCurrency(...)}` with no `dir`. Negatives
+still render correctly because `formatCurrency` injects the bidi marks
+itself; positives prefix a bare `+` literal that the bidi algorithm
+reorders under RTL — `+150 ₪` next to a Hebrew description ends up
+visually scrambled. **Every numeric/currency span needs `dir="ltr"`,
+including inside `<td>`/`<th>` cells, regardless of sign.** The bug we
+keep relapsing into looks like:
+
+```tsx
+{/* WRONG */}
+<span className={isPositive ? "text-emerald-400" : "text-rose-400"}>
+  {isPositive ? "+" : ""}{formatCurrency(amount)}
+</span>
+
+{/* CORRECT */}
+<span dir="ltr" className={isPositive ? "text-emerald-400" : "text-rose-400"}>
+  {isPositive ? "+" : ""}{formatCurrency(amount)}
+</span>
+```
+
+### Truncation of user-supplied text inside RTL — use `dir="auto"`
+
+`text-overflow: ellipsis` (Tailwind's `truncate` / `line-clamp-N`) clips
+at the **end of the line in the document direction**. Under RTL that's
+the visual left. A category badge `"Transportation / Gas"` rendered
+inside an RTL container becomes `"...sportation / Gas"` — the leading
+characters are hidden because the user reads right-to-left.
+
+Fix: every `truncate`/`line-clamp` element whose **content is user
+data** (transaction descriptions, category names, account names, rule
+names, project names, notes, etc.) must add `dir="auto"`:
+
+```tsx
+{/* WRONG — clips "Transportation / Gas" to "...sportation / Gas" in RTL */}
+<span className="truncate">{tx.category}</span>
+
+{/* CORRECT — first-strong-char detection picks LTR for English content,
+    so ellipsis goes on the right; Hebrew content stays RTL with ellipsis
+    on the left. */}
+<span className="truncate" dir="auto">{tx.category}</span>
+```
+
+Translated chrome (column headers, button labels, section titles) does
+**not** need `dir="auto"` — it always matches the document direction.
+Rule of thumb: if the string came from `t(...)` it stays untagged; if
+it came from a DB column or user input, add `dir="auto"`.
+
 ## RTL Layout Rules
 
 ### Prefer Tailwind CSS 4 logical properties over physical ones:
@@ -85,6 +134,8 @@ When adding a new provider, add its display name to BOTH maps.
 1. All user-visible strings use `t("section.key")` — no hardcoded English/Hebrew
 2. Keys added to both `en.json` and `he.json`
 3. Layout uses logical CSS properties (not physical left/right)
-4. Numeric values wrapped in `dir="ltr"` spans when inside translatable text
-5. Directional icons flip based on `isRtl` check
-6. New provider/service names added to both label maps in `textFormatting.ts`
+4. Numeric / signed values wrapped in `dir="ltr"` (always, even unsigned, especially inside table cells and feed rows)
+5. `truncate` / `line-clamp` on user-supplied text gets `dir="auto"`
+6. Directional icons flip based on `isRtl` check
+7. New provider/service names added to both label maps in `textFormatting.ts`
+8. Hardcoded relative-time strings (`"5d ago"`, `"in 3 hours"`) routed through `t(...)` with `{{count}}` interpolation

--- a/.claude/rules/frontend_i18n.md
+++ b/.claude/rules/frontend_i18n.md
@@ -41,32 +41,53 @@ const isRtl = i18n.language === "he";
 ```
 
 ### Numbers/currency in Hebrew context
-Wrap numeric values with `dir="ltr"` to keep them left-to-right inside RTL text:
-```tsx
-<span dir="ltr">{formatCurrency(amount)}</span>
+
+**Israeli convention is digits-then-shekel.** `formatCurrency`,
+`formatCompactCurrency`, and `formatChange` (in
+`frontend/src/utils/numberFormatting.ts`) all emit the canonical
+**sign-magnitude-currency** layout:
+
+```
+1,003,211 ₪
+-25K ₪
++150 ₪
 ```
 
-**This applies to every signed-number node, not just deltas.** A common
-miss: a feed row or table cell renders
-`{isPositive ? "+" : ""}{formatCurrency(...)}` with no `dir`. Negatives
-still render correctly because `formatCurrency` injects the bidi marks
-itself; positives prefix a bare `+` literal that the bidi algorithm
-reorders under RTL — `+150 ₪` next to a Hebrew description ends up
-visually scrambled. **Every numeric/currency span needs `dir="ltr"`,
-including inside `<td>`/`<th>` cells, regardless of sign.** The bug we
-keep relapsing into looks like:
+Not `₪1,003,211`, not `₪ -25K`. If you find yourself prepending `₪`,
+use the helpers — don't roll your own.
+
+**The helpers are bidi-stable.** Each output is wrapped in U+2066 (LRI,
+Left-to-Right Isolate) ... U+2069 (PDI, Pop Directional Isolate) and
+uses NBSP between digits and ₪. That means the digits-then-shekel order
+survives any surrounding paragraph direction — you can drop a
+`formatCurrency(amount)` into a Hebrew sentence, an RTL `<td>`, or a
+plain text node and it will render correctly without an explicit
+`dir="ltr"` wrapper.
+
+**You still need `dir="ltr"` when you concatenate something around the
+helper output yourself.** E.g.:
 
 ```tsx
-{/* WRONG */}
-<span className={isPositive ? "text-emerald-400" : "text-rose-400"}>
-  {isPositive ? "+" : ""}{formatCurrency(amount)}
-</span>
+{/* OK — helper output is bidi-stable on its own */}
+<span>{formatCurrency(amount)}</span>
 
-{/* CORRECT */}
-<span dir="ltr" className={isPositive ? "text-emerald-400" : "text-rose-400"}>
-  {isPositive ? "+" : ""}{formatCurrency(amount)}
-</span>
+{/* OK — concatenated literal "+", needs dir="ltr" for the literal */}
+<span dir="ltr">{isPositive ? "+" : ""}{formatCurrency(amount)}</span>
+
+{/* For deltas use formatChange, which already includes the sign */}
+<span>{formatChange(delta)}</span>   {/* "+35K ₪" — bidi-stable */}
 ```
+
+The previous rule "every numeric span needs `dir="ltr"`" still applies
+when you build the string yourself (date + currency joined with `" / "`,
+hand-written `"+" + formatted`, etc.). It's just no longer needed for a
+bare helper call.
+
+**Don't inline `new Intl.NumberFormat()` in components.** It produces
+locale-dependent output that breaks the canonical layout — the
+`he-IL` locale puts ₪ after the digits without LRI/PDI, and the
+plain default locale puts it before. Either way you're back to the
+`1,003,211₪` / `-₪25K` inconsistency we keep getting bitten by.
 
 ### Truncation of user-supplied text inside RTL — use `dir="auto"`
 
@@ -134,8 +155,9 @@ When adding a new provider, add its display name to BOTH maps.
 1. All user-visible strings use `t("section.key")` — no hardcoded English/Hebrew
 2. Keys added to both `en.json` and `he.json`
 3. Layout uses logical CSS properties (not physical left/right)
-4. Numeric / signed values wrapped in `dir="ltr"` (always, even unsigned, especially inside table cells and feed rows)
-5. `truncate` / `line-clamp` on user-supplied text gets `dir="auto"`
-6. Directional icons flip based on `isRtl` check
-7. New provider/service names added to both label maps in `textFormatting.ts`
-8. Hardcoded relative-time strings (`"5d ago"`, `"in 3 hours"`) routed through `t(...)` with `{{count}}` interpolation
+4. Currency rendered through `formatCurrency` / `formatCompactCurrency` / `formatChange` — never inline `Intl.NumberFormat`. The helpers emit `<digits> ₪` and are LRI/PDI-isolated, so a bare `<span>{formatCurrency(...)}</span>` is safe under RTL
+5. Hand-built numeric strings (concatenation, literal `+`/`-` outside the helpers, date + currency joined manually) still need a `dir="ltr"` wrapper
+6. `truncate` / `line-clamp` on user-supplied text gets `dir="auto"`
+7. Directional icons flip based on `isRtl` check
+8. New provider/service names added to both label maps in `textFormatting.ts`
+9. Hardcoded relative-time strings (`"5d ago"`, `"in 3 hours"`) routed through `t(...)` with `{{count}}` interpolation

--- a/.claude/rules/frontend_i18n_checklist.md
+++ b/.claude/rules/frontend_i18n_checklist.md
@@ -80,6 +80,17 @@ grep -rn 'aria-label="[A-Za-z][^"]*"' frontend/src/pages/ frontend/src/component
 
 # Hardcoded confirm/alert dialogs:
 grep -rn 'window\.\(confirm\|alert\)("[A-Za-z]' frontend/src/
+
+# Hardcoded relative-time strings ("5d ago", "in 3 hours", "2h ago"):
+grep -rEn '`\$\{[^}]+\}d ago|d ago\)\b|h ago\)\b|min ago\)\b' frontend/src/
+
+# Truncate on user data without dir="auto" (heuristic):
+grep -rEn 'className="[^"]*\b(truncate|line-clamp)\b[^"]*"' frontend/src/ \
+  | grep -v 'dir="auto"' | grep -v 'dir="ltr"'
+
+# Signed-number rendering without dir="ltr" (heuristic):
+grep -rEn '\?\s*"\+"\s*:\s*""\s*}' frontend/src/ \
+  | xargs -I{} grep -l 'dir="ltr"' {} || true
 ```
 
 If anything matches and the string is user-facing, fix it before merging.

--- a/.claude/rules/frontend_pitfalls.md
+++ b/.claude/rules/frontend_pitfalls.md
@@ -87,17 +87,31 @@ Import the canonical `Transaction` type from `types/transaction.ts`, not from co
 ```tsx
 import { formatCurrency } from "../../utils/numberFormatting";
 formatCurrency(amount)          // "₪1,234"
-formatCurrency(amount, 2)       // "₪1,234.56"
+formatCurrency(amount, 2)       // "1,234.56 ₪"
 ```
 
-**Never inline** `new Intl.NumberFormat("he-IL", { style: "currency", currency: "ILS" })`. It creates duplicate logic and inconsistent formatting.
+**Canonical layout is sign-magnitude-currency** (Israeli convention:
+₪ after digits, NBSP between). Helpers emit `1,003,211 ₪`, `-25K ₪`,
+`+150 ₪`. Don't roll your own `₪${x}` template — you'll get the
+shekel on the wrong side and re-introduce the inconsistency we
+already fixed twice.
 
-**Don't append `₪` yourself.** `formatCurrency()` already includes the symbol.
-Manual concatenation (`{formatCurrency(x)}₪`) doubles the symbol on RTL builds
-and causes the inconsistent spacing (`1,234₪` here, `1,234 ₪` there) you'll
-see on legacy code. If you need the value without the symbol, route the
-number through `formatCurrency()` and add `, { signDisplay: "never", currency: undefined }`
-options — or extract a separate helper.
+**Never inline** `new Intl.NumberFormat("he-IL", { style: "currency", currency: "ILS" })`.
+The `he-IL` locale puts ₪ after digits without bidi isolation, the default
+locale puts it before, and either way you skip the LRI/PDI envelope the
+shared helpers add. Result: the same dashboard renders some values as
+`1,234 ₪` and others as `₪ 1,234` depending on the surrounding RTL
+context.
+
+**Don't append `₪` yourself.** `formatCurrency()` already includes the
+symbol. Manual concatenation (`{formatCurrency(x)}₪`) doubles the symbol.
+
+**Helper output is bidi-stable.** Each call returns a string wrapped in
+U+2066 (LRI) ... U+2069 (PDI), so `<span>{formatCurrency(x)}</span>`
+without `dir="ltr"` renders correctly under RTL. You only need
+`dir="ltr"` when you concatenate something around the helper output
+yourself (a literal `+`, joining two helper outputs with `" / "` text,
+date + currency on the same line, etc.).
 
 ## Delta / Change Formatting
 
@@ -107,9 +121,9 @@ your own template:
 
 ```tsx
 // CORRECT — single source of truth
-formatChange(-20000)    // "-₪20K"
-formatChange(6500)      // "+₪6.5K"
-formatChange(-132)      // "-₪132"   (small values still get currency)
+formatChange(-20000)    // "-20K ₪"
+formatChange(6500)      // "+6.5K ₪"
+formatChange(-132)      // "-132 ₪"   (small values still get currency)
 ```
 
 Bad patterns that have shipped to prod and looked broken:
@@ -152,30 +166,33 @@ always match document direction.
 ### Signed-number spans without `dir="ltr"` get reordered
 
 The well-known case: deltas like `(+28.2%)` flipping to `(28.2%+)`.
-The less obvious case: a **positive** transaction amount rendered as
-`"+" + formatCurrency(150)`. `formatCurrency` injects RLM/LRM marks for
-negatives so they're safe; positives prefix a literal `+` that has no
-direction wrapper, and under RTL the bidi algorithm reorders the `+`
-into a neighbouring run.
+The less obvious case used to be a **positive** transaction amount
+rendered as `"+" + formatCurrency(150)`: the helper output was
+bidi-safe, but the literal `+` was outside it and got reordered.
 
-Rule: every span/cell that renders a signed or numeric value gets
-`dir="ltr"`, **even when no negative case exists** in your test data.
-Cover the unsigned positive path too:
+The shared helpers in `numberFormatting.ts` now wrap output in
+U+2066 (LRI) ... U+2069 (PDI) and put NBSP between digits and ₪.
+That means a bare `<span>{formatCurrency(x)}</span>` is correct
+under RTL — no `dir="ltr"` needed.
+
+You **still** need `dir="ltr"` (or use `formatChange`, which already
+includes the sign) when you concatenate something around the helper
+output yourself:
 
 ```tsx
-// WRONG — flips under RTL
-<span className="text-end">
-  {isPositive ? "+" : ""}{formatCurrency(amount)}
-</span>
+// WRONG — literal "+" sits outside the LRI/PDI envelope and flips
+<span>{isPositive ? "+" : ""}{formatCurrency(amount)}</span>
 
-// CORRECT
-<span dir="ltr" className="text-end">
-  {isPositive ? "+" : ""}{formatCurrency(amount)}
-</span>
+// CORRECT — the literal "+" is now inside an LTR run
+<span dir="ltr">{isPositive ? "+" : ""}{formatCurrency(amount)}</span>
+
+// BETTER — let formatChange handle the sign
+<span>{formatChange(amount)}</span>
 ```
 
-This is enforced by the auditor in `audit/audit-script.js` (category
-`delta_no_dir`). Run it under RTL before merging.
+Same rule for percent deltas (`(${formatPercentChange(x)})`), date +
+currency joined on one line, two helper outputs joined with `" / "`,
+etc. — anything you build outside the helpers needs the wrapper.
 
 ## Hardcoded Relative-Time Strings
 

--- a/.claude/rules/frontend_pitfalls.md
+++ b/.claude/rules/frontend_pitfalls.md
@@ -122,6 +122,79 @@ Bad patterns that have shipped to prod and looked broken:
 
 If you spot any of these, route them through the central helper.
 
+## RTL Bidi: Truncated User Data and Signed Numbers
+
+Two related bugs that we keep regressing on. Both come from the same
+root cause: the document direction in Hebrew is `rtl`, and CSS / bidi
+algorithms apply that direction to content that should actually be LTR.
+
+### `truncate` on user data clips the wrong end
+
+Tailwind `truncate` is `text-overflow: ellipsis`. CSS truncates at the
+**end of the line in the document direction**. Under RTL, that's the
+visual left side. English content like `"Transportation / Gas"` then
+shows as `"...sportation / Gas"` — leading letters chopped off.
+
+```tsx
+// WRONG
+<span className="truncate">{tx.description}</span>
+
+// CORRECT — bidi auto-detects from first strong character
+<span className="truncate" dir="auto">{tx.description}</span>
+```
+
+Apply `dir="auto"` to every `truncate` / `line-clamp` element that
+holds **user data**: transaction descriptions, category / tag names,
+account names, rule names, project names, free-text notes. Do not
+apply it to chrome strings that came from `t(...)` — those should
+always match document direction.
+
+### Signed-number spans without `dir="ltr"` get reordered
+
+The well-known case: deltas like `(+28.2%)` flipping to `(28.2%+)`.
+The less obvious case: a **positive** transaction amount rendered as
+`"+" + formatCurrency(150)`. `formatCurrency` injects RLM/LRM marks for
+negatives so they're safe; positives prefix a literal `+` that has no
+direction wrapper, and under RTL the bidi algorithm reorders the `+`
+into a neighbouring run.
+
+Rule: every span/cell that renders a signed or numeric value gets
+`dir="ltr"`, **even when no negative case exists** in your test data.
+Cover the unsigned positive path too:
+
+```tsx
+// WRONG — flips under RTL
+<span className="text-end">
+  {isPositive ? "+" : ""}{formatCurrency(amount)}
+</span>
+
+// CORRECT
+<span dir="ltr" className="text-end">
+  {isPositive ? "+" : ""}{formatCurrency(amount)}
+</span>
+```
+
+This is enforced by the auditor in `audit/audit-script.js` (category
+`delta_no_dir`). Run it under RTL before merging.
+
+## Hardcoded Relative-Time Strings
+
+Don't ship strings like `` `${days}d ago` `` or `"in 3 hours"`. They
+slip into Hebrew UIs unchanged. Route them through `t(...)` with
+`{{count}}` interpolation:
+
+```json
+// en.json
+"daysAgo": "{{count}}d ago"
+
+// he.json
+"daysAgo": "לפני {{count}} ימים"
+```
+
+```tsx
+t("investments.daysAgo", { count: snapshotAgeDays })
+```
+
 ## SQLite Booleans in JSX
 
 SQLite stores booleans as `0` / `1` integers. In JSX, `{0 && <Component />}` renders the string `"0"`.

--- a/.claude/rules/frontend_utils.md
+++ b/.claude/rules/frontend_utils.md
@@ -29,14 +29,16 @@ Pure helper functions — stateless, no React, no side effects.
 
 | File | Purpose | Key Exports |
 |------|---------|-------------|
-| `numberFormatting.ts` | Currency display | `formatCurrency(value, maxDigits?)`, `formatCompactCurrency(value)` |
+| `numberFormatting.ts` | Currency display — canonical `<sign><magnitude><NBSP>₪` layout, wrapped in U+2066 (LRI) / U+2069 (PDI) so output is bidi-stable under RTL | `formatCurrency(value, maxDigits?)`, `formatCompactCurrency(value)`, `formatChange(value)`, `formatPercentChange(value)` |
 | `dateFormatting.ts` | Date display (date-fns, Hebrew locale) | `formatDate()`, `formatMonth()` |
 | `textFormatting.ts` | Provider/service labels (bilingual) | `humanizeProvider()`, `humanizeService()`, `PROVIDER_LABELS`, `PROVIDER_LABELS_HE` |
 | `taggingRuleEval.ts` | Evaluate tagging rule conditions against transactions | `findMatchingRule()`, `evalConditionTree()` |
 | `plotlyLocale.ts` | Plotly chart theme, Hebrew locale, touch detection | `chartTheme`, `plotlyConfig()`, `isTouchDevice` |
 
 **Rules:**
-- Always use `formatCurrency()` from `numberFormatting.ts` — never inline `new Intl.NumberFormat()`
+- Always use `formatCurrency()` / `formatCompactCurrency()` / `formatChange()` from `numberFormatting.ts` — never inline `new Intl.NumberFormat()`. Inline calls skip the LRI/PDI wrapper and emit ₪ on the wrong side under RTL.
+- The helpers' canonical layout is `<sign><digits><NBSP>₪` (Israeli convention: ₪ after digits). Don't append `₪` yourself or roll your own template — you'll re-introduce the inconsistent shekel-position bug.
+- The helpers' output is bidi-stable; bare `<span>{formatCurrency(x)}</span>` is safe under RTL. You only need `dir="ltr"` when concatenating literals around the helper output (a leading `+`, `" / "` joiners, date+currency on one line). See `frontend_pitfalls.md` → "RTL Bidi" for the full picture.
 - When adding a new provider, add its label to BOTH `PROVIDER_LABELS` and `PROVIDER_LABELS_HE` in `textFormatting.ts`
 
 ## Hooks (`hooks/`)

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -199,4 +199,37 @@ plus `tsc -b`. The bug, by definition, was something static analysis missed.
   open across mutations when it should, and that the displayed value
   updates after each selection.
 
+## Verifying RTL & responsive — full coverage matrix
+
+A "single pass at desktop English" is **not** enough. Most of our
+production bugs (ellipsis chopping the wrong end, signed-number bidi
+flips, layout overflows) only show up under one combination of
+`(viewport, language)`. Before claiming an audit is complete, drive the
+patched flow under **all four**:
+
+|             | English (LTR)    | Hebrew (RTL)   |
+|-------------|------------------|----------------|
+| Desktop     | 1440 × 900       | 1440 × 900     |
+| Mobile      | 375 × 812        | 375 × 812      |
+
+Workflow:
+
+1. Enable Demo Mode (so test data is consistent).
+2. For each page in the app: drive the user flow at desktop EN, switch
+   to Hebrew via Settings → Language → עברית, repeat. Resize to
+   375 × 812, repeat both languages.
+3. Run `audit/audit-script.js` (the programmatic auditor) on each
+   matrix cell. It catches:
+   - SVG paths with `NaN` (broken charts)
+   - Translation-key leaks like `transactions.envelopeNamePlaceholder`
+   - Signed numbers without `dir="ltr"`
+   - Duplicate currency symbols
+   - Document-level horizontal overflow
+4. For RTL specifically, look at every element with `truncate` or
+   `line-clamp` that holds dynamic data — the auditor flags ellipsis
+   landing at the wrong end.
+
+If any of the four cells surfaces an issue that the others didn't,
+that's the bug class to add a regression test for.
+
 > When changing test structure, naming conventions, or global fixtures, update this rule file.

--- a/frontend/src/components/BudgetProgressBar.tsx
+++ b/frontend/src/components/BudgetProgressBar.tsx
@@ -63,7 +63,7 @@ export const BudgetProgressBar: React.FC<BudgetProgressBarProps> = ({
           {/* Status dot + label */}
           <span className={`w-2 h-2 rounded-full shrink-0 ${dotColor}`} />
           {label && (
-            <span className="font-semibold text-sm text-[var(--text-default)] whitespace-nowrap truncate max-w-[40vw] md:max-w-none">
+            <span className="font-semibold text-sm text-[var(--text-default)] whitespace-nowrap truncate max-w-[40vw] md:max-w-none" dir="auto">
               {label}
             </span>
           )}
@@ -125,12 +125,12 @@ export const BudgetProgressBar: React.FC<BudgetProgressBarProps> = ({
           )}
           <div className="min-w-0">
             {label && (
-              <div className="font-semibold text-[var(--text-default)] truncate">
+              <div className="font-semibold text-[var(--text-default)] truncate" dir="auto">
                 {label}
               </div>
             )}
             {subLabel && (
-              <div className="text-xs font-medium text-[var(--text-muted)] uppercase tracking-wide truncate">
+              <div className="text-xs font-medium text-[var(--text-muted)] uppercase tracking-wide truncate" dir="auto">
                 {subLabel}
               </div>
             )}

--- a/frontend/src/components/TransactionsTable.tsx
+++ b/frontend/src/components/TransactionsTable.tsx
@@ -768,7 +768,7 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
                       className={`px-4 ${compact ? "py-2" : "py-3"} text-[var(--text-default)] font-medium overflow-hidden`}
                       title={getDescription(tx)}
                     >
-                      <div className="truncate">{getDescription(tx)}</div>
+                      <div className="truncate" dir="auto">{getDescription(tx)}</div>
                     </td>
                   )}
                   {visibleColumns.has("category") && (
@@ -780,7 +780,7 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
                         title={`${tx.category || "-"}${tx.tag ? ` / ${tx.tag}` : ""}`}
                       >
                         {categoryIcons?.[tx.category as string] && <span className="shrink-0">{categoryIcons[tx.category as string]}</span>}
-                        <span className="truncate">
+                        <span className="truncate" dir="auto">
                           {tx.category || "-"}
                           {tx.tag && <span className="text-[var(--text-muted)]"> / {tx.tag}</span>}
                         </span>
@@ -790,11 +790,9 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
                   {visibleColumns.has("amount") && (
                     <td
                       className={`px-4 ${compact ? "py-2" : "py-3"} text-end font-bold whitespace-nowrap ${tx.amount > 0 ? "text-emerald-500" : "text-red-500"}`}
+                      dir="ltr"
                     >
-                      {new Intl.NumberFormat("he-IL", {
-                        style: "currency",
-                        currency: "ILS",
-                      }).format(tx.amount)}
+                      {formatCurrency(tx.amount, 2)}
                     </td>
                   )}
                   {visibleColumns.has("account") && (
@@ -803,12 +801,12 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
                       title={`${tx.provider ? humanizeProvider(tx.provider) : "Manual"} - ${tx.account_name}${tx.source === "credit_card_transactions" && tx.account_number ? ` (${tx.account_number.slice(-4)})` : ""}`}
                     >
                       <div className="flex flex-col min-w-0">
-                        <span className="text-[10px] font-bold text-[var(--text-muted)] uppercase tracking-tight leading-none mb-1 truncate">
+                        <span className="text-[10px] font-bold text-[var(--text-muted)] uppercase tracking-tight leading-none mb-1 truncate" dir="auto">
                           {tx.provider
                             ? humanizeProvider(tx.provider)
                             : tx.source?.includes("cash") ? "Cash" : "Manual"}
                         </span>
-                        <span className="truncate font-medium text-[var(--text-default)]">
+                        <span className="truncate font-medium text-[var(--text-default)]" dir="auto">
                           {tx.account_name}
                           {tx.source === "credit_card_transactions" && tx.account_number && (
                             <span className="text-[var(--text-muted)] ms-1">

--- a/frontend/src/components/budget/PendingRefundsSection.tsx
+++ b/frontend/src/components/budget/PendingRefundsSection.tsx
@@ -104,7 +104,7 @@ export const PendingRefundsSection: React.FC<PendingRefundsSectionProps> = ({
                   <span className="text-xs font-mono text-[var(--text-muted)] bg-[var(--surface-light)] px-1.5 py-0.5 rounded shrink-0" dir="ltr">
                     {item.date ? formatDate(item.date) : t("transactions.refunds.noDate")}
                   </span>
-                  <span className="font-medium text-[var(--text-primary)] truncate">
+                  <span className="font-medium text-[var(--text-primary)] truncate" dir="auto">
                     {item.description || t("budget.unknownTransaction")}
                   </span>
                 </div>

--- a/frontend/src/components/common/Sparkline.tsx
+++ b/frontend/src/components/common/Sparkline.tsx
@@ -17,18 +17,19 @@ export function Sparkline({
 }: SparklineProps) {
     const id = useId();
 
-    if (data.length < 2) return null;
+    const numericData = data.filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+    if (numericData.length < 2) return null;
 
     const padding = 2;
     const innerWidth = width - padding * 2;
     const innerHeight = height - padding * 2;
 
-    const min = Math.min(...data);
-    const max = Math.max(...data);
+    const min = Math.min(...numericData);
+    const max = Math.max(...numericData);
     const range = max - min || 1;
 
-    const points = data.map((value, i) => ({
-        x: padding + (i / (data.length - 1)) * innerWidth,
+    const points = numericData.map((value, i) => ({
+        x: padding + (i / (numericData.length - 1)) * innerWidth,
         y: padding + innerHeight - ((value - min) / range) * innerHeight,
     }));
 

--- a/frontend/src/components/dashboard/BudgetSection.tsx
+++ b/frontend/src/components/dashboard/BudgetSection.tsx
@@ -63,7 +63,7 @@ function BudgetRuleCards({
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-1.5 min-w-0">
                     {icon && <span className="text-sm flex-shrink-0">{icon}</span>}
-                    <span className="text-xs font-semibold truncate">{rule.name}</span>
+                    <span className="text-xs font-semibold truncate" dir="auto">{rule.name}</span>
                   </div>
                   <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded-full flex-shrink-0 ${
                     isUnbudgetedSpend || pct > 100

--- a/frontend/src/components/dashboard/DashboardInsightsPanel.tsx
+++ b/frontend/src/components/dashboard/DashboardInsightsPanel.tsx
@@ -703,7 +703,7 @@ export function DashboardInsightsPanel({
                   </div>
                   <div className="min-w-0">
                     <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{t("dashboard.topCategory")}</p>
-                    <p className="text-sm font-bold truncate">{topCategory?.category || "—"}</p>
+                    <p className="text-sm font-bold truncate" dir="auto">{topCategory?.category || "—"}</p>
                   </div>
                 </div>
                 <div className="bg-[var(--surface-light)] rounded-xl px-4 py-3 flex items-center gap-3">
@@ -728,7 +728,7 @@ export function DashboardInsightsPanel({
                     return (
                       <div key={d.category} className="group flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-[var(--surface-light)] transition-colors">
                         <span className="text-base w-6 text-center shrink-0">{icon || (d.category === "Uncategorized" ? "❓" : `${i + 1}.`)}</span>
-                        <span className="text-sm font-medium w-28 truncate shrink-0" title={d.category}>{d.category}</span>
+                        <span className="text-sm font-medium w-28 truncate shrink-0" title={d.category} dir="auto">{d.category}</span>
                         <div className="flex-1 h-5 bg-[var(--surface-light)] rounded-full overflow-hidden">
                           <div
                             className="h-full rounded-full bg-gradient-to-r from-rose-600 to-rose-400 transition-all duration-500"
@@ -758,7 +758,7 @@ export function DashboardInsightsPanel({
                       return (
                         <div key={d.category} className="group flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-[var(--surface-light)] transition-colors">
                           <span className="text-base w-6 text-center shrink-0">{icon || `${i + 1}.`}</span>
-                          <span className="text-sm font-medium w-28 truncate shrink-0" title={d.category}>{d.category}</span>
+                          <span className="text-sm font-medium w-28 truncate shrink-0" title={d.category} dir="auto">{d.category}</span>
                           <div className="flex-1 h-5 bg-[var(--surface-light)] rounded-full overflow-hidden">
                             <div
                               className="h-full rounded-full bg-gradient-to-r from-emerald-600 to-emerald-400 transition-all duration-500"

--- a/frontend/src/components/dashboard/RecentTransactionsSection.tsx
+++ b/frontend/src/components/dashboard/RecentTransactionsSection.tsx
@@ -262,11 +262,12 @@ export function RecentTransactionsFeed({
                         <span
                           className="text-sm block break-words line-clamp-2"
                           title={tx.description || ""}
+                          dir="auto"
                         >
                           {tx.description || ""}
                         </span>
                         <div className="flex items-center gap-1.5 flex-wrap mt-0.5">
-                          <span className="text-[11px] text-[var(--text-muted)]">
+                          <span className="text-[11px] text-[var(--text-muted)]" dir="auto">
                             {tx.category}{tx.tag ? ` / ${tx.tag}` : ""}
                           </span>
                           {matchedRule && (
@@ -325,6 +326,7 @@ export function RecentTransactionsFeed({
                         className={`text-sm font-semibold flex-shrink-0 tabular-nums text-end w-[80px] ${
                           isPositive ? "text-emerald-400" : "text-rose-400"
                         }`}
+                        dir="ltr"
                       >
                         {isPositive ? "+" : ""}
                         {formatCurrency(tx.amount)}

--- a/frontend/src/components/investments/InvestmentAnalysisModal.tsx
+++ b/frontend/src/components/investments/InvestmentAnalysisModal.tsx
@@ -76,7 +76,7 @@ function StatCard({
           <span>{title}</span>
           {tooltip && <InfoTooltip text={tooltip} iconSize={12} width={220} />}
         </p>
-        <p className="text-xl font-black mt-1 text-white">{value}</p>
+        <p className="text-xl font-black mt-1 text-white" dir="ltr">{value}</p>
       </div>
       <div className={`p-3 rounded-xl shrink-0 ${color}`}>
         <Icon size={20} />
@@ -86,7 +86,7 @@ function StatCard({
 }
 
 const formatPercent = (val: number) =>
-  `${val > 0 ? "+" : ""}${val.toFixed(2)}%`;
+  `${val >= 0 ? "+" : "-"}${Math.abs(val).toFixed(2)}%`;
 
 
 interface InvestmentAnalysisModalProps {

--- a/frontend/src/components/investments/PortfolioOverview.tsx
+++ b/frontend/src/components/investments/PortfolioOverview.tsx
@@ -50,7 +50,7 @@ function StatCard({
         <p className="text-[var(--text-muted)] text-[10px] uppercase tracking-widest font-bold">
           {title}
         </p>
-        <p className="text-xl font-black mt-1 text-white">{value}</p>
+        <p className="text-xl font-black mt-1 text-white" dir="ltr">{value}</p>
       </div>
       <div className={`p-3 rounded-xl ${color}`}>
         <Icon size={20} />
@@ -60,7 +60,7 @@ function StatCard({
 }
 
 const formatPercent = (val: number) =>
-  `${val > 0 ? "+" : ""}${val.toFixed(2)}%`;
+  `${val >= 0 ? "+" : "-"}${Math.abs(val).toFixed(2)}%`;
 
 
 interface PortfolioOverviewProps {

--- a/frontend/src/components/layout/BudgetAlertsPopup.tsx
+++ b/frontend/src/components/layout/BudgetAlertsPopup.tsx
@@ -98,10 +98,10 @@ export function BudgetAlertsPopup({ isOpen, onClose }: BudgetAlertsPopupProps) {
                 >
                   <div className="flex items-start justify-between gap-2 mb-2">
                     <div className="min-w-0">
-                      <div className="font-semibold text-sm text-[var(--text-default)] truncate">
+                      <div className="font-semibold text-sm text-[var(--text-default)] truncate" dir="auto">
                         {alert.name || alert.category}
                       </div>
-                      <div className="text-xs text-[var(--text-muted)] truncate">
+                      <div className="text-xs text-[var(--text-muted)] truncate" dir="auto">
                         {alert.category}
                       </div>
                     </div>

--- a/frontend/src/components/modals/LinkRefundModal.tsx
+++ b/frontend/src/components/modals/LinkRefundModal.tsx
@@ -225,7 +225,7 @@ export const LinkRefundModal: React.FC<LinkRefundModalProps> = ({
                     >
                       <div className={`flex items-start justify-between gap-4 ${isSelected ? "pe-7" : ""}`}>
                         <div className="flex-1 min-w-0">
-                          <div className="font-semibold text-white truncate mb-0.5">
+                          <div className="font-semibold text-white truncate mb-0.5" dir="auto">
                             {txn.description || txn.desc || t("modals.linkRefund.unknownExpense")}
                           </div>
                           <div className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
@@ -286,7 +286,7 @@ export const LinkRefundModal: React.FC<LinkRefundModalProps> = ({
                   >
                     <div className={`flex items-start justify-between gap-4 ${selectedPendingId === pending.id ? "pe-7" : ""}`}>
                       <div className="flex-1 min-w-0">
-                        <div className="font-semibold text-white truncate mb-0.5">
+                        <div className="font-semibold text-white truncate mb-0.5" dir="auto">
                           {pending.description || t("modals.linkRefund.unknownExpense")}
                         </div>
                         <div className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
@@ -315,7 +315,7 @@ export const LinkRefundModal: React.FC<LinkRefundModalProps> = ({
                       </div>
                     </div>
                     {pending.notes && (
-                      <p className="text-sm text-[var(--text-muted)] mt-1 truncate">
+                      <p className="text-sm text-[var(--text-muted)] mt-1 truncate" dir="auto">
                         {pending.notes}
                       </p>
                     )}

--- a/frontend/src/components/transactions/AutoTaggingPanel.tsx
+++ b/frontend/src/components/transactions/AutoTaggingPanel.tsx
@@ -282,7 +282,7 @@ export function AutoTaggingPanel() {
                             ) : (rules || []).filter(r => !searchQuery || r.name.toLowerCase().includes(searchQuery.toLowerCase())).map((rule) => (
                                 <div key={rule.id} className="bg-[var(--surface-light)]/30 rounded-xl p-3 border border-[var(--surface-light)]">
                                     <div className="flex items-center justify-between mb-1">
-                                        <span className="font-semibold text-sm truncate">{rule.name}</span>
+                                        <span className="font-semibold text-sm truncate" dir="auto">{rule.name}</span>
                                         <div className="flex items-center gap-1">
                                             <button onClick={() => applySingleMutation.mutate({ id: rule.id!, overwrite: false })} className="p-1 rounded hover:bg-emerald-500/20 text-emerald-400/60 hover:text-emerald-400 transition-colors"><Play size={14} /></button>
                                             <button onClick={() => { setEditingRule(rule); setIsModalOpen(true); }} className="p-1 rounded hover:bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-white transition-colors"><Edit2 size={14} /></button>

--- a/frontend/src/components/transactions/RuleEditorModal.tsx
+++ b/frontend/src/components/transactions/RuleEditorModal.tsx
@@ -387,7 +387,7 @@ function TransactionPreview({ matches, loading, count, showHeader = true }: { ma
                                         <td className="px-4 py-2 text-[var(--text-muted)] whitespace-nowrap">
                                             {tx.date?.split("T")[0] || "—"}
                                         </td>
-                                        <td className="px-4 py-2 truncate max-w-xs" title={tx.description}>
+                                        <td className="px-4 py-2 truncate max-w-xs" title={tx.description} dir="auto">
                                             {tx.description}
                                         </td>
                                         <td className={`px-4 py-2 text-end whitespace-nowrap font-mono ${(tx.amount ?? 0) < 0 ? "text-red-400" : "text-green-400"}`}>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -486,6 +486,7 @@
     "viewAnalysis": "View Analysis",
     "opened": "Opened",
     "updated": "Updated",
+    "daysAgo": "{{count}}d ago",
     "allTagsInUse": "All tags in use",
     "balance": "Balance",
     "source": "Source",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -486,6 +486,7 @@
     "viewAnalysis": "הצג ניתוח",
     "opened": "נפתח",
     "updated": "עודכן",
+    "daysAgo": "לפני {{count}} ימים",
     "allTagsInUse": "כל התגיות בשימוש",
     "balance": "יתרה",
     "source": "מקור",

--- a/frontend/src/pages/Categories.tsx
+++ b/frontend/src/pages/Categories.tsx
@@ -271,7 +271,7 @@ export function Categories() {
                       className="font-bold text-base md:text-lg bg-transparent border-b border-[var(--primary)] outline-none w-full"
                     />
                   ) : (
-                    <h3 className="font-bold text-sm md:text-base truncate text-white">
+                    <h3 className="font-bold text-sm md:text-base truncate text-white" dir="auto">
                       {category}
                     </h3>
                   )}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -47,8 +47,8 @@ function BreakdownList({ items }: { items: { name: string; amount: number }[] })
     <div className="mt-2 pt-2 border-t border-[var(--surface-light)] space-y-1">
       {items.map((item) => (
         <div key={item.name} className="flex justify-between text-xs">
-          <span className="text-[var(--text-muted)] truncate me-2">{item.name}</span>
-          <span className="tabular-nums font-medium shrink-0">{formatCurrency(item.amount)}</span>
+          <span className="text-[var(--text-muted)] truncate me-2" dir="auto">{item.name}</span>
+          <span className="tabular-nums font-medium shrink-0" dir="ltr">{formatCurrency(item.amount)}</span>
         </div>
       ))}
     </div>
@@ -916,7 +916,7 @@ export function Dashboard() {
                     </div>
                     <div className="min-w-0">
                       <p className="text-xs text-[var(--text-muted)] uppercase tracking-wider">{t("dashboard.topCategory")}</p>
-                      <p className="text-sm font-bold truncate">{topCategory?.category || "—"}</p>
+                      <p className="text-sm font-bold truncate" dir="auto">{topCategory?.category || "—"}</p>
                     </div>
                   </div>
                   <div className="bg-[var(--surface-light)] rounded-xl px-3 md:px-4 py-2.5 md:py-3 flex items-center gap-3">
@@ -941,7 +941,7 @@ export function Dashboard() {
                       return (
                         <div key={d.category} className="group flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-[var(--surface-light)] transition-colors">
                           <span className="text-base w-6 text-center shrink-0">{icon || (d.category === "Uncategorized" ? "❓" : `${i + 1}.`)}</span>
-                          <span className="text-xs md:text-sm font-medium w-20 md:w-28 truncate shrink-0" title={d.category}>{d.category}</span>
+                          <span className="text-xs md:text-sm font-medium w-20 md:w-28 truncate shrink-0" title={d.category} dir="auto">{d.category}</span>
                           <div className="flex-1 h-5 bg-[var(--surface-light)] rounded-full overflow-hidden">
                             <div
                               className="h-full rounded-full bg-gradient-to-r from-rose-600 to-rose-400 transition-all duration-500"
@@ -971,7 +971,7 @@ export function Dashboard() {
                         return (
                           <div key={d.category} className="group flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-[var(--surface-light)] transition-colors">
                             <span className="text-base w-6 text-center shrink-0">{icon || `${i + 1}.`}</span>
-                            <span className="text-xs md:text-sm font-medium w-20 md:w-28 truncate shrink-0" title={d.category}>{d.category}</span>
+                            <span className="text-xs md:text-sm font-medium w-20 md:w-28 truncate shrink-0" title={d.category} dir="auto">{d.category}</span>
                             <div className="flex-1 h-5 bg-[var(--surface-light)] rounded-full overflow-hidden">
                               <div
                                 className="h-full rounded-full bg-gradient-to-r from-emerald-600 to-emerald-400 transition-all duration-500"

--- a/frontend/src/pages/Insurances.tsx
+++ b/frontend/src/pages/Insurances.tsx
@@ -467,6 +467,7 @@ function AccountCardFull({
                       <td className="px-4 sm:px-6 py-2 text-end whitespace-nowrap">
                         <span
                           className={`font-mono font-bold ${tx.amount >= 0 ? "text-emerald-400" : "text-rose-400"}`}
+                          dir="ltr"
                         >
                           {tx.amount >= 0 ? "+" : ""}
                           {fmt(tx.amount)}

--- a/frontend/src/pages/Insurances.tsx
+++ b/frontend/src/pages/Insurances.tsx
@@ -294,7 +294,7 @@ function AccountCardFull({
                 </button>
               </div>
               {account.custom_name && (
-                <p className="text-[10px] text-[var(--text-muted)] mt-0.5 italic truncate">
+                <p className="text-[10px] text-[var(--text-muted)] mt-0.5 italic truncate" dir="auto">
                   {account.account_name}
                 </p>
               )}
@@ -319,7 +319,7 @@ function AccountCardFull({
           </p>
           {tracks.map((track, i) => (
             <div key={i} className="flex justify-between items-center text-xs mb-1">
-              <span className="text-[var(--text-muted)] truncate me-2">{track.name}</span>
+              <span className="text-[var(--text-muted)] truncate me-2" dir="auto">{track.name}</span>
               <span
                 className={`font-mono font-bold whitespace-nowrap ${track.yield_pct >= 0 ? "text-emerald-400" : "text-rose-400"}`}
                 dir="ltr"

--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -23,7 +23,7 @@ import { InvestmentAnalysisModal } from "../components/investments/InvestmentAna
 import { useCategories } from "../hooks/useCategories";
 import { useCategoryTagCreate } from "../hooks/useCategoryTagCreate";
 import { useConfirm } from "../context/DialogContext";
-import { formatCurrency } from "../utils/numberFormatting";
+import { formatCurrency, formatChange, formatPercentChange } from "../utils/numberFormatting";
 
 interface Investment {
   id: number;
@@ -51,15 +51,10 @@ interface AllocationItem {
   percentage: number;
   profit_loss?: number;
   roi?: number;
-  history?: BalancePoint[];
+  history?: number[];
   total_deposits?: number;
   total_withdrawals?: number;
   cagr?: number;
-}
-
-interface BalancePoint {
-  date: string;
-  balance: number;
 }
 
 
@@ -145,27 +140,27 @@ function InvestmentCard({
               <>
                 <p
                   className={`text-2xl font-black ${(analysisData.profit_loss ?? 0) >= 0 ? "text-emerald-400" : "text-rose-400"}`}
+                  dir="ltr"
                 >
-                  {(analysisData.profit_loss ?? 0) >= 0 ? "+" : ""}
-                  {formatCurrency(analysisData.profit_loss ?? 0)}
+                  {formatChange(analysisData.profit_loss ?? 0, { compact: false })}
                 </p>
-                <p className="text-sm font-semibold mt-1 text-[var(--text-muted)]">
+                <p className="text-sm font-semibold mt-1 text-[var(--text-muted)]" dir="ltr">
                   {analysisData.roi != null &&
-                    `ROI: ${analysisData.roi >= 0 ? "+" : ""}${analysisData.roi.toFixed(1)}%`}
+                    `ROI: ${formatPercentChange(analysisData.roi)}`}
                 </p>
               </>
             ) : (
               <>
-                <p className="text-2xl font-black text-white">
+                <p className="text-2xl font-black text-white" dir="ltr">
                   {formatCurrency(analysisData.balance)}
                 </p>
                 <p
                   className={`text-sm font-semibold mt-1 ${(analysisData.profit_loss ?? 0) >= 0 ? "text-emerald-400" : "text-rose-400"}`}
+                  dir="ltr"
                 >
-                  {(analysisData.profit_loss ?? 0) >= 0 ? "+" : ""}
-                  {formatCurrency(analysisData.profit_loss ?? 0)}
+                  {formatChange(analysisData.profit_loss ?? 0, { compact: false })}
                   {analysisData.roi != null &&
-                    ` (${analysisData.roi >= 0 ? "+" : ""}${analysisData.roi.toFixed(1)}%)`}
+                    ` (${formatPercentChange(analysisData.roi)})`}
                 </p>
               </>
             )
@@ -179,7 +174,7 @@ function InvestmentCard({
         <div className="flex-shrink-0 ms-4">
           {(analysisData?.history?.length ?? 0) >= 2 ? (
             <Sparkline
-              data={analysisData!.history!.map(p => p.balance)}
+              data={analysisData!.history!}
               width={100}
               height={40}
               color={(analysisData!.profit_loss ?? 0) >= 0 ? "#10b981" : "#f43f5e"}
@@ -206,8 +201,8 @@ function InvestmentCard({
         </div>
         <div className="text-center p-2 rounded-lg bg-[var(--surface-base)]">
           <p className="text-[9px] uppercase font-bold text-[var(--text-muted)] tracking-wider">{t("investments.cagr")}</p>
-          <p className="text-sm font-bold text-white mt-0.5">
-            {analysisData?.cagr != null ? `${(analysisData.cagr ?? 0) >= 0 ? "+" : ""}${(analysisData.cagr ?? 0).toFixed(1)}%` : "—"}
+          <p className="text-sm font-bold text-white mt-0.5" dir="ltr">
+            {analysisData?.cagr != null ? formatPercentChange(analysisData.cagr) : "—"}
           </p>
         </div>
       </div>

--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -215,7 +215,7 @@ function InvestmentCard({
             <span>·</span>
             <span className={snapshotAgeDays > 30 ? "text-amber-400" : ""}>
               {t("investments.updated")} {inv.latest_snapshot_date}
-              {snapshotAgeDays > 30 ? ` (${snapshotAgeDays}d ago)` : ""}
+              {snapshotAgeDays > 30 ? ` (${t("investments.daysAgo", { count: snapshotAgeDays })})` : ""}
             </span>
           </>
         )}

--- a/frontend/src/utils/numberFormatting.test.ts
+++ b/frontend/src/utils/numberFormatting.test.ts
@@ -1,9 +1,31 @@
 import { describe, it, expect } from "vitest";
 import {
+  formatCurrency,
   formatCompactCurrency,
   formatChange,
   formatPercentChange,
 } from "./numberFormatting";
+
+describe("formatCurrency", () => {
+  it("renders positives with the shekel sign before the number", () => {
+    expect(formatCurrency(1_003_211)).toBe("₪1,003,211");
+    expect(formatCurrency(700)).toBe("₪700");
+  });
+
+  it("renders negatives with sign-shekel-magnitude (matches formatChange)", () => {
+    expect(formatCurrency(-25_000)).toBe("-₪25,000");
+    expect(formatCurrency(-1_234_567)).toBe("-₪1,234,567");
+  });
+
+  it("renders zero without a sign", () => {
+    expect(formatCurrency(0)).toBe("₪0");
+  });
+
+  it("respects maximumFractionDigits", () => {
+    expect(formatCurrency(1234.5678, 2)).toBe("₪1,234.57");
+    expect(formatCurrency(-1234.5678, 2)).toBe("-₪1,234.57");
+  });
+});
 
 describe("formatCompactCurrency", () => {
   it("renders positive millions with M suffix and currency before number", () => {

--- a/frontend/src/utils/numberFormatting.test.ts
+++ b/frontend/src/utils/numberFormatting.test.ts
@@ -6,84 +6,95 @@ import {
   formatPercentChange,
 } from "./numberFormatting";
 
+// LRI ... PDI envelope + NBSP between digits and ₪.
+const LRI = "⁦";
+const PDI = "⁩";
+const NBSP = " ";
+const wrap = (inner: string) => `${LRI}${inner}${NBSP}₪${PDI}`;
+
 describe("formatCurrency", () => {
-  it("renders positives with the shekel sign before the number", () => {
-    expect(formatCurrency(1_003_211)).toBe("₪1,003,211");
-    expect(formatCurrency(700)).toBe("₪700");
+  it("renders positives with sign-magnitude-currency wrapped in LRI/PDI", () => {
+    expect(formatCurrency(1_003_211)).toBe(wrap("1,003,211"));
+    expect(formatCurrency(700)).toBe(wrap("700"));
   });
 
-  it("renders negatives with sign-shekel-magnitude (matches formatChange)", () => {
-    expect(formatCurrency(-25_000)).toBe("-₪25,000");
-    expect(formatCurrency(-1_234_567)).toBe("-₪1,234,567");
+  it("renders negatives with sign-magnitude-shekel", () => {
+    expect(formatCurrency(-25_000)).toBe(wrap("-25,000"));
+    expect(formatCurrency(-1_234_567)).toBe(wrap("-1,234,567"));
   });
 
   it("renders zero without a sign", () => {
-    expect(formatCurrency(0)).toBe("₪0");
+    expect(formatCurrency(0)).toBe(wrap("0"));
   });
 
   it("respects maximumFractionDigits", () => {
-    expect(formatCurrency(1234.5678, 2)).toBe("₪1,234.57");
-    expect(formatCurrency(-1234.5678, 2)).toBe("-₪1,234.57");
+    expect(formatCurrency(1234.5678, 2)).toBe(wrap("1,234.57"));
+    expect(formatCurrency(-1234.5678, 2)).toBe(wrap("-1,234.57"));
+  });
+
+  it("uses non-breaking space so digits and ₪ never line-wrap apart", () => {
+    expect(formatCurrency(1_000)).toContain(NBSP);
+    expect(formatCurrency(1_000)).not.toContain(" ₪"); // regular space + ₪ would be wrappable
   });
 });
 
 describe("formatCompactCurrency", () => {
-  it("renders positive millions with M suffix and currency before number", () => {
-    expect(formatCompactCurrency(1_100_000)).toBe("₪1.1M");
+  it("renders positive millions with M suffix and currency after number", () => {
+    expect(formatCompactCurrency(1_100_000)).toBe(wrap("1.1M"));
   });
 
-  it("renders negative millions with sign before currency", () => {
-    expect(formatCompactCurrency(-1_100_000)).toBe("-₪1.1M");
+  it("renders negative millions with sign before magnitude and currency after", () => {
+    expect(formatCompactCurrency(-1_100_000)).toBe(wrap("-1.1M"));
   });
 
   it("renders large thousands with K suffix", () => {
-    expect(formatCompactCurrency(35_000)).toBe("₪35K");
+    expect(formatCompactCurrency(35_000)).toBe(wrap("35K"));
   });
 
-  it("renders negative large thousands with sign before currency", () => {
-    expect(formatCompactCurrency(-20_000)).toBe("-₪20K");
+  it("renders negative large thousands with sign-magnitude-currency", () => {
+    expect(formatCompactCurrency(-20_000)).toBe(wrap("-20K"));
   });
 
   it("renders small thousands with one decimal place", () => {
-    expect(formatCompactCurrency(1_500)).toBe("₪1.5K");
-    expect(formatCompactCurrency(-1_500)).toBe("-₪1.5K");
+    expect(formatCompactCurrency(1_500)).toBe(wrap("1.5K"));
+    expect(formatCompactCurrency(-1_500)).toBe(wrap("-1.5K"));
   });
 
-  it("renders sub-thousand values with same sign-currency-magnitude layout", () => {
-    expect(formatCompactCurrency(132)).toBe("₪132");
-    expect(formatCompactCurrency(-132)).toBe("-₪132");
-    expect(formatCompactCurrency(-482)).toBe("-₪482");
+  it("renders sub-thousand values with same sign-magnitude-currency layout", () => {
+    expect(formatCompactCurrency(132)).toBe(wrap("132"));
+    expect(formatCompactCurrency(-132)).toBe(wrap("-132"));
+    expect(formatCompactCurrency(-482)).toBe(wrap("-482"));
   });
 
   it("renders zero without a sign", () => {
-    expect(formatCompactCurrency(0)).toBe("₪0");
+    expect(formatCompactCurrency(0)).toBe(wrap("0"));
   });
 });
 
 describe("formatChange", () => {
   it("always includes a leading + on non-negative values", () => {
-    expect(formatChange(35_000)).toBe("+₪35K");
-    expect(formatChange(0)).toBe("+₪0");
+    expect(formatChange(35_000)).toBe(wrap("+35K"));
+    expect(formatChange(0)).toBe(wrap("+0"));
   });
 
   it("always includes a leading - on negative values", () => {
-    expect(formatChange(-20_000)).toBe("-₪20K");
-    expect(formatChange(-482)).toBe("-₪482");
+    expect(formatChange(-20_000)).toBe(wrap("-20K"));
+    expect(formatChange(-482)).toBe(wrap("-482"));
   });
 
   it("uses M suffix for millions", () => {
-    expect(formatChange(1_100_000)).toBe("+₪1.1M");
-    expect(formatChange(-603_000)).toBe("-₪603K");
+    expect(formatChange(1_100_000)).toBe(wrap("+1.1M"));
+    expect(formatChange(-603_000)).toBe(wrap("-603K"));
   });
 
   it("renders sub-thousand deltas without abbreviation but in canonical layout", () => {
-    expect(formatChange(150)).toBe("+₪150");
-    expect(formatChange(-132)).toBe("-₪132");
+    expect(formatChange(150)).toBe(wrap("+150"));
+    expect(formatChange(-132)).toBe(wrap("-132"));
   });
 
   it("respects compact: false to disable K/M abbreviation", () => {
-    expect(formatChange(35_000, { compact: false })).toBe("+₪35,000");
-    expect(formatChange(-1_234_567, { compact: false })).toBe("-₪1,234,567");
+    expect(formatChange(35_000, { compact: false })).toBe(wrap("+35,000"));
+    expect(formatChange(-1_234_567, { compact: false })).toBe(wrap("-1,234,567"));
   });
 });
 

--- a/frontend/src/utils/numberFormatting.ts
+++ b/frontend/src/utils/numberFormatting.ts
@@ -1,24 +1,45 @@
 /**
+ * Bidi-stable LTR wrapping. Every currency string we emit is wrapped in
+ * U+2066 (LRI, Left-to-Right Isolate) ... U+2069 (PDI, Pop Directional
+ * Isolate) so the digits + currency render left-to-right regardless of
+ * the surrounding paragraph direction, and a U+00A0 (NBSP) glues the
+ * digits to ₪ so they never line-wrap apart. This means consumers under
+ * RTL no longer have to remember `dir="ltr"` on every span — the string
+ * itself is bidi-stable.
+ */
+const LRI = "⁦";
+const PDI = "⁩";
+const NBSP = " ";
+
+function wrapCurrency(sign: string, body: string): string {
+  return `${LRI}${sign}${body}${NBSP}₪${PDI}`;
+}
+
+/**
  * Format a number as Israeli Shekel currency (₪).
- * Canonical layout: sign-currency-magnitude (e.g., "₪1,234", "-₪132").
- * Matches `formatCompactCurrency` / `formatChange` so the main KPI value and
- * its delta below render with the shekel sign on the same side.
+ * Canonical layout: sign-magnitude-currency with NBSP before ₪
+ * (e.g., "1,234 ₪", "-132 ₪"). The result is wrapped in LRI/PDI so the
+ * digits-then-shekel order is preserved under both LTR and RTL.
+ * Matches `formatCompactCurrency` / `formatChange` so the main KPI
+ * value and its delta below render with the shekel sign on the same
+ * side (Israeli convention: ₪ after digits).
  * @param value - The numeric value to format
  * @param maximumFractionDigits - Decimal places (default: 0)
- * @returns Formatted currency string (e.g., "₪1,234")
+ * @returns Formatted currency string (e.g., "1,234 ₪")
  */
 export function formatCurrency(value: number, maximumFractionDigits = 0): string {
   const v = value || 0;
   const sign = v < 0 ? "-" : "";
   const magnitude = Math.abs(v).toLocaleString("en-US", { maximumFractionDigits });
-  return `${sign}₪${magnitude}`;
+  return wrapCurrency(sign, magnitude);
 }
 
 /**
  * Format currency in compact form for small UI spaces (KPI cards, badges).
- * Canonical layout: sign-currency-magnitude with no spaces (e.g., "₪12K", "-₪1.5M").
- * Uses K/M suffixes for large values; small values render in full but with the same
- * sign-then-currency layout (e.g., "-₪132") so deltas across cards look identical.
+ * Canonical layout: sign-magnitude-currency (e.g., "12K ₪", "-1.5M ₪").
+ * Uses K/M suffixes for large values; small values render in full but with the
+ * same sign-magnitude-currency layout (e.g., "-132 ₪") so deltas across cards
+ * look identical.
  * @param value - The numeric value to format
  * @returns Compact currency string
  */
@@ -26,15 +47,15 @@ export function formatCompactCurrency(value: number): string {
   const v = value || 0;
   const abs = Math.abs(v);
   const sign = v < 0 ? "-" : "";
-  if (abs >= 1_000_000) return `${sign}₪${(abs / 1_000_000).toFixed(1)}M`;
-  if (abs >= 10_000) return `${sign}₪${(abs / 1_000).toFixed(0)}K`;
-  if (abs >= 1_000) return `${sign}₪${(abs / 1_000).toFixed(1)}K`;
-  return `${sign}₪${abs.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+  if (abs >= 1_000_000) return wrapCurrency(sign, `${(abs / 1_000_000).toFixed(1)}M`);
+  if (abs >= 10_000) return wrapCurrency(sign, `${(abs / 1_000).toFixed(0)}K`);
+  if (abs >= 1_000) return wrapCurrency(sign, `${(abs / 1_000).toFixed(1)}K`);
+  return wrapCurrency(sign, abs.toLocaleString("en-US", { maximumFractionDigits: 0 }));
 }
 
 /**
  * Format a delta/change value with explicit sign for KPI deltas and trend cards.
- * Canonical layout: sign-currency-magnitude (e.g., "+₪35K", "-₪20K", "+₪150").
+ * Canonical layout: sign-magnitude-currency (e.g., "+35K ₪", "-20K ₪", "+150 ₪").
  * Always includes a leading "+" or "-" so positive/negative changes look consistent.
  * @param value - The change amount
  * @param options.compact - Use K/M suffixes (default: true)
@@ -46,11 +67,11 @@ export function formatChange(value: number, options: { compact?: boolean } = {})
   const sign = v >= 0 ? "+" : "-";
   const abs = Math.abs(v);
   if (compact) {
-    if (abs >= 1_000_000) return `${sign}₪${(abs / 1_000_000).toFixed(1)}M`;
-    if (abs >= 10_000) return `${sign}₪${(abs / 1_000).toFixed(0)}K`;
-    if (abs >= 1_000) return `${sign}₪${(abs / 1_000).toFixed(1)}K`;
+    if (abs >= 1_000_000) return wrapCurrency(sign, `${(abs / 1_000_000).toFixed(1)}M`);
+    if (abs >= 10_000) return wrapCurrency(sign, `${(abs / 1_000).toFixed(0)}K`);
+    if (abs >= 1_000) return wrapCurrency(sign, `${(abs / 1_000).toFixed(1)}K`);
   }
-  return `${sign}₪${abs.toLocaleString("en-US", { maximumFractionDigits: 0 })}`;
+  return wrapCurrency(sign, abs.toLocaleString("en-US", { maximumFractionDigits: 0 }));
 }
 
 /**

--- a/frontend/src/utils/numberFormatting.ts
+++ b/frontend/src/utils/numberFormatting.ts
@@ -1,15 +1,17 @@
 /**
  * Format a number as Israeli Shekel currency (₪).
+ * Canonical layout: sign-currency-magnitude (e.g., "₪1,234", "-₪132").
+ * Matches `formatCompactCurrency` / `formatChange` so the main KPI value and
+ * its delta below render with the shekel sign on the same side.
  * @param value - The numeric value to format
  * @param maximumFractionDigits - Decimal places (default: 0)
  * @returns Formatted currency string (e.g., "₪1,234")
  */
 export function formatCurrency(value: number, maximumFractionDigits = 0): string {
-  return new Intl.NumberFormat("he-IL", {
-    style: "currency",
-    currency: "ILS",
-    maximumFractionDigits,
-  }).format(value || 0);
+  const v = value || 0;
+  const sign = v < 0 ? "-" : "";
+  const magnitude = Math.abs(v).toLocaleString("en-US", { maximumFractionDigits });
+  return `${sign}₪${magnitude}`;
 }
 
 /**


### PR DESCRIPTION
The portfolio analysis endpoint returns `history` as a plain `number[]`,
but the Investments page typed it as `BalancePoint[]` and called
`.map(p => p.balance)`, producing an array of `undefined` that flowed
into Math.min/max and produced 12 SVG `<path d="M 2 NaN ...">` runtime
errors per render. Also harden Sparkline to ignore non-finite values.

The per-card "+₪3,066 (+6.0%)" delta line had no `dir="ltr"` wrapper, so
the ambient RTL direction reordered the parens/sign/digits and rendered
"(6.0%+)" instead of "(+6.0%)". Route the deltas through the existing
`formatChange`/`formatPercentChange` helpers and wrap each delta block
in `dir="ltr"`. Apply the same `dir="ltr"` to the Insurance transaction
amount cell, the PortfolioOverview StatCard value, and the
InvestmentAnalysisModal StatCard value to prevent the same flip.

Tighten the local `formatPercent` helpers in PortfolioOverview and
InvestmentAnalysisModal to emit an explicit "-" for negative values so a
negative ROI no longer falls through to a bare unsigned number.