### PR TITLE
fix(analytics): include investment gains and cash in dashboard net worth

### DIFF
--- a/.claude/rules/kpi_calculations.md
+++ b/.claude/rules/kpi_calculations.md
@@ -158,11 +158,12 @@ Known structural residual: **net cash position** from cash transactions. Cash in
 - **Output:** Splits into `expenses` (net negative categories) and `refunds` (net positive categories)
 
 ### `get_net_worth_over_time()`
-- **Purpose:** Net worth trend with bank balance and investment value lines
+- **Purpose:** Net worth trend with bank balance, investment value, and cash lines
 - **CC handling:** `exclude_services=["credit_card_transactions"]`
-- **Prior wealth:** All prior wealth starts in `bank_balance`; investment movements shift value between the two lines
-- **Investments:** `-sum(all investment transactions to date)` — same formula as overview KPI, applied cumulatively per month
-- **Formula:** See "Why Investment Prior Wealth Lives in Bank Balance" above
+- **Cash isolation:** Cash transactions are split out of the bank-side cumulative — `bank_balance` is reconstructed from bank + manual-investment transactions only. Cash sits exclusively in the `cash` line. (Before this split, cash spending leaked into `bank_balance` and net worth missed the cash entirely.)
+- **Prior wealth:** Bank/investment prior wealth seeds `bank_balance`; investment movements shift value between the bank and investment lines via the inv_prior offset. Cash prior wealth seeds `cash`.
+- **Investments:** snapshot-resolved per investment per month-end via `InvestmentsService.get_total_value_at_date` (snapshot-first, transaction-based fallback when no snapshot exists). Closed investments naturally contribute 0 after their auto-created close snapshot, and their historical pre-close value before. Market gains/losses recorded as snapshots flow through into both `investment_value` and `net_worth`.
+- **Formula:** `net_worth = bank_balance + investment_value + cash` for each month. See "Why Investment Prior Wealth Lives in Bank Balance" above for the bank↔investment offset.
 
 ### `get_sankey_data()`
 - **Purpose:** Cash flow diagram (sources → Total Income → destinations)

--- a/backend/services/analysis_service.py
+++ b/backend/services/analysis_service.py
@@ -621,11 +621,13 @@ class AnalysisService:
 
     def get_net_worth_over_time(self) -> list[dict]:
         """
-        Get monthly net worth (bank balance + investment value) over time.
+        Get monthly net worth (bank balance + investment value + cash) over time.
 
         Bank balance is reconstructed as ``prior_wealth + cumulative bank transactions``.
-        Investment value is ``cumulative investment transactions``
-        (negative investment amounts are deposits, so balance is negated sum).
+        Investment value is the snapshot-resolved portfolio value at each
+        month end (snapshot-first per investment, transaction-based fallback
+        when no snapshot exists). This means market gains/losses recorded
+        as snapshots flow through into both ``investment_value`` and ``net_worth``.
         Cash balance is reconstructed as ``cash_prior_wealth + cumulative cash transactions``.
         An anchor data point one month before the earliest transaction shows
         the pure prior-wealth baseline.
@@ -637,9 +639,9 @@ class AnalysisService:
 
             - ``month`` – period in ``YYYY-MM`` format.
             - ``bank_balance`` – reconstructed bank balance at month end.
-            - ``investment_value`` – reconstructed investment value at month end.
+            - ``investment_value`` – snapshot-resolved investment value at month end.
             - ``cash`` – reconstructed cash balance at month end.
-            - ``net_worth`` – ``bank_balance + investment_value``.
+            - ``net_worth`` – ``bank_balance + investment_value + cash``.
         """
         bank_prior_wealth = self.bank_balance_service.get_total_prior_wealth()
         investment_prior_wealth = self.investments_service.get_total_prior_wealth()
@@ -656,14 +658,14 @@ class AnalysisService:
         df["month"] = df["date_parsed"].dt.strftime("%Y-%m")
         months = sorted(df["month"].unique())
 
-        # --- Cash transactions: separate from main df for cash balance line ---
+        # --- Split cash off from bank-side cashflow ---
+        # bank_df: bank + manual-investment transactions. Manual investment
+        # deposits/withdrawals stay here because their offset is wired into
+        # investment_prior_wealth, so they correctly drain/refill bank as
+        # they happen. Cash lives only in the cash line.
         cash_mask = df["source"] == Tables.CASH.value
         cash_df = df[cash_mask]
