### PR TITLE
style(dashboard): remove decorative emojis from chrome labels

### DIFF
--- a/frontend/src/components/dashboard/BudgetSection.tsx
+++ b/frontend/src/components/dashboard/BudgetSection.tsx
@@ -300,7 +300,7 @@ export function BudgetSpendingGauge({
       {/* Header row: segmented control */}
       <div className="flex items-center justify-between mb-4">
         <p className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-          🎯 {t("budget.title")}
+          {t("budget.title")}
         </p>
         {segmentedControlEl}
       </div>

--- a/frontend/src/components/dashboard/RecentTransactionsSection.tsx
+++ b/frontend/src/components/dashboard/RecentTransactionsSection.tsx
@@ -216,7 +216,7 @@ export function RecentTransactionsFeed({
     <div className="bg-[var(--surface)] rounded-2xl p-4 md:p-6 border border-[var(--surface-light)]">
       <div className="flex items-center justify-between mb-4">
         <p className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-          🧾 {t("dashboard.recentTransactions")}
+          {t("dashboard.recentTransactions")}
         </p>
         <Link
           to="/transactions"

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -116,7 +116,7 @@ function FinancialHealthHeader({
     >
       {/* Net Worth */}
       <div className="bg-[var(--surface)] rounded-xl px-3 sm:px-4 py-2.5 sm:py-3 border border-[var(--surface-light)] overflow-hidden">
-        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] truncate">💰 {t("dashboard.netWorth")}</p>
+        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] truncate">{t("dashboard.netWorth")}</p>
         <p dir="ltr" className="text-base sm:text-lg font-bold mt-0.5 truncate">
           {latestNetWorth ? formatCurrency(latestNetWorth.net_worth) : "--"}
         </p>
@@ -125,7 +125,7 @@ function FinancialHealthHeader({
 
       {/* Bank Balance */}
       <div className="bg-[var(--surface)] rounded-xl px-3 sm:px-4 py-2.5 sm:py-3 border border-[var(--surface-light)] overflow-hidden">
-        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] truncate">🏦 {t("dashboard.bankBalance")}</p>
+        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] truncate">{t("dashboard.bankBalance")}</p>
         <p dir="ltr" className="text-base sm:text-lg font-bold mt-0.5 truncate">
           {latestNetWorth ? formatCurrency(latestNetWorth.bank_balance) : "--"}
         </p>
@@ -139,7 +139,7 @@ function FinancialHealthHeader({
 
       {/* Investments */}
       <div className="bg-[var(--surface)] rounded-xl px-3 sm:px-4 py-2.5 sm:py-3 border border-[var(--surface-light)] overflow-hidden">
-        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] truncate">📈 {t("dashboard.investmentValue")}</p>
+        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] truncate">{t("dashboard.investmentValue")}</p>
         <p dir="ltr" className="text-base sm:text-lg font-bold mt-0.5 truncate">
           {latestNetWorth ? formatCurrency(latestNetWorth.investment_value) : "--"}
         </p>
@@ -153,7 +153,7 @@ function FinancialHealthHeader({
 
       {/* Cash */}
       <div className="bg-[var(--surface)] rounded-xl px-3 sm:px-4 py-2.5 sm:py-3 border border-[var(--surface-light)] overflow-hidden">
-        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] truncate">💵 {t("dashboard.cashBalance")}</p>
+        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] truncate">{t("dashboard.cashBalance")}</p>
         <p dir="ltr" className="text-base sm:text-lg font-bold mt-0.5 truncate">{formatCurrency(totalCash)}</p>
         <MomBadge mom={cashMom} />
         {expanded && cashBalances && cashBalances.length > 0 && (
@@ -458,10 +458,10 @@ export function Dashboard() {
         <div className="px-3 md:px-6 pt-4 md:pt-5 pb-0">
           <div className="flex bg-[var(--surface-light)] p-1 rounded-xl gap-1 overflow-x-auto scrollbar-auto-hide">
             {([
-              { key: "income_expenses" as const, label: `⚖️ ${t("dashboard.incomeAndExpenses")}` },
-              { key: "net_worth" as const, label: `📈 ${t("dashboard.netWorth")}` },
-              { key: "cash_flow" as const, label: `🌊 ${t("dashboard.cashFlow")}` },
-              { key: "category" as const, label: `🍕 ${t("dashboard.categories")}` },
+              { key: "income_expenses" as const, label: t("dashboard.incomeAndExpenses") },
+              { key: "net_worth" as const, label: t("dashboard.netWorth") },
+              { key: "cash_flow" as const, label: t("dashboard.cashFlow") },
+              { key: "category" as const, label: t("dashboard.categories") },
             ]).map(({ key, label }) => (
               <button
                 key={key}
@@ -752,9 +752,9 @@ export function Dashboard() {
                 </div>
                 <div className="flex bg-[var(--surface-light)] p-1 rounded-xl overflow-x-auto scrollbar-auto-hide">
                   {([
-                    { key: "overview" as const, label: `📊 ${t("dashboard.totals")}` },
-                    { key: "by_source" as const, label: `💼 ${t("dashboard.incomeBreakdown")}` },
-                    { key: "by_category" as const, label: `🍕 ${t("dashboard.expensesBreakdown")}` },
+                    { key: "overview" as const, label: t("dashboard.totals") },
+                    { key: "by_source" as const, label: t("dashboard.incomeBreakdown") },
+                    { key: "by_category" as const, label: t("dashboard.expensesBreakdown") },
                   ]).map(({ key, label }) => (
                     <button
                       key={key}


### PR DESCRIPTION
## Summary

Removes decorative emojis from the dashboard page's chrome labels:

- **Top KPI cards**: 💰 Net Worth, 🏦 Bank Balance, 📈 Investment Value, 💵 Cash Balance
- **Budget section header**: 🎯 BUDGET
- **Recent Transactions section header**: 🧾 RECENT TRANSACTIONS
- **Insight tab labels**: ⚖️ Income & Expenses, 📈 Net Worth, 🌊 Cash Flow, 🍕 Categories
- **Income view sub-tab labels**: 📊 Totals, 💼 Income Breakdown, 🍕 Expenses Breakdown

## Scope notes

Category-specific icons (🏠/🍔/🚗/💳/etc.) rendered inside budget rule cards and transaction rows are **not** touched — those are user-defined category icons stored in the data, not page chrome.

The ⏳ next to "N days remaining" in the budget header was left in place — it wasn't part of the requested change but can be removed in a follow-up if desired.

## Test plan

- [x] Verified via Playwright preview in demo mode: all targeted emojis gone from KPI cards, section headers, and tab labels; category icons in rule cards and transactions still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)