### PR TITLE
test(e2e): fix budget progress section locator after emoji removal

### DIFF
--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -40,8 +40,10 @@ test.describe("Dashboard", () => {
 
   test("shows budget progress section", async ({ page }) => {
     await page.goto("/");
-    // Header was renamed from "Budget Progress" to "BUDGET" — match either.
-    await expect(page.getByText(/^Budget Progress$|^🎯\s*BUDGET$/i).first()).toBeVisible();
+    // The section's "Budget" header is too generic to locate uniquely (the
+    // sidebar nav link has the same text). Assert on the segmented control
+    // inside the section instead — those labels live only in BudgetSection.
+    await expect(page.getByText(/Monthly Budget/i).first()).toBeVisible();
   });
 
   test("inline tag editor stages edits and commits on Done", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Updates the dashboard "shows budget progress section" e2e assertion to locate the section via the `Monthly Budget` segmented-control label instead of the header text.
- Header was just `Budget` after commit 48d7986 (decorative-emoji removal), so the old regex `/^Budget Progress$|^🎯\s*BUDGET$/i` no longer matched and shard 1/4 timed out in CI on the open dev → main PR (#102).

## Why this pattern
- The header text alone ("Budget") collides with the sidebar nav link, so `.first()` would match the wrong element.
- `Monthly Budget` is rendered only by `BudgetSection`'s segmented control on the dashboard, which uniquely identifies the section. Mirrors the locator already used in `budget.spec.ts`.

## Test plan
- [x] `npx playwright test e2e/dashboard.spec.ts` — 5 / 5 pass locally against demo mode
- [ ] CI on this PR: backend + frontend + E2E shard 1/4 green
- [ ] After merge: dev → main PR (#102) CI re-runs and all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)