### PR TITLE
test(e2e): fix demo-mode-toggle failing on non-empty real DB

### DIFF
--- a/frontend/e2e/flows/demo-mode-toggle.spec.ts
+++ b/frontend/e2e/flows/demo-mode-toggle.spec.ts
@@ -17,15 +17,16 @@ test.describe("Demo Mode toggle flow", () => {
     page,
     request,
   }) => {
-    // Start from a known empty state.
+    // Start from a known state: demo mode OFF.
     await setDemoMode(request, false);
 
-    await gotoAndWait(page, "/data-sources");
+    // Verify backend reports demo_mode=false before we touch the UI.
+    const before = await request.get(
+      "http://localhost:8000/api/testing/demo_mode_status",
+    );
+    expect((await before.json()).demo_mode).toBe(false);
 
-    // Demo OFF: the empty-state heading is shown.
-    await expect(
-      page.getByRole("heading", { name: /no accounts connected/i }),
-    ).toBeVisible({ timeout: 10_000 });
+    await gotoAndWait(page, "/data-sources");
 
     // Toggle Demo Mode ON via the UI.
     await page


### PR DESCRIPTION
## Summary
- The `demo-mode-toggle` e2e test asserted a "no accounts connected" heading before toggling demo mode, which only works on an empty real DB
- Replaced with an API call to `GET /api/testing/demo_mode_status` to verify `demo_mode=false` — works regardless of whether the user has real accounts connected
- Test now passes consistently in any environment

## Test plan
- [x] Ran `npx playwright test e2e/flows/demo-mode-toggle.spec.ts --project=chromium` — 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)