### PR TITLE
feat(ui): consistent empty states across all pages with demo mode CTAs

### DIFF
--- a/frontend/src/components/budget/MonthlyBudgetView.tsx
+++ b/frontend/src/components/budget/MonthlyBudgetView.tsx
@@ -12,6 +12,8 @@ import {
 import i18n from "../../i18n";
 import { budgetApi, pendingRefundsApi, type PendingRefund, type RefundLink } from "../../services/api";
 import { Skeleton } from "../common/Skeleton";
+import { EmptyState } from "../common/EmptyState";
+import { DemoModeConfirmPopover } from "../common/DemoModeConfirmPopover";
 import { BudgetProgressBar } from "../BudgetProgressBar";
 import { BudgetRuleModal } from "../modals/BudgetRuleModal";
 import { TransactionCollapsibleList } from "./TransactionCollapsibleList";
@@ -52,6 +54,7 @@ export const MonthlyBudgetView: React.FC = () => {
   const [editingRule, setEditingRule] = useState<BudgetRule | null>(null);
   const [expandedRuleId, setExpandedRuleId] = useState<string | null>(null);
   const [includeSplitParents, setIncludeSplitParents] = useState(false);
+  const [showDemoConfirm, setShowDemoConfirm] = useState(false);
   const [dismissedCopyMonths, setDismissedCopyMonths] = useState<Set<string>>(
     new Set(),
   );
@@ -415,6 +418,25 @@ export const MonthlyBudgetView: React.FC = () => {
       )}
 
       {/* Budget Rules */}
+      {budgetRules.length === 0 && (
+        <EmptyState
+          title={t("emptyStates.budget.title")}
+          description={t("emptyStates.budget.description")}
+          cta={{
+            label: t("budget.addRule"),
+            onClick: () => setIsRuleModalOpen(true),
+          }}
+          secondary={{
+            label: t("emptyStates.tryDemoMode"),
+            onClick: () => setShowDemoConfirm(true),
+          }}
+          footer={
+            showDemoConfirm ? (
+              <DemoModeConfirmPopover onClose={() => setShowDemoConfirm(false)} />
+            ) : undefined
+          }
+        />
+      )}
       <div className="space-y-4">
         {rules.map((item: BudgetAnalysisItem) => {
           const isTotalBudget = item.rule.name === "Total Budget";

--- a/frontend/src/components/common/DemoModeConfirmPopover.test.tsx
+++ b/frontend/src/components/common/DemoModeConfirmPopover.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DemoModeConfirmPopover } from "./DemoModeConfirmPopover";
+import { renderWithProviders } from "../../test-utils";
+
+describe("DemoModeConfirmPopover", () => {
+  it("renders the confirmation description and both action buttons", () => {
+    renderWithProviders(<DemoModeConfirmPopover onClose={vi.fn()} />);
+    expect(screen.getByText(/sample data/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /enable demo mode/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /cancel/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderWithProviders(<DemoModeConfirmPopover onClose={onClose} />);
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/common/DemoModeConfirmPopover.tsx
+++ b/frontend/src/components/common/DemoModeConfirmPopover.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDemoMode } from "../../context/DemoModeContext";
+
+interface DemoModeConfirmPopoverProps {
+  onClose: () => void;
+}
+
+export function DemoModeConfirmPopover({
+  onClose,
+}: DemoModeConfirmPopoverProps) {
+  const { toggleDemoMode } = useDemoMode();
+  const { t } = useTranslation();
+  const [isPending, setIsPending] = useState(false);
+
+  const handleConfirm = async () => {
+    setIsPending(true);
+    try {
+      await toggleDemoMode(true);
+      onClose();
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <div className="mt-2 p-4 bg-[var(--surface-light)] rounded-xl border border-[var(--surface-light)] text-sm text-center">
+      <p className="text-[var(--text-muted)] mb-3">
+        {t("emptyStates.demoConfirmDescription")}
+      </p>
+      <div className="flex items-center justify-center gap-3">
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={isPending}
+          className="px-4 py-1.5 rounded-lg bg-[var(--primary)] text-white font-medium hover:bg-[var(--primary)]/90 transition-colors disabled:opacity-50"
+        >
+          {t("emptyStates.demoConfirmEnable")}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-sm text-[var(--text-muted)] hover:text-[var(--text)] transition-colors"
+        >
+          {t("emptyStates.demoConfirmCancel")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/DemoModeConfirmPopover.tsx
+++ b/frontend/src/components/common/DemoModeConfirmPopover.tsx
@@ -40,7 +40,8 @@ export function DemoModeConfirmPopover({
         <button
           type="button"
           onClick={onClose}
-          className="text-sm text-[var(--text-muted)] hover:text-[var(--text)] transition-colors"
+          disabled={isPending}
+          className="text-sm text-[var(--text-muted)] hover:text-[var(--text)] transition-colors disabled:opacity-50 disabled:pointer-events-none"
         >
           {t("emptyStates.demoConfirmCancel")}
         </button>

--- a/frontend/src/components/common/EmptyState.test.tsx
+++ b/frontend/src/components/common/EmptyState.test.tsx
@@ -75,4 +75,30 @@ describe("EmptyState", () => {
     );
     expect(screen.getByRole("status")).toBeInTheDocument();
   });
+
+  it("renders without an icon when icon prop is omitted", () => {
+    renderWithProviders(<EmptyState title="No data" />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    // No SVG icon wrapper present
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("renders step cards with arrows when steps prop is provided", () => {
+    renderWithProviders(
+      <EmptyState
+        title="No data"
+        steps={[
+          { title: "Connect", description: "Add your accounts" },
+          { title: "Scrape", description: "Import transactions" },
+          { title: "Analyse", description: "See your picture" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Connect")).toBeInTheDocument();
+    expect(screen.getByText("Add your accounts")).toBeInTheDocument();
+    expect(screen.getByText("Scrape")).toBeInTheDocument();
+    expect(screen.getByText("Analyse")).toBeInTheDocument();
+    // Two arrows between three steps
+    expect(screen.getAllByText("→")).toHaveLength(2);
+  });
 });

--- a/frontend/src/components/common/EmptyState.tsx
+++ b/frontend/src/components/common/EmptyState.tsx
@@ -1,13 +1,19 @@
-import { type ComponentType, type ReactNode } from "react";
+import { Fragment, type ComponentType, type ReactNode } from "react";
 import { type LucideProps } from "lucide-react";
 
 interface EmptyStateProps {
-  /** Lucide icon component shown above the title. */
-  icon: ComponentType<LucideProps>;
+  /** Lucide icon component shown above the title. Omit for icon-less variant. */
+  icon?: ComponentType<LucideProps>;
   /** Headline — short, sentence case. Already-translated string. */
   title: string;
   /** Optional supporting copy. Already-translated string. */
   description?: string;
+  /**
+   * Optional 2–4 step cards rendered between the description and the CTA
+   * buttons. Use for onboarding flows where the user needs a sequence of
+   * actions to get data flowing (connect → scrape → analyse).
+   */
+  steps?: Array<{ title: string; description: string }>;
   /**
    * Primary call-to-action. Use a single CTA per empty state — the goal
    * is to give the user one obvious next step.
@@ -17,7 +23,7 @@ interface EmptyStateProps {
     onClick: () => void;
   };
   /**
-   * Secondary supporting action (e.g. "Read the docs"). Render only when
+   * Secondary supporting action (e.g. "Try demo mode"). Render only when
    * the primary CTA is present and a true alternative exists.
    */
   secondary?: {
@@ -26,7 +32,7 @@ interface EmptyStateProps {
   };
   /**
    * Optional fully-rendered footer slot for cases where the action isn't
-   * a single button (e.g. "or skip this and we'll come back later").
+   * a single button (e.g. inline confirmation dialogs).
    */
   footer?: ReactNode;
   /** Compact variant for inline / in-card usage. Default is page-level. */
@@ -35,17 +41,17 @@ interface EmptyStateProps {
 }
 
 /**
- * Per-page empty-state placeholder with a single primary CTA.
+ * Per-page empty-state placeholder with an optional 3-step onboarding flow
+ * and a single primary CTA.
  *
  * The component is presentational: callers are responsible for translating
- * `title`, `description`, `cta.label`, and `secondary.label` via i18next
- * before passing them in. This keeps the component free of i18n
- * coupling and easy to unit-test.
+ * all string props via i18next before passing them in.
  */
 export function EmptyState({
   icon: Icon,
   title,
   description,
+  steps,
   cta,
   secondary,
   footer,
@@ -68,14 +74,41 @@ export function EmptyState({
 
   return (
     <div role="status" className={`${containerClasses} ${className}`}>
-      <div className={iconClasses}>
-        <Icon size={isPage ? 32 : 24} />
-      </div>
+      {Icon && (
+        <div className={iconClasses}>
+          <Icon size={isPage ? 32 : 24} />
+        </div>
+      )}
       <h2 className={titleClasses}>{title}</h2>
       {description && (
         <p className="text-sm text-[var(--text-muted)] max-w-md mx-auto">
           {description}
         </p>
+      )}
+      {steps && steps.length > 0 && (
+        <div className="flex items-start gap-2 justify-center mt-6 max-w-sm mx-auto">
+          {steps.map((step, i) => (
+            <Fragment key={i}>
+              <div className="flex-1 min-w-0 bg-[var(--surface-light)] rounded-xl p-3 text-center">
+                <p className="text-sm font-semibold text-[var(--text)]">
+                  {step.title}
+                </p>
+                <p className="text-xs text-[var(--text-muted)] mt-1">
+                  {step.description}
+                </p>
+              </div>
+              {i < steps.length - 1 && (
+                <span
+                  className="text-[var(--primary)] text-base shrink-0 mt-3"
+                  dir="ltr"
+                  aria-hidden="true"
+                >
+                  →
+                </span>
+              )}
+            </Fragment>
+          ))}
+        </div>
       )}
       {(cta || secondary) && (
         <div className="mt-6 flex flex-col sm:flex-row items-center justify-center gap-3">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -521,6 +521,48 @@
     }
   },
   "emptyStates": {
+    "connectStep": {
+      "title": "Connect",
+      "description": "Add your bank or credit card accounts"
+    },
+    "scrapeStep": {
+      "title": "Scrape",
+      "description": "Import your transactions"
+    },
+    "analyseStep": {
+      "title": "Analyse",
+      "description": "See your full financial picture"
+    },
+    "dashboard": {
+      "title": "No data yet",
+      "description": "Connect your accounts to see your full financial picture."
+    },
+    "transactions": {
+      "title": "No transactions yet",
+      "description": "Connect your accounts to start importing your transactions."
+    },
+    "transactionsFiltered": {
+      "title": "No transactions found",
+      "description": "Try adjusting your filters."
+    },
+    "budget": {
+      "title": "No budgets configured",
+      "description": "Add a budget to start tracking your monthly spending."
+    },
+    "investments": {
+      "title": "No active investments",
+      "description": "Create your first investment to start tracking your portfolio."
+    },
+    "liabilities": {
+      "title": "No liabilities tracked",
+      "description": "Add a loan or debt to monitor what you owe."
+    },
+    "insurance": {
+      "title": "No insurance data yet",
+      "description": "Connect your insurance accounts to get started."
+    },
+    "connectAccounts": "Connect accounts",
+    "tryDemoMode": "Try demo mode",
     "demoConfirmDescription": "Switches to sample data — your real data won't be affected.",
     "demoConfirmEnable": "Enable demo mode",
     "demoConfirmCancel": "Cancel"

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -520,6 +520,11 @@
       "other": "Other"
     }
   },
+  "emptyStates": {
+    "demoConfirmDescription": "Switches to sample data — your real data won't be affected.",
+    "demoConfirmEnable": "Enable demo mode",
+    "demoConfirmCancel": "Cancel"
+  },
   "dataSources": {
     "title": "Data Sources",
     "subtitle": "Manage your connected accounts",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -520,6 +520,11 @@
       "other": "אחר"
     }
   },
+  "emptyStates": {
+    "demoConfirmDescription": "עובר לנתוני דוגמה — הנתונים האמיתיים שלך לא יושפעו.",
+    "demoConfirmEnable": "הפעל מצב הדגמה",
+    "demoConfirmCancel": "ביטול"
+  },
   "dataSources": {
     "title": "מקורות מידע",
     "subtitle": "נהל את החשבונות המחוברים שלך",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -521,6 +521,48 @@
     }
   },
   "emptyStates": {
+    "connectStep": {
+      "title": "חיבור",
+      "description": "הוסף את חשבון הבנק או כרטיס האשראי שלך"
+    },
+    "scrapeStep": {
+      "title": "סריקה",
+      "description": "ייבא את העסקאות שלך"
+    },
+    "analyseStep": {
+      "title": "ניתוח",
+      "description": "ראה את התמונה הפיננסית המלאה שלך"
+    },
+    "dashboard": {
+      "title": "אין נתונים עדיין",
+      "description": "חבר את חשבונותיך כדי לראות את התמונה הפיננסית המלאה שלך."
+    },
+    "transactions": {
+      "title": "אין עסקאות עדיין",
+      "description": "חבר את חשבונותיך כדי להתחיל לייבא עסקאות."
+    },
+    "transactionsFiltered": {
+      "title": "לא נמצאו עסקאות",
+      "description": "נסה לשנות את הסינון."
+    },
+    "budget": {
+      "title": "לא הוגדרו תקציבים",
+      "description": "הוסף תקציב כדי להתחיל לעקוב אחרי ההוצאות החודשיות שלך."
+    },
+    "investments": {
+      "title": "אין השקעות פעילות",
+      "description": "צור את ההשקעה הראשונה שלך כדי להתחיל לעקוב אחרי תיק ההשקעות שלך."
+    },
+    "liabilities": {
+      "title": "לא עוקבים אחרי התחייבויות",
+      "description": "הוסף הלוואה או חוב כדי לעקוב אחרי מה שאתה חייב."
+    },
+    "insurance": {
+      "title": "אין נתוני ביטוח עדיין",
+      "description": "חבר את חשבונות הביטוח שלך כדי להתחיל."
+    },
+    "connectAccounts": "חבר חשבונות",
+    "tryDemoMode": "נסה מצב הדגמה",
     "demoConfirmDescription": "עובר לנתוני דוגמה — הנתונים האמיתיים שלך לא יושפעו.",
     "demoConfirmEnable": "הפעל מצב הדגמה",
     "demoConfirmCancel": "ביטול"

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   TrendingDown,
@@ -19,6 +20,8 @@ import { BudgetSpendingGauge } from "../components/dashboard/BudgetSection";
 import { RecentTransactionsFeed } from "../components/dashboard/RecentTransactionsSection";
 import { SankeyChart } from "../components/SankeyChart";
 import { Skeleton } from "../components/common/Skeleton";
+import { EmptyState } from "../components/common/EmptyState";
+import { DemoModeConfirmPopover } from "../components/common/DemoModeConfirmPopover";
 import { useDemoMode } from "../context/DemoModeContext";
 import { useTranslation } from "react-i18next";
 import { formatCurrency, formatChange, formatPercentChange } from "../utils/numberFormatting";
@@ -174,6 +177,8 @@ function FinancialHealthHeader({
 export function Dashboard() {
   const { t } = useTranslation();
   const { isDemoMode } = useDemoMode();
+  const navigate = useNavigate();
+  const [showDemoConfirm, setShowDemoConfirm] = useState(false);
   const [netWorthView, setNetWorthView] = useState<NetWorthView>("all");
   const [incomeView, setIncomeView] = useState<"overview" | "by_source" | "by_category">("overview");
   const [excludePendingRefunds, setExcludePendingRefunds] = useState(true);
@@ -384,6 +389,45 @@ export function Dashboard() {
   // ================================================================
   //  Render
   // ================================================================
+
+  const isDbEmpty =
+    !transactionsLoading && (allTransactions?.length ?? 0) === 0;
+
+  if (isDbEmpty) {
+    return (
+      <EmptyState
+        title={t("emptyStates.dashboard.title")}
+        description={t("emptyStates.dashboard.description")}
+        steps={[
+          {
+            title: t("emptyStates.connectStep.title"),
+            description: t("emptyStates.connectStep.description"),
+          },
+          {
+            title: t("emptyStates.scrapeStep.title"),
+            description: t("emptyStates.scrapeStep.description"),
+          },
+          {
+            title: t("emptyStates.analyseStep.title"),
+            description: t("emptyStates.analyseStep.description"),
+          },
+        ]}
+        cta={{
+          label: t("emptyStates.connectAccounts"),
+          onClick: () => navigate("/data-sources"),
+        }}
+        secondary={{
+          label: t("emptyStates.tryDemoMode"),
+          onClick: () => setShowDemoConfirm(true),
+        }}
+        footer={
+          showDemoConfirm ? (
+            <DemoModeConfirmPopover onClose={() => setShowDemoConfirm(false)} />
+          ) : undefined
+        }
+      />
+    );
+  }
 
   return (
     <div className="space-y-4 md:space-y-8 animate-in fade-in duration-500">

--- a/frontend/src/pages/Insurances.tsx
+++ b/frontend/src/pages/Insurances.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  Shield,
   ArrowUpRight,
   Heart,
   Percent,
@@ -20,6 +20,8 @@ import Plot from "react-plotly.js";
 import { chartTheme, plotlyConfig } from "../utils/plotlyLocale";
 import { insuranceAccountsApi, transactionsApi, type InsuranceAccount } from "../services/api";
 import { formatDate } from "../utils/dateFormatting";
+import { EmptyState } from "../components/common/EmptyState";
+import { DemoModeConfirmPopover } from "../components/common/DemoModeConfirmPopover";
 
 // ─── Types ───────────────────────────────────────────────────────────────
 interface InsuranceTransaction {
@@ -488,6 +490,8 @@ function AccountCardFull({
 // ─── Main Page ───────────────────────────────────────────────────────────
 export function Insurances() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [showDemoConfirm, setShowDemoConfirm] = useState(false);
   const { data: accountsData, isLoading: accountsLoading } = useQuery({
     queryKey: ["insurance-accounts"],
     queryFn: () => insuranceAccountsApi.getAll().then((r) => r.data),
@@ -514,11 +518,23 @@ export function Insurances() {
 
   if (accounts.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-96 text-[var(--text-muted)] gap-4">
-        <Shield size={48} className="opacity-30" />
-        <p className="text-lg">{t("insurance.noAccountsFound")}</p>
-        <p className="text-sm">{t("insurance.scrapeToGetStarted")}</p>
-      </div>
+      <EmptyState
+        title={t("emptyStates.insurance.title")}
+        description={t("emptyStates.insurance.description")}
+        cta={{
+          label: t("emptyStates.connectAccounts"),
+          onClick: () => navigate("/data-sources"),
+        }}
+        secondary={{
+          label: t("emptyStates.tryDemoMode"),
+          onClick: () => setShowDemoConfirm(true),
+        }}
+        footer={
+          showDemoConfirm ? (
+            <DemoModeConfirmPopover onClose={() => setShowDemoConfirm(false)} />
+          ) : undefined
+        }
+      />
     );
   }
 

--- a/frontend/src/pages/Investments.tsx
+++ b/frontend/src/pages/Investments.tsx
@@ -20,6 +20,7 @@ import { Skeleton } from "../components/common/Skeleton";
 import { Sparkline } from "../components/common/Sparkline";
 import { InfoTooltip } from "../components/common/InfoTooltip";
 import { EmptyState } from "../components/common/EmptyState";
+import { DemoModeConfirmPopover } from "../components/common/DemoModeConfirmPopover";
 import { PortfolioOverview } from "../components/investments/PortfolioOverview";
 import { InvestmentAnalysisModal } from "../components/investments/InvestmentAnalysisModal";
 import { useCategories } from "../hooks/useCategories";
@@ -312,6 +313,7 @@ export function Investments() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const [showDemoConfirm, setShowDemoConfirm] = useState(false);
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [selectedAnalysisId, setSelectedAnalysisId] = useState<number | null>(
     null,
@@ -580,12 +582,15 @@ export function Investments() {
           </>
         ) : (
           <EmptyState
-            icon={TrendingUp}
-            title={t("investments.noActiveInvestments")}
+            title={
+              Object.keys(filteredCategories).length === 0
+                ? t("investments.noActiveInvestments")
+                : t("emptyStates.investments.title")
+            }
             description={
               Object.keys(filteredCategories).length === 0
                 ? t("investments.noTagsAvailable")
-                : t("investments.noActiveInvestmentsDesc")
+                : t("emptyStates.investments.description")
             }
             cta={
               Object.keys(filteredCategories).length === 0
@@ -597,6 +602,19 @@ export function Investments() {
                     label: t("investments.addFirstInvestment"),
                     onClick: () => setIsAddOpen(true),
                   }
+            }
+            secondary={
+              Object.keys(filteredCategories).length > 0
+                ? {
+                    label: t("emptyStates.tryDemoMode"),
+                    onClick: () => setShowDemoConfirm(true),
+                  }
+                : undefined
+            }
+            footer={
+              showDemoConfirm ? (
+                <DemoModeConfirmPopover onClose={() => setShowDemoConfirm(false)} />
+              ) : undefined
             }
           />
         )}

--- a/frontend/src/pages/Liabilities.tsx
+++ b/frontend/src/pages/Liabilities.tsx
@@ -20,6 +20,7 @@ import { liabilitiesApi } from "../services/api";
 import { SelectDropdown } from "../components/common/SelectDropdown";
 import { Skeleton } from "../components/common/Skeleton";
 import { EmptyState } from "../components/common/EmptyState";
+import { DemoModeConfirmPopover } from "../components/common/DemoModeConfirmPopover";
 import { formatCurrency } from "../utils/numberFormatting";
 import { formatDate } from "../utils/dateFormatting";
 import { useCategories } from "../hooks/useCategories";
@@ -285,6 +286,7 @@ export function Liabilities() {
   const queryClient = useQueryClient();
 
   const [isAddOpen, setIsAddOpen] = useState(false);
+  const [showDemoConfirm, setShowDemoConfirm] = useState(false);
   const [analysisModalId, setAnalysisModalId] = useState<number | null>(null);
   const [payOffForm, setPayOffForm] = useState<{
     id: number | null;
@@ -669,13 +671,21 @@ export function Liabilities() {
           </>
         ) : (
           <EmptyState
-            icon={Landmark}
-            title={t("liabilities.noLiabilities")}
-            description={t("liabilities.noLiabilitiesDesc")}
+            title={t("emptyStates.liabilities.title")}
+            description={t("emptyStates.liabilities.description")}
             cta={{
               label: t("liabilities.addFirstLiability"),
               onClick: () => setIsAddOpen(true),
             }}
+            secondary={{
+              label: t("emptyStates.tryDemoMode"),
+              onClick: () => setShowDemoConfirm(true),
+            }}
+            footer={
+              showDemoConfirm ? (
+                <DemoModeConfirmPopover onClose={() => setShowDemoConfirm(false)} />
+              ) : undefined
+            }
           />
         )}
       </div>

--- a/frontend/src/pages/Transactions.tsx
+++ b/frontend/src/pages/Transactions.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState, useMemo, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { transactionsApi, cashBalancesApi, type PendingRefund, type RefundLink } from "../services/api";
 import { useCashBalances } from "../hooks/useCashBalances";
@@ -10,6 +11,8 @@ import RefundsView from "../components/transactions/RefundsView";
 import { pendingRefundsApi } from "../services/api";
 import { Plus, Trash2, DollarSign, X } from "lucide-react";
 import { Skeleton } from "../components/common/Skeleton";
+import { EmptyState } from "../components/common/EmptyState";
+import { DemoModeConfirmPopover } from "../components/common/DemoModeConfirmPopover";
 
 import { TransactionFormModal } from "../components/modals/TransactionFormModal";
 import { formatCurrency } from "../utils/numberFormatting";
@@ -238,10 +241,12 @@ function CashBalancesCard({ queryClient }: { queryClient: ReturnType<typeof useQ
 export function Transactions() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const { selectedService, setSelectedService } = useAppStore();
   const [includeSplitParents, setIncludeSplitParents] = useState(false);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [filterOnlyUntagged, setFilterOnlyUntagged] = useState(false);
+  const [showDemoConfirm, setShowDemoConfirm] = useState(false);
 
   const {
     data: transactions,
@@ -343,6 +348,38 @@ export function Transactions() {
               <Skeleton variant="text" lines={1} className="w-48" />
               <Skeleton variant="card" className="h-64" />
             </div>
+          ) : selectedService === "all" && (transactions?.length ?? 0) === 0 ? (
+            <EmptyState
+              title={t("emptyStates.transactions.title")}
+              description={t("emptyStates.transactions.description")}
+              steps={[
+                {
+                  title: t("emptyStates.connectStep.title"),
+                  description: t("emptyStates.connectStep.description"),
+                },
+                {
+                  title: t("emptyStates.scrapeStep.title"),
+                  description: t("emptyStates.scrapeStep.description"),
+                },
+                {
+                  title: t("emptyStates.analyseStep.title"),
+                  description: t("emptyStates.analyseStep.description"),
+                },
+              ]}
+              cta={{
+                label: t("emptyStates.connectAccounts"),
+                onClick: () => navigate("/data-sources"),
+              }}
+              secondary={{
+                label: t("emptyStates.tryDemoMode"),
+                onClick: () => setShowDemoConfirm(true),
+              }}
+              footer={
+                showDemoConfirm ? (
+                  <DemoModeConfirmPopover onClose={() => setShowDemoConfirm(false)} />
+                ) : undefined
+              }
+            />
           ) : (
             <>
               {selectedService === "cash" && <CashBalancesCard queryClient={queryClient} />}


### PR DESCRIPTION
## Summary

- Extend `EmptyState` with optional `icon` prop and new `steps` prop for onboarding flows (3-card Connect → Scrape → Analyse sequence)
- Add `DemoModeConfirmPopover` — inline confirmation component used when "Try demo mode" is clicked from any empty state
- Replace all ad-hoc empty states on Dashboard, Transactions, Budget, Investments, Liabilities, and Insurances with consistent `EmptyState` components that guide users to connect accounts or try demo mode
- Add full `emptyStates.*` i18n keys to both `en.json` and `he.json`

## Test Plan

- [ ] All 167 existing tests pass (`npm test -- --run`)
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [ ] With an empty database (or demo mode off + no data), Dashboard and Transactions show the 3-step onboarding card with "Connect accounts" and "Try demo mode" buttons
- [ ] Budget page with no rules shows empty state; "Add Rule" opens the rule modal
- [ ] Investments, Liabilities, and Insurances empty states have no icon, show "Try demo mode" secondary button
- [ ] Clicking "Try demo mode" shows inline confirmation; "Enable demo mode" switches to demo data; "Cancel" dismisses without action
- [ ] Cancel button is disabled while demo mode toggle is in-flight (no double-close)
- [ ] Transactions page: filter-empty state (filters active, no results) shows plain text with no step cards or CTAs
- [ ] Hebrew locale renders all new strings correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)