### PR TITLE
feat(transactions): default auto-tagging rule conditions to OR

### DIFF
--- a/frontend/e2e/flows/transaction-create-rule.spec.ts
+++ b/frontend/e2e/flows/transaction-create-rule.spec.ts
@@ -34,4 +34,31 @@ test.describe("Auto-tagging rule flow", () => {
       page.getByRole("button", { name: /add rule|new rule/i }).first(),
     ).toBeVisible({ timeout: 5_000 });
   });
+
+  test("new rule defaults the conditions group to OR", async ({ page }) => {
+    await gotoAndWait(page, "/transactions");
+    await expect(page.locator("table tbody tr").first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("button", { name: /auto tagging/i }).click();
+    await page.getByRole("button", { name: /new rule/i }).first().click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Top-level conditions group should default to "OR (Any match)".
+    await expect(
+      dialog.getByRole("button", { name: /OR \(Any match\)/i }).first(),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Adding a nested group should also default to OR (consistency).
+    await dialog.getByRole("button", { name: /^\+ Group$|^Group$/ }).first().click();
+    await expect(
+      dialog.getByRole("button", { name: /OR \(Any match\)/i }),
+    ).toHaveCount(2, { timeout: 5_000 });
+
+    // Close without saving.
+    await dialog.getByRole("button", { name: /^cancel$/i }).click();
+  });
 });

--- a/frontend/src/components/transactions/RuleBuilder.tsx
+++ b/frontend/src/components/transactions/RuleBuilder.tsx
@@ -106,7 +106,7 @@ export function RuleBuilder({ value, onChange, depth = 0, onRemove }: RuleBuilde
                             <Plus size={10} /> {t("ruleBuilder.condition")}
                         </button>
                         <button
-                            onClick={() => addSubCondition("AND")}
+                            onClick={() => addSubCondition("OR")}
                             className="flex items-center gap-1 px-2 py-1.5 rounded bg-[var(--surface)] hover:bg-[var(--surface-light)] text-[10px] font-bold border border-[var(--surface-light)]"
                         >
                             <Plus size={10} /> {t("ruleBuilder.group")}

--- a/frontend/src/components/transactions/RuleEditorModal.tsx
+++ b/frontend/src/components/transactions/RuleEditorModal.tsx
@@ -20,7 +20,7 @@ interface RuleEditorModalProps {
 }
 
 const EMPTY_CONDITIONS: ConditionNode = {
-    type: "AND",
+    type: "OR",
     subconditions: [
         { type: "CONDITION", field: "description", operator: "contains", value: "" }
     ]


### PR DESCRIPTION
## Summary

- New auto-tagging rule modal now defaults the top-level conditions group to **OR (Any match)** instead of **AND (All match)**.
- The "+ Group" button inside the rule builder also creates nested groups as OR, so the default stays consistent at every depth.
- Users can still toggle either group to AND via the existing AND/OR dropdown.

## Why

Most rules people write match alternative descriptions (`"NETFLIX" OR "SPOTIFY" OR …`) rather than requiring every condition to hold at once. Defaulting to OR removes the need to flip the dropdown on almost every new rule.

## Files

- [RuleEditorModal.tsx:23](https://github.com/tomerroditi/finance-analysis/blob/claude/beautiful-blackwell-3a7134/frontend/src/components/transactions/RuleEditorModal.tsx#L23) — `EMPTY_CONDITIONS.type` changed from `"AND"` to `"OR"` (new-rule default).
- [RuleBuilder.tsx:109](https://github.com/tomerroditi/finance-analysis/blob/claude/beautiful-blackwell-3a7134/frontend/src/components/transactions/RuleBuilder.tsx#L109) — "+ Group" button now calls `addSubCondition("OR")` instead of `"AND"`.
- [transaction-create-rule.spec.ts](https://github.com/tomerroditi/finance-analysis/blob/claude/beautiful-blackwell-3a7134/frontend/e2e/flows/transaction-create-rule.spec.ts) — new e2e test asserts both the top-level group and a newly-added nested group default to "OR (Any match)".

## Test plan

- [x] Open the Create Rule modal — top-level dropdown shows "OR (Any match)".
- [x] Click "+ Group" inside conditions — the new nested group also shows "OR (Any match)".
- [x] \`npx playwright test flows/transaction-create-rule.spec.ts\` passes (2 tests).
- [ ] Reviewer: confirm existing saved rules (stored as AND) still render correctly when re-opened for edit — no behavior change there; the default only applies to fresh state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)