### PR TITLE
chore(tagging-rules): drop "Auto: " prefix from rule names

### DIFF
--- a/backend/alembic/versions/b2c4d6e8f0a1_strip_auto_prefix_from_tagging_rule_names.py
+++ b/backend/alembic/versions/b2c4d6e8f0a1_strip_auto_prefix_from_tagging_rule_names.py
@@ -1,0 +1,48 @@
+"""strip "Auto: " prefix from tagging rule names
+
+Revision ID: b2c4d6e8f0a1
+Revises: a1b2c3d4e5f6
+Create Date: 2026-05-23 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b2c4d6e8f0a1'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Remove the legacy ``Auto: `` prefix from existing tagging rule names."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if 'tagging_rules' not in inspector.get_table_names():
+        return
+    conn.execute(
+        sa.text(
+            "UPDATE tagging_rules "
+            "SET name = SUBSTR(name, 7) "
+            "WHERE name LIKE 'Auto: %'"
+        )
+    )
+
+
+def downgrade() -> None:
+    """Re-apply the ``Auto: `` prefix to rule names that lack it."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if 'tagging_rules' not in inspector.get_table_names():
+        return
+    conn.execute(
+        sa.text(
+            "UPDATE tagging_rules "
+            "SET name = 'Auto: ' || name "
+            "WHERE name NOT LIKE 'Auto: %'"
+        )
+    )

--- a/frontend/src/components/transactions/RuleEditorModal.tsx
+++ b/frontend/src/components/transactions/RuleEditorModal.tsx
@@ -61,7 +61,7 @@ export function RuleEditorModal({ isOpen, onClose, editingRule, onSaved }: RuleE
         ? (categories[category] || []).filter(t => !takenTags.has(`${category}::${t}`))
         : [];
 
-    const name = tag ? `Auto: ${category} - ${tag}` : "";
+    const name = tag ? `${category} - ${tag}` : "";
 
     // Initialize form when editing
      


### PR DESCRIPTION
## Summary
- `RuleEditorModal` no longer prepends `Auto: ` to auto-generated rule names — new rules are named `<Category> - <Tag>`.
- Adds alembic migration `b2c4d6e8f0a1` that strips the legacy `Auto: ` prefix from existing `tagging_rules.name` rows on next boot. Idempotent — only updates rows matching `LIKE 'Auto: %'`, skips if the table doesn't exist yet.

## Test plan
- [ ] Backend tests pass: `poetry run pytest tests/backend/unit/repositories/test_tagging_rules_repository.py tests/backend/unit/services/test_tagging_rules_service.py tests/backend/routes/test_tagging_rules_routes.py tests/backend/unit/models/test_tagging_rules_model.py` (116 passed locally).
- [ ] Migration applies cleanly: boot the backend against a DB seeded with a `Auto: Foo - Bar` rule and confirm it becomes `Foo - Bar` and `alembic_version` advances to `b2c4d6e8f0a1`.
- [ ] Open the Auto-Tagging panel in the UI, create a new rule, and confirm the generated name preview reads `<Category> - <Tag>` (no `Auto: ` prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)