### PR TITLE
style(charts): dim chart grid lines across all figures

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.15.0",
+  "version": "1.19.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.15.0",
+      "version": "1.19.7",
       "dependencies": {
         "@tanstack/query-async-storage-persister": "^5.100.3",
         "@tanstack/react-query": "^5.90.12",

--- a/frontend/src/components/dashboard/DashboardInsightsPanel.tsx
+++ b/frontend/src/components/dashboard/DashboardInsightsPanel.tsx
@@ -352,6 +352,7 @@ export function DashboardInsightsPanel({
                         ...chartTheme,
                         autosize: true,
                         yaxis: {
+                          ...chartTheme.yaxis,
                           title: {
                             text: t("dashboard.amountILS"),
                             font: { color: "#94a3b8" },
@@ -547,7 +548,8 @@ export function DashboardInsightsPanel({
                       x: 0.5,
                       xanchor: "center",
                     },
-                    yaxis: { automargin: true, type: "category", dtick: 1, ticksuffix: "  " },
+                    xaxis: { ...chartTheme.xaxis },
+                    yaxis: { ...chartTheme.yaxis, automargin: true, type: "category", dtick: 1, ticksuffix: "  " },
                     margin: { ...chartTheme.margin, l: 80, r: 20 },
                   }}
                   style={{ width: "100%", height: "100%" }}
@@ -589,11 +591,12 @@ export function DashboardInsightsPanel({
                         hovermode: isTouchDevice ? "closest" : "y unified",
                         hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" } },
                         xaxis: {
+                          ...chartTheme.xaxis,
                           range: [0, maxStack * 1.05],
                           fixedrange: true,
                           showspikes: false,
                         },
-                        yaxis: { automargin: true, type: "category", dtick: 1, ticksuffix: "  ", showspikes: false },
+                        yaxis: { ...chartTheme.yaxis, automargin: true, type: "category", dtick: 1, ticksuffix: "  ", showspikes: false },
                         legend: {
                           orientation: "h",
                           y: -0.15,
@@ -648,8 +651,8 @@ export function DashboardInsightsPanel({
                         height: Math.max(400, expensesByCategoryOverTime.length * 25),
                         hovermode: isTouchDevice ? "closest" : "y unified",
                         hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" } },
-                        xaxis: { range: [0, maxStackTotal * 1.05], fixedrange: true, showspikes: false },
-                        yaxis: { automargin: true, type: "category", dtick: 1, ticksuffix: "  ", showspikes: false },
+                        xaxis: { ...chartTheme.xaxis, range: [0, maxStackTotal * 1.05], fixedrange: true, showspikes: false },
+                        yaxis: { ...chartTheme.yaxis, automargin: true, type: "category", dtick: 1, ticksuffix: "  ", showspikes: false },
                         legend: {
                           orientation: "h",
                           y: -0.15,

--- a/frontend/src/components/investments/InvestmentAnalysisModal.tsx
+++ b/frontend/src/components/investments/InvestmentAnalysisModal.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import Plot from "react-plotly.js";
 import { investmentsApi } from "../../services/api";
-import { chartTheme, plotlyConfig } from "../../utils/plotlyLocale";
+import { chartTheme, plotlyConfig, CHART_GRID_COLOR } from "../../utils/plotlyLocale";
 import { formatCurrency } from "../../utils/numberFormatting";
 import { InfoTooltip } from "../common/InfoTooltip";
 import { Skeleton } from "../common/Skeleton";
@@ -271,7 +271,7 @@ export function InvestmentAnalysisModal({
                     layout={{
                       ...chartTheme,
                       xaxis: { showgrid: false },
-                      yaxis: { gridcolor: "rgba(255,255,255,0.05)" },
+                      yaxis: { ...chartTheme.yaxis, gridcolor: CHART_GRID_COLOR },
                     }}
                     style={{ width: "100%", height: "100%" }}
                     config={plotlyConfig()}

--- a/frontend/src/components/investments/PortfolioOverview.tsx
+++ b/frontend/src/components/investments/PortfolioOverview.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Wallet, DollarSign, Percent } from "lucide-react";
 import Plot from "react-plotly.js";
 import { investmentsApi } from "../../services/api";
-import { chartTheme, plotlyConfig } from "../../utils/plotlyLocale";
+import { chartTheme, plotlyConfig, CHART_GRID_COLOR } from "../../utils/plotlyLocale";
 import { formatCurrency } from "../../utils/numberFormatting";
 
 interface AllocationItem {
@@ -150,7 +150,7 @@ export function PortfolioOverview({ portfolioAnalysis }: PortfolioOverviewProps)
                 layout={{
                   ...chartTheme,
                   xaxis: { showgrid: false },
-                  yaxis: { gridcolor: "rgba(255,255,255,0.05)" },
+                  yaxis: { ...chartTheme.yaxis, gridcolor: CHART_GRID_COLOR },
                   showlegend: true,
                   legend: { orientation: "h", y: -0.12, font: { size: 10 } },
                 }}

--- a/frontend/src/components/retirement/NetWorthProjectionChart.tsx
+++ b/frontend/src/components/retirement/NetWorthProjectionChart.tsx
@@ -136,12 +136,12 @@ export function NetWorthProjectionChart({ data, fireNumber, targetAge }: Props) 
         ...chartTheme,
         margin: { ...chartTheme.margin, l: 80 },
         xaxis: {
+          ...chartTheme.xaxis,
           title: { text: t("earlyRetirement.charts.age") },
-          gridcolor: "rgba(148, 163, 184, 0.1)",
           dtick: 5,
         },
         yaxis: {
-          gridcolor: "rgba(148, 163, 184, 0.1)",
+          ...chartTheme.yaxis,
           tickformat: ",.0f",
           automargin: true,
         },

--- a/frontend/src/components/retirement/RetirementIncomeChart.tsx
+++ b/frontend/src/components/retirement/RetirementIncomeChart.tsx
@@ -76,12 +76,12 @@ export function RetirementIncomeChart({ data }: Props) {
         margin: { ...chartTheme.margin, l: 80 },
         barmode: "stack" as const,
         xaxis: {
+          ...chartTheme.xaxis,
           title: { text: t("earlyRetirement.charts.age") },
-          gridcolor: "rgba(148, 163, 184, 0.1)",
           dtick: 5,
         },
         yaxis: {
-          gridcolor: "rgba(148, 163, 184, 0.1)",
+          ...chartTheme.yaxis,
           tickformat: ",.0f",
           automargin: true,
         },

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -597,6 +597,7 @@ export function Dashboard() {
                           autosize: true,
                           xaxis: { ...chartTheme.xaxis, type: "date" },
                           yaxis: {
+                            ...chartTheme.yaxis,
                             title: {
                               text: netWorthView === "all" ? t("dashboard.amountILS") : t("dashboard.monthlyChange"),
                               font: { color: "#94a3b8" },
@@ -806,7 +807,8 @@ export function Dashboard() {
                         x: 0.5,
                         xanchor: "center",
                       },
-                      yaxis: { automargin: true, type: "category", dtick: 1, ticksuffix: "  " },
+                      xaxis: { ...chartTheme.xaxis },
+                      yaxis: { ...chartTheme.yaxis, automargin: true, type: "category", dtick: 1, ticksuffix: "  " },
                       margin: { ...chartTheme.margin, l: 80, r: 20 },
                     }}
                     style={{ width: "100%", height: "100%" }}
@@ -847,11 +849,12 @@ export function Dashboard() {
                           height: Math.max(400, incomeBySourceData.length * 25),
                           hovermode: isTouchDevice ? "closest" : "y unified",
                           xaxis: {
+                            ...chartTheme.xaxis,
                             range: [0, maxStack * 1.05],
                             fixedrange: true,
                             showspikes: false,
                           },
-                          yaxis: { automargin: true, type: "category", dtick: 1, ticksuffix: "  ", showspikes: false },
+                          yaxis: { ...chartTheme.yaxis, automargin: true, type: "category", dtick: 1, ticksuffix: "  ", showspikes: false },
                           legend: {
                             orientation: "h",
                             y: -0.15,
@@ -905,8 +908,8 @@ export function Dashboard() {
                           autosize: true,
                           height: Math.max(400, expensesByCategoryOverTime.length * 25),
                           hovermode: isTouchDevice ? "closest" : "y unified",
-                          xaxis: { range: [0, maxStackTotal * 1.05], fixedrange: true, showspikes: false },
-                          yaxis: { automargin: true, type: "category", dtick: 1, ticksuffix: "  ", showspikes: false },
+                          xaxis: { ...chartTheme.xaxis, range: [0, maxStackTotal * 1.05], fixedrange: true, showspikes: false },
+                          yaxis: { ...chartTheme.yaxis, automargin: true, type: "category", dtick: 1, ticksuffix: "  ", showspikes: false },
                           legend: {
                             orientation: "h",
                             y: -0.15,

--- a/frontend/src/pages/Insurances.tsx
+++ b/frontend/src/pages/Insurances.tsx
@@ -17,7 +17,7 @@ import {
   RotateCcw,
 } from "lucide-react";
 import Plot from "react-plotly.js";
-import { chartTheme, plotlyConfig } from "../utils/plotlyLocale";
+import { chartTheme, plotlyConfig, CHART_GRID_COLOR } from "../utils/plotlyLocale";
 import { insuranceAccountsApi, transactionsApi, type InsuranceAccount } from "../services/api";
 import { formatDate } from "../utils/dateFormatting";
 import { EmptyState } from "../components/common/EmptyState";
@@ -621,10 +621,10 @@ export function Insurances() {
               ...chartTheme,
               height: 280,
               margin: { t: 20, b: 40, l: 50, r: 50 },
-              xaxis: { color: "#94a3b8", gridcolor: "#334155", tickfont: { size: 10 } },
+              xaxis: { color: "#94a3b8", gridcolor: CHART_GRID_COLOR, tickfont: { size: 10 } },
               yaxis: {
                 color: "#94a3b8",
-                gridcolor: "#334155",
+                gridcolor: CHART_GRID_COLOR,
                 tickfont: { size: 10 },
                 title: { text: t("insurance.chartMonthly"), font: { size: 10, color: "#94a3b8" } },
               },

--- a/frontend/src/pages/Liabilities.tsx
+++ b/frontend/src/pages/Liabilities.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useScrollLock } from "../hooks/useScrollLock";
 import Plot from "react-plotly.js";
-import { chartTheme, plotlyConfig } from "../utils/plotlyLocale";
+import { chartTheme, plotlyConfig, CHART_GRID_COLOR } from "../utils/plotlyLocale";
 import {
   Plus,
   Landmark,
@@ -595,7 +595,7 @@ export function Liabilities() {
                 layout={{
                   ...chartTheme,
                   xaxis: { showgrid: false },
-                  yaxis: { gridcolor: "rgba(255,255,255,0.05)" },
+                  yaxis: { ...chartTheme.yaxis, gridcolor: CHART_GRID_COLOR },
                   showlegend: true,
                   legend: { orientation: "h", y: -0.12, font: { size: 10 } },
                 }}

--- a/frontend/src/utils/plotlyLocale.ts
+++ b/frontend/src/utils/plotlyLocale.ts
@@ -23,6 +23,15 @@ export const isTouchDevice =
   typeof window !== "undefined" &&
   (navigator.maxTouchPoints > 0 || "ontouchstart" in window);
 
+/**
+ * Default grid color for chart axes — slate-400 @ 10% opacity.
+ * Subtle enough to disappear behind data, visible enough to give scale.
+ * Use this constant (or spread `chartTheme.xaxis`/`chartTheme.yaxis`) instead
+ * of hard-coding bright `#334155` solids or rolling per-file values.
+ */
+export const CHART_GRID_COLOR = "rgba(148, 163, 184, 0.1)";
+export const CHART_ZEROLINE_COLOR = "rgba(148, 163, 184, 0.18)";
+
 /** Shared Plotly layout theme for dark mode charts */
 export const chartTheme: Partial<Plotly.Layout> = {
   paper_bgcolor: "rgba(0,0,0,0)",
@@ -32,7 +41,15 @@ export const chartTheme: Partial<Plotly.Layout> = {
   hoverlabel: { bgcolor: "#1e293b", bordercolor: "#334155", font: { color: "#e2e8f0" }, namelength: -1 },
   hovermode: isTouchDevice ? "closest" : "x unified",
   legend: { orientation: "h", y: -0.15, x: 0.5, xanchor: "center", font: { size: 11 }, itemwidth: 30 },
-  xaxis: { showspikes: false },
+  xaxis: {
+    showspikes: false,
+    gridcolor: CHART_GRID_COLOR,
+    zerolinecolor: CHART_ZEROLINE_COLOR,
+  },
+  yaxis: {
+    gridcolor: CHART_GRID_COLOR,
+    zerolinecolor: CHART_ZEROLINE_COLOR,
+  },
 };
 
 /** Plotly config with locale-aware date formatting */


### PR DESCRIPTION
## Summary

The default bright-white Plotly grid was overpowering the data lines on every chart in the app (Net Worth, Income & Expenses, debt totals, investment balance history, retirement projections, insurance trends). This PR dims the grid to a barely-visible slate so the data lines become the visual focus.

- Centralised the grid color in `chartTheme` (`frontend/src/utils/plotlyLocale.ts`) via two new exported constants — `CHART_GRID_COLOR = "rgba(148, 163, 184, 0.1)"` (slate-400 @ 10%) and `CHART_ZEROLINE_COLOR = "rgba(148, 163, 184, 0.18)"` — and baked them into `chartTheme.xaxis` / `chartTheme.yaxis` as the new default.
- Rewired every per-chart `xaxis` / `yaxis` override in `Dashboard.tsx`, `DashboardInsightsPanel.tsx`, `Liabilities.tsx`, `PortfolioOverview.tsx`, `InvestmentAnalysisModal.tsx`, `RetirementIncomeChart.tsx`, and `NetWorthProjectionChart.tsx` to spread `...chartTheme.xaxis` / `...chartTheme.yaxis` first, so the dim default isn't obliterated by the override.
- Replaced the brightest offender — `gridcolor: "#334155"` solid in `Insurances.tsx` — with the shared constant.
- Unified the previously divergent dim values (`rgba(255,255,255,0.05)` in Liabilities / Investments, hard-coded `rgba(148, 163, 184, 0.1)` literals in Retirement) on the single `CHART_GRID_COLOR` constant, so future tuning is a one-line change.

## Before / after

The original screenshot the user shared showed the Net Worth chart's grid as a prominent white lattice across the chart body. After the change the grid is a subtle slate texture; the Net Worth (red), Bank Balance (yellow), and Investment Value (purple) lines now dominate visually.

## Test plan

- [x] `npx tsc -b` from `frontend/` — passes clean (exit 0).
- [x] Playwright in demo mode: navigated to Dashboard → 📈 Net Worth, confirmed the chart grid is now barely visible and data lines stand out (screenshot captured locally).
- [ ] Reviewer spot-check: open Dashboard → Income & Expenses, Cash Flow, Categories, and the Investments / Liabilities / Insurances / Early Retirement pages to confirm grids look consistently dim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)