### PR TITLE
fix(startup): run alembic upgrade head on lifespan boot

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -68,6 +68,28 @@ async def lifespan(app: FastAPI):
     print("Starting Finance Analysis API...")
     Base.metadata.create_all(bind=get_engine())
 
+    # Apply pending Alembic migrations. ``create_all`` only creates missing
+    # tables — it never adds columns to existing ones — so without this every
+    # schema change after the initial install silently fails to land and the
+    # ORM raises "no such column" on first query. The Alembic env wires the
+    # URL to ``get_database_url()`` so this runs against the same DB the app
+    # uses, and every migration is idempotent (each inspects the schema before
+    # altering), so it's safe on fresh installs too.
+    from alembic import command
+    from alembic.config import Config
+
+    if getattr(sys, "frozen", False):
+        alembic_ini = Path(getattr(sys, "_MEIPASS", "")) / "alembic.ini"
+    else:
+        alembic_ini = Path(__file__).resolve().parent.parent / "alembic.ini"
+
+    if alembic_ini.is_file():
+        command.upgrade(Config(str(alembic_ini)), "head")
+    else:
+        logger.warning(
+            "alembic.ini not found at %s — skipping migrations", alembic_ini
+        )
+
     # Seed categories and migrate credentials
     with get_db_context() as db:
         config = AppConfig()


### PR DESCRIPTION
## Summary

- `Base.metadata.create_all()` only creates missing tables — it never adds columns to existing ones — so any schema change after the initial install silently failed to land on user DBs. The `InsuranceAccount.custom_name` column (migration `a1b2c3d4e5f6`) was the victim: existing installs hit `no such column: custom_name` on every SELECT, `/api/insurance-accounts/` 500'd, and the Insurances page rendered EmptyState even with policies present in the DB.
- Wire `alembic.command.upgrade(cfg, "head")` into the lifespan right after `create_all()`. Resolves `alembic.ini` from `sys._MEIPASS` when frozen and from the source tree otherwise, mirroring `_resolve_frontend_dist()`.
- All existing migrations are written idempotently (each inspects the schema before altering), so this is safe to run on every startup — current, stale, or completely fresh.

## Why this is the root-cause fix

The PyInstaller spec already bundles Alembic (`build/finance_analysis.spec:62-63`), and the comment at line 46 literally mentions "alembic stamp" as something the lifespan should do. Someone laid the groundwork but never finished wiring it. Without this, every future migration the team adds would silently fail to apply on existing user DBs, surfacing as a "no such column" 500 the next time the ORM SELECTs from the affected table.

## Test plan

- [x] All 1132 backend tests pass (88.55% coverage).
- [x] Idempotency: running `upgrade(head)` twice in a row is a no-op (no migrations logged the second time).
- [x] Fresh-install path: DB with no `alembic_version` table → upgrade applies all migrations, each no-ops on existing tables, version lands at head.
- [x] Integration test via `TestClient`: started from a DB at `ecec034aa367` with `custom_name` dropped → lifespan logged `Running upgrade ecec034aa367 -> a1b2c3d4e5f6, add custom_name to insurance_accounts` → endpoint returned 200 / 5 rows after boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)