-
-        # --- Investment transactions: fetch once, filter per month in-memory ---
-        inv_df = self.investments_service.get_all_investment_transactions_combined(include_closed=True)
-        if not inv_df.empty:
-            inv_df["date_parsed"] = pd.to_datetime(inv_df["date"])
+        bank_df = df[~cash_mask]
 
         # --- Prior-wealth anchor point (1 month before earliest data) ---
         anchor_month = (pd.to_datetime(months[0] + "-01") - pd.DateOffset(months=1)).strftime("%Y-%m")
@@ -673,20 +675,18 @@ class AnalysisService:
             "bank_balance": round(prior_wealth_total, 2),
             "investment_value": 0.0,
             "cash": round(cash_prior_wealth, 2),
-            "net_worth": round(prior_wealth_total, 2),
+            "net_worth": round(prior_wealth_total + cash_prior_wealth, 2),
         }]
 
         for month in months:
             month_end = pd.to_datetime(month + "-01") + pd.offsets.MonthEnd(0)
+            month_end_str = month_end.strftime("%Y-%m-%d")
 
             bank_balance = prior_wealth_total + float(
-                df.loc[df["date_parsed"] <= month_end, "amount"].sum()
+                bank_df.loc[bank_df["date_parsed"] <= month_end, "amount"].sum()
             )
 
-            inv_to_date = (
-                -float(inv_df.loc[inv_df["date_parsed"] <= month_end, "amount"].sum())
-                if not inv_df.empty else 0.0
-            )
+            inv_value = self.investments_service.get_total_value_at_date(month_end_str)
 
             cash_balance = cash_prior_wealth + float(
                 cash_df.loc[cash_df["date_parsed"] <= month_end, "amount"].sum()
@@ -695,9 +695,9 @@ class AnalysisService:
             result.append({
                 "month": month,
                 "bank_balance": round(bank_balance, 2),
-                "investment_value": round(inv_to_date, 2),
+                "investment_value": round(inv_value, 2),
                 "cash": round(cash_balance, 2),
-                "net_worth": round(bank_balance + inv_to_date, 2),
+                "net_worth": round(bank_balance + inv_value + cash_balance, 2),
             })
 
         return result

--- a/backend/services/investments_service.py
+++ b/backend/services/investments_service.py
@@ -803,6 +803,48 @@ class InvestmentsService:
         )
         return self._calculate_balance_from_transactions(transactions_df)
 
+    def get_total_value_at_date(self, target_date: str) -> float:
+        """Sum snapshot-resolved balances for every investment as of a date.
+
+        Per investment, applies the same resolution as
+        ``calculate_current_balance``: latest snapshot on or before
+        ``target_date`` if present, otherwise the transaction-based
+        ``-sum(amounts up to target_date)``. Closed investments are
+        included — they auto-receive a 0-balance snapshot at close, so
+        the snapshot-first logic naturally returns 0 for dates after
+        the close, and their pre-close value for dates before.
+
+        Parameters
+        ----------
+        target_date : str
+            Cut-off date in ``YYYY-MM-DD`` format (inclusive).
+
+        Returns
+        -------
+        float
+            Total portfolio value as of ``target_date``.
+        """
+        investments = self.investments_repo.get_all_investments(include_closed=True)
+        if investments.empty:
+            return 0.0
+
+        total = 0.0
+        for _, inv in investments.iterrows():
+            inv_id = int(inv["id"])
+            snapshot = self.snapshots_repo.get_latest_snapshot_on_or_before(
+                inv_id, target_date
+            )
+            if snapshot is not None:
+                total += float(snapshot["balance"])
+                continue
+            txns = self._get_all_transactions_for_investment(
+                inv["category"], inv["tag"], investment_id=inv_id
+            )
+            total += self._calculate_balance_from_transactions(
+                txns, as_of_date=target_date
+            )
+        return total
+
     def calculate_balance_over_time(
         self, investment_id: int, start_date: str, end_date: str
     ) -> List[Dict[str, Any]]:

--- a/tests/backend/unit/services/test_analysis_service.py
+++ b/tests/backend/unit/services/test_analysis_service.py
@@ -1,7 +1,9 @@
 """Tests for AnalysisService functionality."""
 
+import pandas as pd
 import pytest
 
+from backend.constants.tables import Tables
 from backend.models.transaction import BankTransaction, CreditCardTransaction
 from backend.services.analysis_service import AnalysisService
 from backend.services.investments_service import InvestmentsService
@@ -184,16 +186,50 @@ class TestAnalysisServiceNetWorthOverTime:
         months = [r["month"] for r in result]
         assert months == ["2023-12", "2024-01", "2024-02", "2024-03"]
 
