### PR TITLE
fix(dmg): switch DMG format from UDBZ (bzip2) to UDZO (zlib)

### DIFF
--- a/build/build_dmg.sh
+++ b/build/build_dmg.sh
@@ -99,8 +99,14 @@ hdiutil create \
     -volname "$APP_NAME" \
     -srcfolder "$STAGING" \
     -ov \
-    -format UDBZ \
+    -format UDZO \
     "$DMG_PATH"
+# UDZO (zlib) is Apple's default DMG format and what almost every
+# modern macOS distribution uses. We previously used UDBZ (bzip2),
+# which yields ~5% smaller files at significant cost: it's slower
+# to mount on the user's Mac and triggers extra inspection passes
+# in Chrome's macOS download path that visibly throttle downloads
+# past ~70 MB. UDZO sidesteps all of that.
 
 rm -rf "$STAGING"
 


### PR DESCRIPTION
User report: the .dmg downloads fast for ~70 MB then crawls, while the Windows .exe from the same release downloads in seconds.

GitHub Releases doesn't rate-limit public artifact downloads, so the slowdown is client-side. The most likely culprit is Chrome on macOS doing extra content sniffing + signature inspection on .dmg files mid-download — and that pass behaves worse on UDBZ (bzip2-compressed) disk images, which are uncommon enough today that Apple's signature-checking tooling has slower paths for them.

UDZO (zlib) is Apple's default DMG format and what virtually every modern macOS distribution ships. The trade-off:

  UDBZ: ~5% smaller file, slower mount, slower download verification
  UDZO: standard format, fast mount, normal download path

For a ~150 MB DMG the size difference is single-digit MB — not worth the download experience. Switching.

Local rebuild on Apple Silicon confirms the DMG mounts cleanly and the bundle's --smoke-test still exits 0.