### PR TITLE
feat(scraper): handle Hapoalim's conditional SMS-OTP challenge

### DIFF
--- a/backend/scraper/__init__.py
+++ b/backend/scraper/__init__.py
@@ -1,7 +1,21 @@
 from backend.scraper.adapter import InsuranceScraperAdapter, ScraperAdapter, create_adapter
 
-# Providers that require 2FA. Kept in sync with scraper.models.credentials.
-_2FA_PROVIDERS = {"onezero", "hafenix", "test_bank_2fa", "test_credit_card_2fa"}
+# Providers that can request 2FA. Kept in sync with the ``requires_2fa`` flag
+# on ``scraper.models.credentials.PROVIDER_CONFIGS``. The duplication is a
+# legacy of ``backend.scraper`` shadowing the root ``scraper`` package — keep
+# both in sync until they're unified.
+#
+# Semantics: "requires_2fa" means the scraper *may* request an OTP during
+# login (e.g. Hapoalim only requests it from new devices). The status only
+# flips to WAITING_FOR_2FA once the scraper actually awaits the OTP — see
+# ``ScraperAdapter._otp_callback``.
+_2FA_PROVIDERS = {
+    "hapoalim",
+    "onezero",
+    "hafenix",
+    "test_bank_2fa",
+    "test_credit_card_2fa",
+}
 
 
 def is_2fa_required(service_name: str, provider_name: str) -> bool:

--- a/backend/scraper/adapter.py
+++ b/backend/scraper/adapter.py
@@ -30,6 +30,16 @@ from backend.services.tagging_service import CategoriesTagsService
 
 logger = logging.getLogger(__name__)
 
+# Module-level registry of adapters whose scrapers may end up awaiting an OTP.
+# Lives here (next to ``ScraperAdapter``) rather than in ``scraping_service``
+# so the adapter can clean itself up on completion without importing
+# ``scraping_service`` — which would create a cycle, since ``scraping_service``
+# imports from ``backend.scraper`` (and that loads this module).
+#
+# Keyed by ``"{service} - {provider} - {account}"`` to match the lookup the
+# 2FA POST route uses; the value is the live adapter instance.
+_tfa_scrapers_waiting: dict[str, "ScraperAdapter"] = {}
+
 
 def _import_scraper_module(name: str):
     """Import a module from the root ``scraper`` package.
@@ -191,20 +201,10 @@ class ScraperAdapter:
 
         Belt-and-braces cleanup: ``submit_2fa_code`` already pops the entry
         when the user provides the OTP, but if the scraper never awaited
-        2FA (Hapoalim happy path) the entry would otherwise leak. Lazy
-        import to avoid a circular dependency between
-        ``backend.scraper.adapter`` and ``backend.services.scraping_service``.
+        2FA (Hapoalim happy path) the entry would otherwise leak.
         """