-    def test_get_net_worth_over_time_net_worth_equals_bank_plus_investments(
+    def test_get_net_worth_over_time_net_worth_equals_bank_plus_investments_plus_cash(
         self, db_session, seed_base_transactions
     ):
-        """Verify net_worth = bank_balance + investment_value for each month."""
+        """Verify net_worth = bank_balance + investment_value + cash for each month."""
         service = AnalysisService(db_session)
         result = service.get_net_worth_over_time()
 
         for entry in result:
             assert entry["net_worth"] == pytest.approx(
-                entry["bank_balance"] + entry["investment_value"]
+                entry["bank_balance"] + entry["investment_value"] + entry["cash"]
+            )
+
+    def test_get_net_worth_over_time_cash_does_not_leak_into_bank_balance(
+        self, db_session, seed_base_transactions
+    ):
+        """Verify bank_balance reflects only bank-side flows, not cash spending.
+
+        seed_base_transactions has no investments and no bank-balance prior
+        wealth seeded, so prior_wealth_total is 0 and bank_balance at any
+        month-end must equal the cumulative sum of *bank-only* transactions
+        up to that month-end. Cash transactions belong in the cash line, not
+        bundled into bank_balance.
+        """
+        from backend.repositories.transactions_repository import TransactionsRepository
+
+        repo = TransactionsRepository(db_session)
+        bank_only = repo.get_cashflow_transactions()
+        bank_only["date_parsed"] = pd.to_datetime(bank_only["date"])
+        bank_only = bank_only[bank_only["source"] != Tables.CASH.value]
+
+        service = AnalysisService(db_session)
+        result = service.get_net_worth_over_time()
+
+        for entry in result[1:]:  # skip anchor
+            month_end = (
+                pd.to_datetime(entry["month"] + "-01") + pd.offsets.MonthEnd(0)
+            )
+            expected = float(
+                bank_only.loc[bank_only["date_parsed"] <= month_end, "amount"].sum()
+            )
+            assert entry["bank_balance"] == pytest.approx(expected), (
+                f"bank_balance for {entry['month']} should be {expected} "
+                f"(bank+inv cumulative only) but was {entry['bank_balance']} — "
+                f"cash leaked in"
             )
 
 


### PR DESCRIPTION
## Summary

- The Dashboard's **Investment Value** KPI was showing transaction-based net invested (and including closed investments) instead of snapshot-based current portfolio value.
- **Net Worth** was therefore missing investment gains AND missing cash entirely.
- **Bank Balance** silently included cash transactions in its cumulative sum, so cash spend got double-counted (dragging bank down while also showing in the cash line).

This PR fixes all three so the four KPI cards on the dashboard tell a consistent story, and the same correction flows through to the Net Worth chart and the 5Y/3Y/1Y/6M/1M change cards.

## Changes

- **`InvestmentsService.get_total_value_at_date(target_date)`** *(new)* — sums snapshot-resolved balances across every investment as of a date. Snapshot-first per investment, transaction-based fallback when no snapshot exists. Closed investments naturally contribute 0 after their auto-created close snapshot and their pre-close value before.
- **`AnalysisService.get_net_worth_over_time`** — `investment_value` now uses the new helper; the cumulative used for `bank_balance` is split into `bank_df` (bank + manual-investment) and `cash_df`, so cash stays exclusively in the cash line; `net_worth = bank_balance + investment_value + cash`.
- **Regression test** locks in cash-isolation by deriving the expected bank-only cumulative from seed data and asserting `bank_balance` matches it.
- **`kpi_calculations.md`** rewritten to describe the new formulas.

## Empirical impact (demo data)

| KPI | Before | After |
|---|---|---|
| Investment Value | 266,334 ₪ | **402,809 ₪** (snapshot growth + drops closed Corporate Bond) |
| Bank Balance | 1,003,211 ₪ | **1,012,358 ₪** (cash spend no longer subtracted) |
| Net Worth | 1,269,546 ₪ | **1,407,320 ₪** (includes inv gains + cash, no double-count) |
| 1M change (Investments) | 0% | **+31.5%** (now reflects real value change) |

## Test plan

- [x] `pytest tests/backend/unit/services/test_analysis_service.py` (51 pass)
- [x] `pytest tests/backend/unit/services/test_investments_service.py tests/backend/routes/test_analytics_routes.py tests/backend/routes/test_investments_routes.py tests/backend/integration/` (97 pass)
- [x] Frontend `tsc -b` clean
- [x] Verified end-to-end in browser with Demo Mode on: dashboard KPI values, MoM badges, expansion breakdown sums all match
- [x] Verified Investments page's Total Value matches the Dashboard's Investment Value KPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)