### PR TITLE
Expand build-smoke coverage: JS bundle + API roundtrip + uninstall CLI

### DIFF
--- a/.github/workflows/build-smoke.yml
+++ b/.github/workflows/build-smoke.yml
@@ -71,12 +71,35 @@ jobs:
         run: poetry run python build/build_app.py
 
       - name: Smoke-test the bundle
+        # Boot the bundle, hit /api/version + / + /assets/*.js +
+        # /api/onboarding/status. See build/app_entry.py::_run_smoke_test
+        # for what each probe catches. Exits 1 on any probe failure.
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "macOS" ]; then
             "dist/Finance Analysis.app/Contents/MacOS/FinanceAnalysis" --smoke-test
           else
             "dist/FinanceAnalysis/FinanceAnalysis.exe" --smoke-test
+          fi
+
+      - name: Exercise --uninstall-cleanup CLI
+        # The Windows NSIS uninstaller invokes the bundled exe in
+        # ``--uninstall-cleanup --keep-data | --wipe`` mode to delete
+        # Keychain / Credential Manager entries before removing the
+        # install dir (see installer_script.nsi). If app_entry's CLI
+        # dispatch regresses, the uninstall flow silently leaves
+        # secrets behind and we'd never notice from a user-facing
+        # test. Run it here against a tmp ``FAD_USER_DIR`` so the CI
+        # runner's env stays clean.
+        shell: bash
+        env:
+          FAD_USER_DIR: ${{ runner.temp }}/finance-analysis-smoke-uninstall
+        run: |
+          mkdir -p "$FAD_USER_DIR"
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            "dist/Finance Analysis.app/Contents/MacOS/FinanceAnalysis" --uninstall-cleanup --keep-data
+          else
+            "dist/FinanceAnalysis/FinanceAnalysis.exe" --uninstall-cleanup --keep-data
           fi
 
       - name: Assert bundle size sanity

--- a/build/app_entry.py
+++ b/build/app_entry.py
@@ -196,17 +196,23 @@ def _run_smoke_test() -> int:
     and exits 0 only if it all works. A failure here means the bundle
     is broken; we surface it as a CI red-x instead of shipping.
 
