### PR TITLE
fix(release): produce a real macOS .app bundle inside the DMG, pick a free port at launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ __pycache__/
 *.egg-info/
 .eggs/
 dist/
-build/
+build/*.app/
+build/*.dmg
+build/*.exe
 *.log
 *.pot
 *.mo

--- a/build/build_dmg.sh
+++ b/build/build_dmg.sh
@@ -1,29 +1,104 @@
 #!/bin/bash
-set -e
-
-# Build a macOS .dmg from the dist/ directory
-# Requires: dist/ to be populated by build_installer.py first
+# Build a "Finance Analysis.app" bundle and wrap it in a drag-to-Applications DMG.
+# Requires: dist/ to be populated by build_installer.py first.
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 DIST_DIR="$PROJECT_ROOT/dist"
+ICON_PNG="$PROJECT_ROOT/frontend/public/icons/icon-512.png"
+LAUNCHER_SRC="$SCRIPT_DIR/macos/launcher.sh"
+
+APP_NAME="Finance Analysis"
+APP_BUNDLE="$SCRIPT_DIR/$APP_NAME.app"
 DMG_NAME="FinanceAnalysis.dmg"
-OUTPUT_PATH="$SCRIPT_DIR/$DMG_NAME"
+DMG_PATH="$SCRIPT_DIR/$DMG_NAME"
 
 if [ ! -d "$DIST_DIR" ]; then
     echo "ERROR: dist/ directory not found. Run 'python build/build_installer.py' first."
     exit 1
 fi
+if [ ! -f "$ICON_PNG" ]; then
+    echo "ERROR: icon source not found at $ICON_PNG"
+    exit 1
+fi
+if [ ! -f "$LAUNCHER_SRC" ]; then
+    echo "ERROR: launcher script not found at $LAUNCHER_SRC"
+    exit 1
+fi
 
-# Remove existing DMG if present
-rm -f "$OUTPUT_PATH"
+VERSION=$(awk -F'"' '/^version[[:space:]]*=/ { print $2; exit }' "$PROJECT_ROOT/pyproject.toml")
+if [ -z "$VERSION" ]; then
+    echo "ERROR: could not parse version from pyproject.toml"
+    exit 1
+fi
 
-echo "Creating $DMG_NAME from dist/..."
+rm -rf "$APP_BUNDLE"
+rm -f "$DMG_PATH"
+
+echo "Building $APP_NAME.app (version $VERSION)..."
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+
+cp "$LAUNCHER_SRC" "$APP_BUNDLE/Contents/MacOS/FinanceAnalysis"
+chmod +x "$APP_BUNDLE/Contents/MacOS/FinanceAnalysis"
+
+ditto "$DIST_DIR" "$APP_BUNDLE/Contents/Resources/app"
+
+echo "Generating .icns icon from $ICON_PNG..."
+ICONSET_PARENT=$(mktemp -d)
+ICONSET="$ICONSET_PARENT/icon.iconset"
+mkdir -p "$ICONSET"
+for SIZE in 16 32 64 128 256 512; do
+    sips -z "$SIZE" "$SIZE" "$ICON_PNG" --out "$ICONSET/icon_${SIZE}x${SIZE}.png" >/dev/null
+done
+for SIZE in 16 32 128 256 512; do
+    DOUBLE=$((SIZE * 2))
+    sips -z "$DOUBLE" "$DOUBLE" "$ICON_PNG" --out "$ICONSET/icon_${SIZE}x${SIZE}@2x.png" >/dev/null
+done
+iconutil -c icns "$ICONSET" -o "$APP_BUNDLE/Contents/Resources/icon.icns"
+rm -rf "$ICONSET_PARENT"
+
+echo "Writing Info.plist..."
+cat > "$APP_BUNDLE/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>$APP_NAME</string>
+    <key>CFBundleDisplayName</key>
+    <string>$APP_NAME</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.tomerroditi.finance-analysis</string>
+    <key>CFBundleVersion</key>
+    <string>$VERSION</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$VERSION</string>
+    <key>CFBundleExecutable</key>
+    <string>FinanceAnalysis</string>
+    <key>CFBundleIconFile</key>
+    <string>icon.icns</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>10.15</string>
+</dict>
+</plist>
+PLIST
+
+echo "Building $DMG_NAME..."
+STAGING=$(mktemp -d)
+cp -R "$APP_BUNDLE" "$STAGING/"
+ln -s /Applications "$STAGING/Applications"
+
 hdiutil create \
-    -volname "Finance Analysis" \
-    -srcfolder "$DIST_DIR" \
+    -volname "$APP_NAME" \
+    -srcfolder "$STAGING" \
     -ov \
     -format UDBZ \
-    "$OUTPUT_PATH"
+    "$DMG_PATH"
 
-echo "DMG created at: $OUTPUT_PATH"
+rm -rf "$STAGING"
+
+echo "DMG created at: $DMG_PATH"

--- a/build/find_port.py
+++ b/build/find_port.py
@@ -1,0 +1,34 @@
+"""Print a free TCP port on 127.0.0.1.
+
+Tries a small list of preferred ports first; falls back to an OS-assigned
+ephemeral port if all are busy. Used by run.sh / run.bat to avoid binding a
+hardcoded port that may already be taken (e.g. by another local dev server).
+"""
+
+import socket
+import sys
+
+PREFERRED = (8765, 8766, 8767, 17654, 39817)
+
+
+def find_port() -> int:
+    for port in PREFERRED:
+        sock = socket.socket()
+        try:
+            sock.bind(("127.0.0.1", port))
+            return port
+        except OSError:
+            continue
+        finally:
+            sock.close()
+
+    sock = socket.socket()
+    try:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+if __name__ == "__main__":
+    sys.stdout.write(str(find_port()))

--- a/build/macos/launcher.sh
+++ b/build/macos/launcher.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Entry point for the Finance Analysis.app bundle on macOS.
+# Syncs the bundled app source to ~/.finance-analysis/app, then runs setup + uvicorn
+# in a Terminal window so the user can see logs.
+set -e
+
+LAUNCHER="${BASH_SOURCE[0]}"
+MACOS_DIR="$(cd "$(dirname "$LAUNCHER")" && pwd)"
+APP_BUNDLE="$(cd "$MACOS_DIR/../.." && pwd)"
+APP_SRC="$APP_BUNDLE/Contents/Resources/app"
+USER_DIR="$HOME/.finance-analysis"
+USER_APP="$USER_DIR/app"
+
+mkdir -p "$USER_APP"
+
+/usr/bin/rsync -a --delete \
+    --exclude='.venv' \
+    --exclude='node_modules' \
+    "$APP_SRC/" "$USER_APP/"
+
+SETUP="$USER_APP/build/setup.sh"
+RUN="$USER_APP/build/run.sh"
+CMD="bash '$SETUP' && bash '$RUN'"
+
+osascript <<APPLESCRIPT
+tell application "Terminal"
+    activate
+    do script "$CMD"
+end tell
+APPLESCRIPT

--- a/build/run.bat
+++ b/build/run.bat
@@ -8,11 +8,12 @@ echo ==================================================
 cd /d "%~dp0"
 cd ..
 
-:: Activate environment
 call .venv\Scripts\activate.bat
 
-:: Launch FastAPI server (serves both API and frontend)
-start "" http://localhost:8765
-uvicorn backend.main:app --host 127.0.0.1 --port 8765
+for /f "delims=" %%p in ('python build\find_port.py') do set PORT=%%p
+
+echo Starting on http://localhost:%PORT%
+start "" "http://localhost:%PORT%"
+uvicorn backend.main:app --host 127.0.0.1 --port %PORT%
 
 endlocal

--- a/build/run.sh
+++ b/build/run.sh
@@ -6,9 +6,10 @@ echo "=================================================="
 
 cd "$(dirname "$0")/.."
 
-# Activate environment
 source .venv/bin/activate
 
-# Launch FastAPI server (serves both API and frontend)
-open http://localhost:8765
-uvicorn backend.main:app --host 127.0.0.1 --port 8765
+PORT=$(python3 build/find_port.py)
+
+echo "Starting on http://localhost:$PORT"
+(sleep 2 && open "http://localhost:$PORT") &
+uvicorn backend.main:app --host 127.0.0.1 --port "$PORT"


### PR DESCRIPTION
## Summary

- The macOS DMG was previously just `hdiutil`-wrapping the project source folder — mounting it on a Mac showed `backend/`, `frontend/`, `pyproject.toml`, etc. with nothing to install. Rebuild it as a proper `Finance Analysis.app` bundle next to an `/Applications` symlink (the standard drag-to-install layout).
- Fix a port-collision bug where `run.sh` / `run.bat` hardcoded port 8765, so if another local service was already on 8765 the browser silently loaded the wrong app while uvicorn failed to bind.

## What changed

### macOS DMG → real `.app` bundle
- [build/build_dmg.sh](https://github.com/tomerroditi/finance-analysis/blob/claude/great-chatterjee-420a7a/build/build_dmg.sh) — rewritten to assemble `Finance Analysis.app` with:
  - `Contents/Info.plist` (version pulled from `pyproject.toml` so `CFBundleVersion` matches the release tag)
  - `Contents/MacOS/FinanceAnalysis` launcher executable (sourced from `build/macos/launcher.sh`)
  - `Contents/Resources/icon.icns` generated at build time from `frontend/public/icons/icon-512.png` via `sips` + `iconutil` (full multi-resolution iconset)
  - `Contents/Resources/app/` payload (the existing `dist/` produced by `build_installer.py`)
- DMG staging adds an `Applications` symlink so the user gets the standard drag-to-install UX.
- [build/macos/launcher.sh](https://github.com/tomerroditi/finance-analysis/blob/claude/great-chatterjee-420a7a/build/macos/launcher.sh) — new. On launch, rsyncs the bundled source into `~/.finance-analysis/app/` (preserving `.venv` and `node_modules`), then opens Terminal and runs `setup.sh && run.sh` — same pattern the Windows NSIS installer uses with `setup.bat` + `run.bat`.

### Port collision fix
- [build/find_port.py](https://github.com/tomerroditi/finance-analysis/blob/claude/great-chatterjee-420a7a/build/find_port.py) — new. Tries `(8765, 8766, 8767, 17654, 39817)` then falls back to an OS-assigned ephemeral port.
- [build/run.sh](https://github.com/tomerroditi/finance-analysis/blob/claude/great-chatterjee-420a7a/build/run.sh) and [build/run.bat](https://github.com/tomerroditi/finance-analysis/blob/claude/great-chatterjee-420a7a/build/run.bat) call the helper, log the chosen port, and open the browser against the actual port after a 2 s delay (so uvicorn has time to start before the browser tries to connect).

### .gitignore
- Replaced the blanket `build/` rule with `build/*.app/`, `build/*.dmg`, `build/*.exe` so new tracked source files (like `build/macos/launcher.sh`) aren't silently ignored — only build outputs are.

## Why

The reporter downloaded a release DMG on macOS and got a Finder window full of project source instead of an installable app. Separately, when they re-tested locally the launcher's hardcoded `:8765` collided with another local dev server (`autoresearch`) and the browser opened that other server's UI, masking that uvicorn never started.

## Caveat to flag in the release notes

The `.app` is unsigned (no Apple Developer cert). On first launch from a downloaded DMG, Gatekeeper will say "cannot be opened because the developer cannot be verified" — users need to right-click → **Open** the first time, or run `xattr -dr com.apple.quarantine "/Applications/Finance Analysis.app"`. Proper fix is codesigning + notarization with a paid Apple Developer account; out of scope here.

## Test plan

- [x] `python3 build/build_installer.py && bash build/build_dmg.sh` produces `build/FinanceAnalysis.dmg` locally
- [x] `hdiutil attach` on the DMG shows `Finance Analysis.app` next to an `Applications` symlink
- [x] `plutil -lint` passes on the generated `Info.plist` (version matches `pyproject.toml`)
- [x] `python3 build/find_port.py` returns 8766 when 8765 is occupied (verified locally with autoresearch sitting on 8765)
- [ ] On a Mac: drag `Finance Analysis` onto `Applications`, eject DMG, right-click → Open → setup runs in Terminal, browser opens to the chosen `localhost:<port>` showing the Finance Analysis dashboard
- [ ] CI release workflow uploads the DMG to the GitHub release as before (no workflow change, `build/build_dmg.sh` signature is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)