### PR TITLE
fix(build): re-sign app bundle after resource injection to fix Gatekeeper

### DIFF
--- a/build/build_dmg.sh
+++ b/build/build_dmg.sh
@@ -8,12 +8,15 @@
 # Our remaining responsibilities:
 #   1. Inject build/macos/uninstall.command as a Resource so users have a
 #      standalone uninstaller alongside Settings → Uninstall.
-#   2. Inject build/macos/fix-gatekeeper.command into the DMG root so
+#   2. Re-sign the bundle after step 1 (adding files post-PyInstaller
+#      breaks the sealed code signature, which causes Gatekeeper to show
+#      "is damaged" even after the user strips the quarantine xattr).
+#   3. Inject build/macos/fix-gatekeeper.command into the DMG root so
 #      users can clear the macOS quarantine xattr after dragging.
-#   3. Generate icon.icns from the project's 512px PNG (only if the spec
+#   4. Generate icon.icns from the project's 512px PNG (only if the spec
 #      didn't already supply one — keeps a single source of truth for
 #      the icon at frontend/public/icons/icon-512.png).
-#   4. hdiutil-wrap into FinanceAnalysis.dmg with the drag-to-Applications
+#   5. hdiutil-wrap into FinanceAnalysis.dmg with the drag-to-Applications
 #      symlink.
 #
 # Single arm64 build only — see release.yml for why we don't ship x86_64.
@@ -55,7 +58,18 @@ mkdir -p "$RESOURCES"
 cp "$UNINSTALL_SRC" "$RESOURCES/uninstall.command"
 chmod +x "$RESOURCES/uninstall.command"
 
-# 2. Icon: PyInstaller's BUNDLE step embedded build/icon.icns into the
+# 2. Re-sign the bundle with an ad-hoc signature.
+#    PyInstaller signs the bundle at the end of its build step. Adding
+#    uninstall.command to Contents/Resources above breaks that sealed
+#    signature (the code directory hash no longer matches the on-disk
+#    files). Without re-signing, Gatekeeper shows "Finance Analysis is
+#    damaged and can't be opened" even after the user strips the
+#    quarantine xattr with Fix Gatekeeper.command, because macOS
+#    validates the seal independently of quarantine status.
+echo "Re-signing bundle after resource injection..."
+codesign --force --deep --sign - "$APP_BUNDLE"
+
+# 3. Icon: PyInstaller's BUNDLE step embedded build/icon.icns into the
 #    .app's Info.plist (CFBundleIconFile points at icon.icns) BECAUSE
 #    build_app.py::_step_icns generated it before PyInstaller ran.
 #    Nothing to do here; the icon is already inside the bundle and
@@ -65,7 +79,7 @@ if [ ! -f "$RESOURCES/icon.icns" ]; then
     exit 1
 fi
 
-# 3. Build the DMG.
+# 4. Build the DMG.
 echo "Building $DMG_NAME..."
 rm -f "$DMG_PATH"
 
@@ -85,7 +99,6 @@ done
 STAGING=$(mktemp -d)
 cp -R "$APP_BUNDLE" "$STAGING/"
 ln -s /Applications "$STAGING/Applications"
-
 # Ship the Gatekeeper-unquarantine script alongside the .app so the
 # user has a one-click fix for the unsigned-binary "is damaged" error.
 # Without code signing + notarization this is the only viable path —

--- a/build/macos/fix-gatekeeper.command
+++ b/build/macos/fix-gatekeeper.command
@@ -1,35 +1,39 @@
 #!/bin/bash
-# Fix the macOS Gatekeeper "damaged and can't be opened" error.
+# Fix Gatekeeper "is damaged" error after downloading Finance Analysis from GitHub.
 #
