### PR TITLE
perf(investments): speed up snapshot delete and analysis refresh

### DIFF
--- a/backend/services/investments_service.py
+++ b/backend/services/investments_service.py
@@ -806,7 +806,14 @@ class InvestmentsService:
     def calculate_balance_over_time(
         self, investment_id: int, start_date: str, end_date: str
     ) -> List[Dict[str, Any]]:
-        """Calculate balance at daily intervals between two dates for charting.
+        """Calculate balance over time at the dates that actually move the line.
+
+        Samples at month-starts plus the meaningful inflection points
+        (start, end, snapshot dates, transaction dates). Daily resolution
+        was wasteful: snapshots are monthly to begin with, the chart cannot
+        display higher resolution than its pixel width, and both downstream
+        callers (``get_portfolio_overview`` and ``get_portfolio_balance_history``)
+        immediately decimate the output.
 
         When balance snapshots exist, interpolates linearly between snapshot
         points. Falls back to the transaction-based approach for dates before
@@ -824,7 +831,7 @@ class InvestmentsService:
         Returns
         -------
         list[dict]
-            List of ``{"date": str, "balance": float}`` dicts, one per day.
+            List of ``{"date": str, "balance": float}`` dicts, sorted by date.
         """
         investment = self.investments_repo.get_by_id(investment_id)
         if investment.empty:
@@ -847,25 +854,39 @@ class InvestmentsService:
             requested_end_date = datetime.strptime(end_date, "%Y-%m-%d").date()
             actual_end_date = min(last_txn_date, requested_end_date).strftime("%Y-%m-%d")
 
+        start_ts = pd.Timestamp(start_date)
+        end_ts = pd.Timestamp(actual_end_date)
+        sample_dates = pd.DatetimeIndex([start_ts, end_ts]).union(
+            pd.date_range(start=start_ts, end=end_ts, freq="MS")
+        )
+        if not transactions_df.empty:
+            txn_dates = pd.to_datetime(transactions_df["date"])
+            sample_dates = sample_dates.union(
+                txn_dates[(txn_dates >= start_ts) & (txn_dates <= end_ts)]
+            )
+        if not snapshots_df.empty:
+            snap_dates = pd.to_datetime(snapshots_df["date"])
+            sample_dates = sample_dates.union(
+                snap_dates[(snap_dates >= start_ts) & (snap_dates <= end_ts)]
+            )
+
         if snapshots_df.empty:
-            # No snapshots — use transaction-based approach
-            dates = pd.date_range(start=start_date, end=actual_end_date, freq="D")
-            balances = []
-            for d in dates:
-                balance = self._calculate_balance_from_transactions(
-                    transactions_df, as_of_date=d.strftime("%Y-%m-%d")
-                )
-                balances.append({"date": d.strftime("%Y-%m-%d"), "balance": balance})
+            balances = [
+                {
+                    "date": d.strftime("%Y-%m-%d"),
+                    "balance": self._calculate_balance_from_transactions(
+                        transactions_df, as_of_date=d.strftime("%Y-%m-%d")
+                    ),
+                }
+                for d in sample_dates
+            ]
         else:
-            # Snapshot-aware: interpolate between snapshots
             snapshots_df = snapshots_df.copy()
             snapshots_df["date"] = pd.to_datetime(snapshots_df["date"])
             snapshots_df = snapshots_df.sort_values("date")
 
-            dates = pd.date_range(start=start_date, end=actual_end_date, freq="D")
             balances = []
-
-            for d in dates:
+            for d in sample_dates:
                 d_str = d.strftime("%Y-%m-%d")
                 before = snapshots_df[snapshots_df["date"] <= d]
                 after = snapshots_df[snapshots_df["date"] >= d]

--- a/frontend/src/components/investments/InvestmentAnalysisModal.tsx
+++ b/frontend/src/components/investments/InvestmentAnalysisModal.tsx
@@ -136,7 +136,15 @@ export function InvestmentAnalysisModal({
   const deleteSnapshotMutation = useMutation({
     mutationFn: ({ snapshotId }: { snapshotId: number }) =>
       investmentsApi.deleteBalanceSnapshot(investmentId, snapshotId),
-    onSuccess: invalidateAll,
+    onSuccess: (_, { snapshotId }) => {
+      // Synchronous patch so the row disappears immediately. The global
+      // MutationCache.onSuccess in queryClient.ts handles refreshing the
+      // heavier portfolio/analysis queries after a 200 ms debounce.
+      queryClient.setQueryData<Snapshot[]>(
+        ["investment-snapshots", investmentId],
+        (old) => old?.filter((s) => s.id !== snapshotId),
+      );
+    },
   });
 
   const updateSnapshotMutation = useMutation({

--- a/tests/backend/unit/services/test_investments_service.py
+++ b/tests/backend/unit/services/test_investments_service.py
@@ -124,7 +124,7 @@ class TestInvestmentsServiceCalculations:
         assert metrics["first_transaction_date"] == "2023-01-10"
 
     def test_calculate_balance_over_time(self, db_session, seed_investments):
-        """Verify daily balance series returns correct balances at key dates."""
+        """Verify balance series returns correct balances at key dates."""
         service = InvestmentsService(db_session)
         stock_fund = seed_investments["investments"][0]
 


### PR DESCRIPTION
Two related fixes for the slow feel of the investment-analysis modal.

## 1. Patch snapshot cache on delete instead of refetching

Deleting a balance snapshot fanned out to four invalidations — including the expensive `portfolio-analysis` refetch (loops every investment, walks day-by-day through its history). The cheap snapshots refetch — the one the table actually waits for — queued behind it, so the row took several seconds to disappear.

The delete mutation's `onSuccess` now patches the snapshots query directly with `setQueryData`, filtering the deleted row out. The row updates in the same render cycle. The global `MutationCache.onSuccess` in `queryClient.ts` already invalidates everything 200 ms after any mutation, so portfolio totals, profit/loss numbers, and the Plotly chart still converge — just in the background, off the user's critical path.

## 2. Sample `calculate_balance_over_time` at meaningful dates, not daily

The function iterated day-by-day even though:
- Balance snapshots are monthly to begin with (fixed-rate auto-calculator writes monthly points; manual ones are at similar cadence).
- The Plotly chart can't display higher resolution than its pixel width.
- Both downstream callers (`get_portfolio_overview`'s sparkline decimation to ~30 points, `get_portfolio_balance_history`'s month-period group-by) immediately throw the daily resolution away.

Sample dates are now: month-starts + start + end + every snapshot date + (when no snapshots exist) every transaction date so step jumps in the transaction-only fallback still appear on the line. For a 2-year investment this is ~50 iterations instead of ~730 — a ~15× reduction in pandas filter work per call. The win compounds for `portfolio-analysis`, which calls this once per investment.

## Test plan
- [x] `pytest tests/backend/unit/services/test_investments_service.py` — 51 pass (including the 5 `calculate_balance_over_time` tests; specific date assertions like `2023-06-15`, `2024-01-15`, snapshot endpoints, and `last_date == "2024-01-10"` all still hold because those dates are either endpoints, transaction dates, or snapshot dates).
- [x] `pytest tests/backend/routes/test_investments_routes.py tests/backend/integration/` — 37 pass.
- [ ] Open Investments → "View analysis" on an investment with several snapshots → click trash. Row disappears immediately. Stat cards (current balance, profit/loss, ROI, CAGR), the Plotly chart, and the underlying portfolio totals update within ~300 ms instead of a few seconds.
- [ ] Confirm the chart still passes exactly through each snapshot point and shows step jumps at transaction dates for investments with no snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)