-        try:
-            from backend.services.scraping_service import _tfa_scrapers_waiting
-
-            name = f"{self.service_name} - {self.provider_name} - {self.account_name}"
-            _tfa_scrapers_waiting.pop(name, None)
-        except Exception as exc:
-            logger.debug(
-                "%s: %s: Failed to unregister from 2FA registry — %s",
-                self.provider_name, self.account_name, exc,
-            )
+        name = f"{self.service_name} - {self.provider_name} - {self.account_name}"
+        _tfa_scrapers_waiting.pop(name, None)
 
     def set_otp_code(self, code: str) -> None:
         """Set OTP code and signal the waiting coroutine.

--- a/backend/scraper/adapter.py
+++ b/backend/scraper/adapter.py
@@ -30,14 +30,9 @@ from backend.services.tagging_service import CategoriesTagsService
 
 logger = logging.getLogger(__name__)
 
-# Module-level registry of adapters whose scrapers may end up awaiting an OTP.
-# Lives here (next to ``ScraperAdapter``) rather than in ``scraping_service``
-# so the adapter can clean itself up on completion without importing
-# ``scraping_service`` — which would create a cycle, since ``scraping_service``
-# imports from ``backend.scraper`` (and that loads this module).
-#
-# Keyed by ``"{service} - {provider} - {account}"`` to match the lookup the
-# 2FA POST route uses; the value is the live adapter instance.
+# Live adapters whose scrapers may end up awaiting an OTP. Keyed by
+# ``"{service} - {provider} - {account}"`` — the same string the
+# ``POST /api/scraping/2fa`` route uses to resolve the waiting adapter.
 _tfa_scrapers_waiting: dict[str, "ScraperAdapter"] = {}
 
 

--- a/backend/scraper/adapter.py
+++ b/backend/scraper/adapter.py
@@ -178,12 +178,33 @@ class ScraperAdapter:
             )
         finally:
             self._record_scraping_attempt(self.process_id)
+            self._unregister_from_2fa_waiting()
 
         ts = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         logger.info(
             "[%s] %s: %s: Scraping finished",
             ts, self.provider_name, self.account_name,
         )
+
+    def _unregister_from_2fa_waiting(self) -> None:
+        """Pop this adapter from the 2FA-waiting registry if still present.
+
+        Belt-and-braces cleanup: ``submit_2fa_code`` already pops the entry
+        when the user provides the OTP, but if the scraper never awaited
+        2FA (Hapoalim happy path) the entry would otherwise leak. Lazy
+        import to avoid a circular dependency between
+        ``backend.scraper.adapter`` and ``backend.services.scraping_service``.
+        """
+        try:
+            from backend.services.scraping_service import _tfa_scrapers_waiting
+
+            name = f"{self.service_name} - {self.provider_name} - {self.account_name}"
+            _tfa_scrapers_waiting.pop(name, None)
+        except Exception as exc:
+            logger.debug(
+                "%s: %s: Failed to unregister from 2FA registry — %s",
+                self.provider_name, self.account_name, exc,
+            )
 
     def set_otp_code(self, code: str) -> None:
         """Set OTP code and signal the waiting coroutine.
@@ -238,17 +259,43 @@ class ScraperAdapter:
     async def _otp_callback(self) -> str:
         """Async callback passed to the scraper for OTP requests.
 
-        Clears the event, waits for ``set_otp_code`` to fire, and returns
-        the code (or ``"cancel"``).
+        Flips the scraping-history status to WAITING_FOR_2FA (so the UI's
+        polling loop shows the OTP prompt), clears the event, waits for
+        ``set_otp_code`` to fire, and returns the code (or ``"cancel"``).
+
+        The status flip happens lazily — only when the scraper actually
+        awaits an OTP — so providers that *may* request 2FA (like Hapoalim
+        from a trusted device) don't show a stale "Waiting for 2FA" state
+        when no code is actually needed.
 
         Returns
         -------
         str
             The OTP code entered by the user.
         """
+        self._mark_waiting_for_2fa()
         self._otp_event.clear()
         await self._otp_event.wait()
         return self._otp_code
+
+    def _mark_waiting_for_2fa(self) -> None:
+        """Update the scraping-history status to WAITING_FOR_2FA.
+
+        Wrapped in a try/except so a transient DB failure can't crash the
+        OTP flow — the scrape can still complete and report its final
+        status; only the intermediate UI hint would be lost.
+        """
+        try:
+            with get_db_context() as db:
+                history_repo = ScrapingHistoryRepository(db)
+                history_repo.update_status(
+                    self.process_id, history_repo.WAITING_FOR_2FA
+                )
+        except Exception as exc:
+            logger.warning(
+                "%s: %s: Failed to mark waiting_for_2fa — %s",
+                self.provider_name, self.account_name, exc,
+            )
 
     # ------------------------------------------------------------------
     # Data conversion

--- a/backend/services/scraping_service.py
+++ b/backend/services/scraping_service.py
@@ -128,15 +128,15 @@ class ScrapingService:
         creds = self.credentials_repo.get_credentials(service, provider, account)
         requires_2fa = is_2fa_required(service, provider)
 
+        # Always start IN_PROGRESS — even for 2FA-capable providers. The
+        # adapter's _otp_callback flips status to WAITING_FOR_2FA only when
+        # the scraper actually awaits the OTP, so the UI never shows a 2FA
+        # prompt for providers that didn't end up needing one (e.g. Hapoalim
+        # from a trusted device, OneZero with a stored long-term token).
         with get_db_context() as db:
             history_repo = ScrapingHistoryRepository(db)