-# The error is misleading: the app isn't damaged. macOS adds a
-# ``com.apple.quarantine`` extended attribute to anything downloaded
-# via a browser, and refuses to launch unsigned + unnotarized apps
-# carrying that attribute. Stripping the xattr lets the app launch.
+# macOS attaches a com.apple.quarantine extended attribute to files
+# downloaded from the internet. For unsigned apps, Gatekeeper treats
+# this as "damaged" and refuses to open them. This script removes the
+# quarantine attribute so the app can launch normally.
 #
-# Once code-signing + notarization are in place this script can be
-# deleted — Gatekeeper will trust the signature directly.
-set -u
+# Usage:
+#   1. Drag "Finance Analysis.app" from this DMG to /Applications.
+#   2. Double-click this file — Terminal opens and runs the fix.
+#   3. Re-launch Finance Analysis from Launchpad or /Applications.
+set -euo pipefail
 
-APP_NAME="Finance Analysis"
-APP_BUNDLE="/Applications/${APP_NAME}.app"
+APP="/Applications/Finance Analysis.app"
 
 echo "=================================================="
-echo "     ${APP_NAME} — Fix macOS Gatekeeper"
+echo "  Finance Analysis — Fix Gatekeeper"
 echo "=================================================="
 echo
 
-if [ ! -d "$APP_BUNDLE" ]; then
-    echo "ERROR: ${APP_BUNDLE} not found."
-    echo "Drag ${APP_NAME}.app into /Applications first, then run this script."
+if [ ! -d "$APP" ]; then
+    echo "ERROR: Finance Analysis.app not found in /Applications."
+    echo
+    echo "Please drag Finance Analysis.app from this DMG to your"
+    echo "/Applications folder first, then run this script again."
     echo
     echo "Press any key to close this window."
     read -n 1 -s
     exit 1
 fi
 
-echo "Removing quarantine attribute from ${APP_BUNDLE}..."
-xattr -cr "$APP_BUNDLE"
-
+echo "Removing macOS quarantine flag from Finance Analysis.app..."
+xattr -cr "$APP"
+echo "Done."
 echo
-echo "Done. ${APP_NAME} should launch normally now."
-echo "You can close this Terminal window."
+echo "You can now launch Finance Analysis from Launchpad or /Applications."
+echo "Press any key to close this window."
+read -n 1 -s


### PR DESCRIPTION
## Summary

- `build_dmg.sh` was copying `uninstall.command` into `Contents/Resources` **after** PyInstaller sealed the code signature, breaking the bundle seal with _"a sealed resource is missing or invalid"_
- This caused macOS to reject the app even after users ran `Fix Gatekeeper.command` to strip the quarantine xattr, because the seal validation is independent of quarantine status
- Added `codesign --force --deep --sign -` immediately after the resource injection step so the ad-hoc signature covers all final bundle contents

## Root cause chain

```
CI build:
  PyInstaller → signs bundle (ad-hoc)
  build_dmg.sh → copies uninstall.command into Contents/Resources   ← breaks seal
  hdiutil create → packages broken-seal app into DMG

User download:
  Chrome → adds com.apple.quarantine to DMG
  Drag to /Applications → quarantine propagates to .app
  Launch → "Finance Analysis is damaged" (quarantine + broken seal)
  Fix Gatekeeper.command → strips quarantine xattr
  Re-launch → STILL "damaged" (seal still broken)  ← the unfixed state
```

## Fix

`build_dmg.sh` now re-signs after all bundle modifications:

```bash
codesign --force --deep --sign - "$APP_BUNDLE"
```

After this fix the user flow works:
1. Drag app to /Applications
2. Run `Fix Gatekeeper.command` from the DMG
3. Launch — app opens

## Test plan

- [x] Local build + `codesign --verify --deep` → **valid on disk**
- [x] `spctl --assess` changes from _"sealed resource missing or invalid"_ → plain _"rejected"_ (expected for ad-hoc/unsigned)
- [x] Smoke test (`--smoke-test`) still passes
- [x] Quarantine simulation: apply `com.apple.quarantine`, run `xattr -cr`, confirm `spctl` no longer reports broken seal

🤖 Generated with [Claude Code](https://claude.com/claude-code)