### PR TITLE
refactor(categories): remove redundant in-page title

### DIFF
--- a/frontend/src/pages/Categories.test.tsx
+++ b/frontend/src/pages/Categories.test.tsx
@@ -6,12 +6,10 @@ import { Categories } from "./Categories";
 
 describe("Categories", () => {
   describe("rendering", () => {
-    it("renders the page heading", async () => {
+    it("renders the new-category action", async () => {
       renderWithProviders(<Categories />);
       await waitFor(() => {
-        // Title renders as "Categories" (translated) or "categories.title" (key fallback)
-        const h1 = document.querySelector("h1");
-        expect(h1).toBeInTheDocument();
+        expect(screen.getByText("categories.newCategory")).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/pages/Categories.test.tsx
+++ b/frontend/src/pages/Categories.test.tsx
@@ -9,7 +9,9 @@ describe("Categories", () => {
     it("renders the new-category action", async () => {
       renderWithProviders(<Categories />);
       await waitFor(() => {
-        expect(screen.getByText("categories.newCategory")).toBeInTheDocument();
+        expect(
+          screen.getByRole("button", { name: /categories\.newCategory|new category/i }),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/pages/Categories.tsx
+++ b/frontend/src/pages/Categories.tsx
@@ -177,11 +177,7 @@ export function Categories() {
   return (
     <div className="space-y-4 md:space-y-6 animate-in fade-in duration-500">
       {/* Header */}
-      <div className="flex flex-col md:flex-row md:items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl md:text-3xl font-bold">{t("categories.title")}</h1>
-          <p className="text-sm text-[var(--text-muted)] mt-1">{t("categories.subtitle")}</p>
-        </div>
+      <div className="flex items-center justify-end gap-3">
         <button
           onClick={() => setIsAddCategoryOpen(true)}
           className="flex items-center justify-center gap-2 px-4 md:px-6 py-2.5 bg-[var(--primary)] text-white rounded-xl font-bold shadow-lg shadow-[var(--primary)]/20 hover:bg-[var(--primary-dark)] transition-all text-sm md:text-base"


### PR DESCRIPTION
## Summary

- Removes the `<h1>` page title and subtitle from the Categories page. It was the only page that rendered its name in the body — every other page (Dashboard, Transactions, Budget, Investments, Data Sources, Liabilities, Insurance, Early Retirement) already relies on the sidebar/top bar for that.
- The mobile top bar already shows the active page label via the sidebar's `currentPageLabel`, so the in-page heading was duplicating it on mobile and standing out as inconsistent on desktop.
- Header row simplified to right-align the "+ New Category" action.
- Test updated: `Categories` rendering check now asserts on the new-category action instead of the removed `<h1>`.

## Test plan

- [ ] `cd frontend && npm test -- --run Categories`
- [ ] Visit `/categories` on desktop — page renders with the action button right-aligned, no title block
- [ ] Visit `/categories` on mobile — top bar still shows "Categories"; in-page header gone