-            status = (
-                history_repo.WAITING_FOR_2FA
-                if requires_2fa
-                else history_repo.IN_PROGRESS
-            )
             process_id = history_repo.record_scrape_start(
-                service, provider, account, start_date, status
+                service, provider, account, start_date, history_repo.IN_PROGRESS
             )
 
         adapter = create_adapter(
@@ -144,6 +144,11 @@ class ScrapingService:
         )
         asyncio.create_task(adapter.run())
 
+        # Park the adapter so submit_2fa_code can resolve it later. We register
+        # eagerly (rather than when the scraper actually awaits OTP) because
+        # the user can submit the code immediately after receiving the SMS,
+        # before the scraper has reached `await on_otp_request()`. The
+        # adapter's run() cleans this entry up on completion.
         if requires_2fa:
             name = f"{service} - {provider} - {account}"
             _tfa_scrapers_waiting[name] = adapter

--- a/backend/services/scraping_service.py
+++ b/backend/services/scraping_service.py
@@ -9,8 +9,7 @@ from backend.errors import EntityNotFoundException
 from backend.repositories.credentials_repository import CredentialsRepository
 from backend.repositories.scraping_history_repository import ScrapingHistoryRepository
 from backend.scraper import ScraperAdapter, create_adapter, is_2fa_required
-
-_tfa_scrapers_waiting: Dict[str, ScraperAdapter] = {}
+from backend.scraper.adapter import _tfa_scrapers_waiting
 
 
 class ScrapingService:

--- a/scraper/models/credentials.py
+++ b/scraper/models/credentials.py
@@ -28,6 +28,7 @@ PROVIDER_CONFIGS: dict[str, ProviderConfig] = {
     "hapoalim": ProviderConfig(
         name="Hapoalim",
         required_fields=["userCode", "password"],
+        requires_2fa=True,
     ),
     "leumi": ProviderConfig(
         name="Leumi",

--- a/scraper/providers/banks/hapoalim.py
+++ b/scraper/providers/banks/hapoalim.py
@@ -1,17 +1,18 @@
 import json
 import logging
+import random
 import re
 import uuid
 from datetime import date, datetime, timedelta
 
-from scraper.base import BrowserScraper, LoginOptions
+from scraper.base import BrowserScraper
 from scraper.models.account import AccountResult
 from scraper.models.result import LoginResult
 from scraper.models.transaction import Transaction, TransactionStatus, TransactionType
 from scraper.utils import (
     fetch_get_within_page,
-    wait_for_redirect,
     wait_until,
+    wait_until_element_found,
 )
 
 logger = logging.getLogger(__name__)
@@ -347,36 +348,197 @@ def _get_possible_login_results() -> dict[LoginResult, list]:
     }
 
 
+LOGIN_URL = f"{BASE_URL}/cgi-bin/poalwwwc?reqName=getLogonPage"
+
+# OTP modal selectors. Hapoalim renders an Angular ``auth-otp-login`` modal on
+# the SAME URL as the login form when 2FA is needed (new-device check), so
+# detection must be DOM-based, not URL-based. The five digit inputs carry
+# ``data-testid="separated-{0..4}"`` and the submit button is the only
+# ``type="submit"`` inside ``auth-otp-login``.
+OTP_MODAL_SELECTOR = "auth-otp-login"
+OTP_FIRST_INPUT_SELECTOR = 'auth-otp-login input[data-testid="separated-0"]'
+OTP_SUBMIT_SELECTOR = 'auth-otp-login button[type="submit"]'
+OTP_LENGTH = 5
+
+# Substrings the live page transitions to once the bank has resolved the login
+# attempt. We pass these into a single ``wait_for_function`` that races against
+# the OTP modal showing up, so we exit the wait as soon as *either* path fires.
+_SUCCESS_URL_SUBSTRINGS = [
+    "/portalserver/HomePage",
+    "/ng-portals-bt/rb/he/homepage",
+    "/ng-portals/rb/he/homepage",
+]
+_ERROR_URL_SUBSTRINGS = [
+    "errorcode=1.6",  # invalid password
+    "/MCP/START",  # password expired
+    "/ABOUTTOEXPIRE/START",  # password expiring soon
+]
+
+
 class HapoalimScraper(BrowserScraper):
     """Scraper for Bank Hapoalim (https://www.bankhapoalim.co.il).
 
     Uses browser automation to log in, then fetches transaction data
-    via the bank's internal REST API endpoints.
+    via the bank's internal REST API endpoints. The login flow handles
+    Hapoalim's *conditional* SMS-OTP challenge: the bank only asks for
+    a one-time code when it doesn't recognise the device, so the
+    scraper detects the OTP modal at runtime instead of always
+    expecting it.
     """
 
-    def get_login_options(self, credentials: dict) -> LoginOptions:
-        """Return Hapoalim-specific login configuration.
+    async def login(self) -> LoginResult:
+        """Log in to Hapoalim, handling the SMS-OTP challenge if it appears.
 
-        Parameters
-        ----------
-        credentials : dict
-            Must contain 'userCode' and 'password' keys.
+        Flow:
+
+        1. Navigate to the login page and fill ``userCode`` + ``password``
+           with human-like timing (Hapoalim fingerprints bots).
+        2. Click the submit button, then race-wait for either:
+
+           - a URL match against a known SUCCESS / INVALID_PASSWORD /
+             CHANGE_PASSWORD pattern, OR
+           - the ``auth-otp-login`` modal being injected into the DOM
+             (only happens when the bank doesn't trust the device).
+
+        3. If the OTP modal appeared, request the code from the user
+           (the adapter flips the scraping status to WAITING_FOR_2FA at
+           this point), type it into the five separated inputs, submit
+           the modal, then re-check the URL against the result patterns.
 
         Returns
         -------
-        LoginOptions
-            Login configuration for the generic login flow.
+        LoginResult
+            SUCCESS / INVALID_PASSWORD / CHANGE_PASSWORD / UNKNOWN_ERROR.
         """
-        return LoginOptions(
-            login_url=f"{BASE_URL}/cgi-bin/poalwwwc?reqName=getLogonPage",
-            fields=[
-                {"selector": "#userCode", "value": credentials["userCode"]},
-                {"selector": "#password", "value": credentials["password"]},
+        try:
+            possible_results = _get_possible_login_results()
+
+            self._emit_progress("navigating to login page")
+            await self.navigate_to(LOGIN_URL)
+            await wait_until_element_found(self.page, ".login-btn")
+
+            await self._human_delay(0.5, 1.0)
+            await self._human_mouse_move()
+            await self._human_delay(0.3, 0.7)
+
+            self._emit_progress("filling login credentials")
+            await self.page.click("#userCode")
+            await self._human_delay(0.1, 0.3)
+            await self._type_like_human("#userCode", self.credentials["userCode"])
+            await self._human_delay(0.3, 0.8)
+
+            await self.page.click("#password")
+            await self._human_delay(0.1, 0.3)
+            await self._type_like_human("#password", self.credentials["password"])
+            await self._human_delay(0.5, 1.0)
+
+            self._emit_progress("submitting login form")
+            await self.page.click(".login-btn")
+
+            post_state = await self._wait_for_post_login_state()
+
+            if post_state == "needs_otp":
+                otp_result = await self._handle_otp_challenge()
+                if otp_result != LoginResult.SUCCESS:
+                    return otp_result
+
+            return await self._detect_login_result(possible_results)
+
+        except Exception as exc:
+            logger.error("Hapoalim login failed: %s", exc)
+            return LoginResult.UNKNOWN_ERROR
+
+    async def _wait_for_post_login_state(self) -> str:
+        """Race-wait for the post-submit state.
+
+        Returns
+        -------
+        str
+            ``"needs_otp"`` if the auth-otp-login modal appears,
+            ``"resolved"`` if the URL transitions to a known result pattern.
+        """
+        js_fn = """([successSubs, errorSubs, otpSelector]) => {
+            const url = window.location.href.toLowerCase();
+            const lower = (s) => s.toLowerCase();
+            if (successSubs.some(s => url.includes(lower(s)))) return 'resolved';
+            if (errorSubs.some(s => url.includes(lower(s)))) return 'resolved';
+            if (document.querySelector(otpSelector)) return 'needs_otp';
+            return false;
+        }"""
+        handle = await self.page.wait_for_function(
+            js_fn,
+            arg=[
+                _SUCCESS_URL_SUBSTRINGS,
+                _ERROR_URL_SUBSTRINGS,
+                OTP_MODAL_SELECTOR,
             ],
-            submit_button_selector=".login-btn",
-            post_action=lambda: wait_for_redirect(self.page),
-            possible_results=_get_possible_login_results(),
+            timeout=self.options.default_timeout,
         )
+        return await handle.json_value()
+
+    async def _handle_otp_challenge(self) -> LoginResult:
+        """Request OTP from the user and submit it via the modal.
+
+        Returns
+        -------
+        LoginResult
+            SUCCESS if the modal was successfully submitted and the page
+            navigated to a homepage URL; UNKNOWN_ERROR on cancellation or
+            invalid input.
+        """
+        if self.on_otp_request is None:
+            logger.error(
+                "Hapoalim 2FA modal appeared but no on_otp_request callback "
+                "is configured — provider is misregistered"
+            )
+            return LoginResult.UNKNOWN_ERROR
+
+        self._emit_progress("waiting for OTP code")
+        otp_code = await self.on_otp_request()
+
+        if otp_code == "cancel":
+            return LoginResult.UNKNOWN_ERROR
+
+        digits = (otp_code or "").strip()
+        if len(digits) != OTP_LENGTH or not digits.isdigit():
+            logger.error(
+                "Hapoalim OTP must be %d digits, got %r",
+                OTP_LENGTH, otp_code,
+            )
+            return LoginResult.UNKNOWN_ERROR
+
+        self._emit_progress("submitting OTP code")
+        # Focus the first separated input; the Angular component auto-advances
+        # focus to the next input on each keystroke, so we can just type the
+        # digits through the keyboard API.
+        await self.page.click(OTP_FIRST_INPUT_SELECTOR)
+        await self._human_delay(0.2, 0.4)
+        for digit in digits:
+            await self.page.keyboard.type(digit, delay=random.randint(50, 150))
+            await self._human_delay(0.05, 0.15)
+
+        await self._human_delay(0.3, 0.7)
+
+        await self.page.wait_for_selector(
+            f"{OTP_SUBMIT_SELECTOR}:not([disabled])", timeout=10000
+        )
+        await self.page.click(OTP_SUBMIT_SELECTOR)
+
+        self._emit_progress("waiting for login to complete")
+        try:
+            await self.page.wait_for_function(
+                """([successSubs]) => {
+                    const url = window.location.href.toLowerCase();
+                    return successSubs.some(s => url.includes(s.toLowerCase()));
+                }""",
+                arg=[_SUCCESS_URL_SUBSTRINGS],
+                timeout=self.options.default_timeout,
+            )
+        except Exception as exc:
+            logger.error("Hapoalim post-OTP navigation failed: %s", exc)
+            return LoginResult.UNKNOWN_ERROR
+
+        return LoginResult.SUCCESS
 
     async def fetch_data(self) -> list[AccountResult]:
         """Fetch account data and transactions from Bank Hapoalim.

--- a/tests/backend/unit/services/test_scraping_service.py
+++ b/tests/backend/unit/services/test_scraping_service.py
@@ -182,6 +182,7 @@ class TestScrapingServiceStart:
         service.scraping_history_repo.get_last_successful_scrape_date.return_value = None
 
         mock_history_repo = MagicMock()
+        mock_history_repo.IN_PROGRESS = "in_progress"
         mock_history_repo.WAITING_FOR_2FA = "waiting_for_2fa"
         mock_history_repo.record_scrape_start.return_value = 15
 
@@ -202,6 +203,46 @@ class TestScrapingServiceStart:
         expected_key = "banks - leumi - MyAcc"
         assert expected_key in ss._tfa_scrapers_waiting
         assert ss._tfa_scrapers_waiting[expected_key] is mock_adapter
+
+    @patch("backend.services.scraping_service.asyncio")
+    @patch("backend.services.scraping_service.create_adapter")
+    @patch("backend.services.scraping_service.get_db_context")
+    @patch("backend.services.scraping_service.is_2fa_required")
+    def test_start_scraping_2fa_starts_in_progress(
+        self, mock_is_2fa, mock_get_db_ctx, mock_create_adapter, mock_asyncio, service
+    ):
+        """2FA-capable scrapes start in IN_PROGRESS (status flips lazily later).
+
+        The adapter's _otp_callback transitions the status to WAITING_FOR_2FA
+        only when the scraper actually awaits the OTP — so the UI doesn't
+        show a 2FA prompt for providers like Hapoalim that don't always need
+        one.
+        """
+        mock_is_2fa.return_value = True
+        service.credentials_repo.get_credentials.return_value = {"user": "test"}
+        service.scraping_history_repo.get_last_successful_scrape_date.return_value = None
+
+        mock_history_repo = MagicMock()
+        mock_history_repo.IN_PROGRESS = "in_progress"
+        mock_history_repo.WAITING_FOR_2FA = "waiting_for_2fa"
+        mock_history_repo.record_scrape_start.return_value = 20
+
+        @contextmanager
+        def fake_db_context():
+            yield MagicMock()
+
+        mock_get_db_ctx.side_effect = fake_db_context
+
+        with patch(
+            "backend.services.scraping_service.ScrapingHistoryRepository",
+            return_value=mock_history_repo,
+        ):
+            service.start_scraping_single("banks", "hapoalim", "MyAcc")
+
+        mock_history_repo.record_scrape_start.assert_called_once()
+        # 5th positional arg of record_scrape_start is the initial status
+        call_args = mock_history_repo.record_scrape_start.call_args
+        assert call_args[0][4] == "in_progress"
 
 
 class TestScrapingService2FA:

--- a/tests/backend/unit/test_scraper/test_scraper_2fa.py
+++ b/tests/backend/unit/test_scraper/test_scraper_2fa.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import datetime
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 from backend.scraper import ScraperAdapter
 
@@ -68,3 +70,73 @@ class TestAdapter2FA:
 
         code = asyncio.run(run())
         assert code == "654321"
+
+    def test_otp_callback_flips_status_to_waiting_for_2fa(self):
+        """The status is flipped to WAITING_FOR_2FA when the scraper awaits an OTP.
+
+        This is the "lazy 2FA prompt" behavior — the UI only sees
+        WAITING_FOR_2FA once the scraper actually needs the code, not at
+        the start of the scrape. Without this, providers like Hapoalim
+        (which only sometimes need 2FA) would show a spurious 2FA prompt
+        on every run.
+        """
+        adapter = ScraperAdapter(
+            "banks", "hapoalim", DUMMY_ACCOUNT,
+            DUMMY_CREDENTIALS, DUMMY_START_DATE, DUMMY_PROCESS_ID,
+        )
+
+        mock_history_repo = MagicMock()
+        mock_history_repo.WAITING_FOR_2FA = "waiting_for_2fa"
+
+        @contextmanager
+        def fake_db_context():
+            yield MagicMock()
+
+        async def run():
+            async def set_code():
+                await asyncio.sleep(0.05)
+                adapter.set_otp_code("12345")
+
+            asyncio.create_task(set_code())
+            return await adapter._otp_callback()
+
+        with patch(
+            "backend.scraper.adapter.get_db_context",
+            side_effect=fake_db_context,
+        ), patch(
+            "backend.scraper.adapter.ScrapingHistoryRepository",
+            return_value=mock_history_repo,
+        ):
+            code = asyncio.run(run())
+
+        assert code == "12345"
+        mock_history_repo.update_status.assert_called_once_with(
+            DUMMY_PROCESS_ID, "waiting_for_2fa"
+        )
+
+    def test_otp_callback_survives_status_update_failure(self):
+        """OTP flow continues even if the WAITING_FOR_2FA status flip fails.
+
+        The status update is best-effort UI signaling; a transient DB error
+        shouldn't crash the OTP flow or the rest of the scrape.
+        """
+        adapter = ScraperAdapter(
+            "banks", "hapoalim", DUMMY_ACCOUNT,
+            DUMMY_CREDENTIALS, DUMMY_START_DATE, DUMMY_PROCESS_ID,
+        )
+
+        async def run():
+            async def set_code():
+                await asyncio.sleep(0.05)
+                adapter.set_otp_code("99999")
+
+            asyncio.create_task(set_code())
+            return await adapter._otp_callback()
+
+        with patch(
+            "backend.scraper.adapter.get_db_context",
+            side_effect=RuntimeError("DB locked"),
+        ):
+            code = asyncio.run(run())
+
+        assert code == "99999"

--- a/tests/backend/unit/test_scraper/test_scraper_base.py
+++ b/tests/backend/unit/test_scraper/test_scraper_base.py
@@ -22,9 +22,13 @@ class TestIs2FARequired:
         """Verify onezero bank provider requires 2FA."""
         assert is_2fa_required("banks", "onezero") is True
 
-    def test_hapoalim_no_2fa(self):
-        """Verify hapoalim bank provider does not require 2FA."""
-        assert is_2fa_required("banks", "hapoalim") is False
+    def test_hapoalim_requires_2fa(self):
+        """Hapoalim is 2FA-capable: the bank sometimes asks for an SMS code.
+
+        The scraper resolves dynamically whether 2FA is needed for a given
+        run; the registry just needs to know an OTP *may* be requested.
+        """
+        assert is_2fa_required("banks", "hapoalim") is True
 
     def test_max_no_2fa(self):
         """Verify max credit card provider does not require 2FA."""


### PR DESCRIPTION
## Summary

- **Hapoalim now handles SMS-OTP at runtime.** The bank only triggers a 2FA challenge from unrecognised devices, so the new `login()` method races a URL match (success / invalid-password / change-password) against the `auth-otp-login` modal appearing in the DOM. When the modal shows up, the scraper awaits the OTP via the existing callback, types the five separated digit inputs (Angular auto-advances focus), submits, and re-checks the URL.
- **Lazy `WAITING_FOR_2FA` status flip.** Scraping always starts in `IN_PROGRESS`, regardless of `requires_2fa`. The adapter's `_otp_callback` updates the DB status to `WAITING_FOR_2FA` only when the scraper actually awaits an OTP — so a Hapoalim run from a trusted device never shows a stale "Waiting for 2FA" prompt. OneZero with a stored long-term token gets the same treatment as a side effect (no false 2FA flash before login).
- **Tests:** unit coverage for the status flip, for the flip surviving DB failures, and for the new "2FA-capable scrapes start in IN_PROGRESS" behavior. The `test_hapoalim_no_2fa` test was renamed to `test_hapoalim_requires_2fa`.

## Files changed

- `scraper/providers/banks/hapoalim.py` — replaced `get_login_options()` with a custom `login()` that handles dynamic 2FA, OTP filling via the keyboard API, and post-OTP URL verification
- `scraper/models/credentials.py` — `hapoalim.requires_2fa = True`
- `backend/scraper/__init__.py` — added `hapoalim` to `_2FA_PROVIDERS` (the parallel hardcoded set; flagged for future unification)
- `backend/scraper/adapter.py` — `_otp_callback` flips status to `WAITING_FOR_2FA` on demand; `run()` cleans the registry entry on completion to prevent leaks
- `backend/services/scraping_service.py` — always start in `IN_PROGRESS`; kept eager registration in `_tfa_scrapers_waiting` so `submit_2fa_code` can resolve the adapter before the OTP is awaited

## Test plan

- [x] `poetry run pytest tests/backend/` — all 1133 tests pass
- [x] `ruff check` on all changed files — clean
- [x] End-to-end: `python -m scraper hapoalim --headless false` from a trusted device → login succeeds without OTP prompt, transactions print
- [ ] End-to-end: same command from a new IP / fingerprint → OTP modal opens, CLI prompts `Enter OTP code:`, code is typed into the five separated inputs, submit succeeds, transactions print *(deferred — the trusted-device cookie didn't expire during testing; the DOM selectors and submission flow were verified manually via Playwright MCP during exploration)*
- [ ] In-app flow: trigger a Hapoalim scrape from Settings → confirm the UI shows `IN_PROGRESS` until the OTP modal pops (only when 2FA is actually needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)