-    Two probes:
-        1. ``GET /api/version`` — covers the backend layers + asserts
-           the version comes from a bundled pyproject.toml (not the
-           "0.0.0" fallback that fires if the file isn't shipped).
-        2. ``GET /``            — covers the StaticFiles mount and the
-           SPA fallback handler. The bundled frontend lives at
-           ``_MEIPASS/frontend/dist/index.html`` and a request to "/"
-           must resolve to it via ``backend.main`` 's resolver. If the
-           ``datas`` entry for ``frontend/dist`` is missing (or the
-           ``_MEIPASS``-aware path resolution regresses), the probe
-           returns a 404 and the bundle is flagged broken.
+    Four probes covering the layers a user actually hits on first launch:
+        1. ``GET /api/version``           — backend lifespan + routes;
+           asserts the version comes from the bundled pyproject.toml
+           (not the "0.0.0" fallback that fires if the file isn't shipped).
+        2. ``GET /``                      — StaticFiles mount + SPA fallback.
+           The bundled frontend lives at ``_MEIPASS/frontend/dist/index.html``.
+        3. ``GET /assets/<bundle>.js``    — confirms the StaticFiles
+           ``/assets`` mount actually serves the JS bundle Vite produced.
+           Without this, a regression in the static-mount wiring would
+           let "/" return HTML but every JS asset 404 — the dashboard
+           would silently fail to load. Probe extracts the script src
+           from the index.html body, then fetches it.
+        4. ``GET /api/onboarding/status`` — exercises a route that
+           actually hits the service + repository + DB (alembic schema
+           created by the lifespan). A failure here means the bundle
+           launches but the DB layer is broken — much more useful than
+           catching "the bundle won't even start."
     """
     user = _setup_env()
     _configure_file_logging(user)
@@ -248,28 +254,97 @@ def _run_smoke_test() -> int:
 
             # 2. GET / — StaticFiles + SPA fallback. The bundled
             # frontend/dist/index.html should come back as a real
-            # HTML document. We accept any 2xx (the SPA handler may
-            # serve via different code paths) but require an HTML body.
+            # HTML document.
+            index_body = ""
             with urllib.request.urlopen(
                 f"http://127.0.0.1:{port}/", timeout=5.0
             ) as resp:
                 if resp.status not in (200, 304):
                     failures.append(f"/ returned {resp.status}")
                 else:
-                    body = resp.read().decode("utf-8", errors="replace")
+                    index_body = resp.read().decode("utf-8", errors="replace")
                     # The Vite-built index.html always contains either a
                     # <!doctype html> declaration or an <html> root tag.
-                    # A bare 200 with empty / JSON body would mean the
-                    # SPA fallback isn't actually serving the bundled
-                    # React app.
-                    lower = body.lower()
+                    lower = index_body.lower()
                     if "<!doctype html" not in lower and "<html" not in lower:
                         failures.append(
                             "/ returned a 200 but the body isn't HTML "
-                            f"(first 80 chars: {body[:80]!r})"
+                            f"(first 80 chars: {index_body[:80]!r})"
                         )
                     else:
-                        print(f"smoke-test ok: / served HTML ({len(body)} bytes)")
+                        print(f"smoke-test ok: / served HTML ({len(index_body)} bytes)")
+
+            # 3. /assets/<bundle>.js — extract the script src from the
+            # index.html and fetch it. Confirms that StaticFiles actually
+            # serves the JS bundle Vite produced under /assets, not just
+            # the HTML shell. A regression in the assets mount would
+            # leave the dashboard silently broken.
+            if index_body:
+                import re
+
+                # Vite's index.html has exactly one entrypoint script tag,
+                # something like: <script type="module" crossorigin src="/assets/index-aB12.js"></script>
+                # Match the first /assets/...js src.
+                match = re.search(
+                    r'<script\b[^>]*\ssrc=["\'](?P<src>/assets/[^"\']+\.js)["\']',
+                    index_body,
+                )
+                if match is None:
+                    failures.append(
+                        "/ returned HTML but no /assets/*.js script tag — "
+                        "the index.html shape changed or the bundle is broken"
+                    )
+                else:
+                    asset_src = match.group("src")
+                    try:
+                        with urllib.request.urlopen(
+                            f"http://127.0.0.1:{port}{asset_src}", timeout=5.0
+                        ) as asset_resp:
+                            if asset_resp.status not in (200, 304):
+                                failures.append(
+                                    f"{asset_src} returned {asset_resp.status}"
+                                )
+                            else:
+                                asset_bytes = asset_resp.read()
+                                if len(asset_bytes) < 1024:
+                                    failures.append(
+                                        f"{asset_src} suspiciously small "
+                                        f"({len(asset_bytes)} bytes)"
+                                    )
+                                else:
+                                    print(
+                                        f"smoke-test ok: {asset_src} served "
+                                        f"({len(asset_bytes)} bytes)"
+                                    )
+                    except Exception as exc:
+                        failures.append(f"asset fetch raised: {exc}")
+
+            # 4. /api/onboarding/status — a real backend roundtrip
+            # through route → service → repository → DB. The lifespan
+            # creates the schema; this confirms the DB layer is wired
+            # correctly inside the frozen bundle. The endpoint returns
+            # five booleans on a fresh DB (all true except is_first_run).
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/api/onboarding/status", timeout=5.0
+            ) as resp:
+                if resp.status != 200:
+                    failures.append(f"/api/onboarding/status returned {resp.status}")
+                else:
+                    body = json.loads(resp.read().decode())
+                    expected_keys = {
+                        "has_credentials",
+                        "has_transactions",
+                        "has_budgets",
+                        "has_investments",
+                        "is_first_run",
+                    }
+                    missing = expected_keys - set(body.keys())
+                    if missing:
+                        failures.append(
+                            f"/api/onboarding/status missing keys: {missing}; got {body}"
+                        )
+                    else:
+                        print(f"smoke-test ok: /api/onboarding/status returned {body}")
         except Exception as exc:
             failures.append(f"probe raised: {exc}")
         finally:


### PR DESCRIPTION
## Summary

You flagged that "smoke test" was overselling what we actually validated. Right call — the job hit `/api/version` and `/`, both useful but narrow. CI could be green while the dashboard's JS bundle 404s, the DB layer is dead, or the Windows uninstall flow's bundled-binary CLI silently regresses.

This PR expands the in-bundle smoke from 2 probes to 4, plus adds one new CI step that exercises the bundled exe's CLI dispatch.

## What's new

| # | Probe | Catches |
|---|-------|---------|
| 1 | `GET /api/version` (existing) | Bundle won't start; `pyproject.toml` not bundled |
| 2 | `GET /` (existing) | StaticFiles mount + SPA fallback |
| 3 | **`GET /assets/<bundle>.js` (new)** | Regression in `/assets` StaticFiles wiring — would let `/` serve HTML while every JS asset 404s |
| 4 | **`GET /api/onboarding/status` (new)** | Full route → service → repository → DB roundtrip; broken lifespan / schema migration / dependency injection |
| 5 | **`--uninstall-cleanup --keep-data` CI step (new)** | Bundled exe's CLI dispatch (Windows NSIS uninstaller invokes the binary in this mode to wipe Keychain entries — silent regression possible today) |

## Local verification (Apple Silicon)

```
smoke-test ok: 1.19.1 on darwin
smoke-test ok: / served HTML (1272 bytes)
smoke-test ok: /assets/index-DCB77HAC.js served (5894239 bytes)
smoke-test ok: /api/onboarding/status returned {has_credentials: False, ...}

--uninstall-cleanup --keep-data → exit 0, JSON report shows 0 errors
```

Adds ~3-5s to the smoke job. Total build-smoke runtime stays well under our 10-min target.

## What's still NOT covered (tracked separately)

- Real browser interaction (Playwright clicking around the React app)
- Scraper Playwright launch via `channel="chrome"`/`channel="msedge"`
- macOS Gatekeeper / Windows SmartScreen behavior on a real download
- NSIS UI flow (only validated via the manual smoke-test matrix in `installation_and_updates.md`)

The next meaningful expansion would be (1) — booting headless Chrome via Playwright inside the bundle and asserting the dashboard renders. That's a real test, not a smoke test, so a separate Playwright-vs-bundle CI job is the right shape rather than glomming more onto this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)