### PR TITLE
fix(SelectDropdown): stop list from jumping while hovering options

### DIFF
--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -70,4 +70,50 @@ test.describe("Transactions", () => {
       await page.waitForTimeout(300);
     }
   });
+
+  test("bulk-edit category dropdown does not scroll when hovering visible options", async ({ page }) => {
+    // Regression: hovering options used to call scrollIntoView on every
+    // mouseenter, which fed back on itself — items shifted under the cursor,
+    // a new mouseenter fired, the list scrolled again, and so on until it
+    // bottomed out.
+    await navigateTo(page, "/transactions");
+    await expect(page.locator("table tbody tr").first()).toBeVisible({ timeout: 10_000 });
+
+    // Select 3 transactions to surface the BulkActionsBar.
+    const checkboxes = page.locator("table tbody tr input[type='checkbox']");
+    for (let i = 0; i < 3; i++) {
+      await checkboxes.nth(i).check();
+    }
+
+    // Open the bulk Category dropdown.
+    await page.getByRole("button", { name: "Category" }).click();
+    const listbox = page.getByRole("listbox");
+    await expect(listbox).toBeVisible();
+
+    // Find the visible options inside the listbox.
+    const visibleOptions = await page.evaluate(() => {
+      const lb = document.querySelector('[role="listbox"]') as HTMLElement;
+      if (!lb) return [];
+      const rect = lb.getBoundingClientRect();
+      return Array.from(lb.querySelectorAll('[role="option"]'))
+        .map((el) => {
+          const r = (el as HTMLElement).getBoundingClientRect();
+          const fullyVisible = r.top >= rect.top && r.bottom <= rect.bottom;
+          return { name: (el.textContent || "").trim(), fullyVisible };
+        })
+        .filter((o) => o.fullyVisible);
+    });
+    expect(visibleOptions.length).toBeGreaterThanOrEqual(3);
+
+    const scrollTopBefore = await listbox.evaluate((el) => el.scrollTop);
+
+    // Hover several fully-visible options. Each hover sets highlightIndex
+    // via onMouseEnter; if the regression returns the listbox will scroll.
+    for (const opt of visibleOptions.slice(0, 3)) {
+      await page.getByRole("option", { name: opt.name, exact: true }).hover();
+    }
+
+    const scrollTopAfter = await listbox.evaluate((el) => el.scrollTop);
+    expect(scrollTopAfter).toBe(scrollTopBefore);
+  });
 });

--- a/frontend/src/components/common/SelectDropdown.tsx
+++ b/frontend/src/components/common/SelectDropdown.tsx
@@ -33,6 +33,10 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
   const dropdownRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  // Only scroll the highlighted item into view when keyboard nav moved it —
+  // mouse hover already implies the item is visible, and scrolling on hover
+  // creates a feedback loop (items shift under the cursor → new mouseenter).
+  const scrollOnNextHighlight = useRef(false);
   const [pos, setPos] = useState({ top: 0, left: 0, width: 0, openUp: false });
   const [isCreating, setIsCreating] = useState(false);
   const [createValue, setCreateValue] = useState("");
@@ -113,8 +117,13 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
     setHighlightIndex(-1);
   }, [search]);
 
-  // Scroll highlighted item into view
+  // Scroll highlighted item into view — only for keyboard nav (Arrow keys).
+  // Mouse hover sets highlightIndex too, but scrolling then creates a feedback
+  // loop: the listbox scrolls, items shift under the cursor, a new mouseenter
+  // fires on the now-hovered item, and the list keeps walking to the bottom.
   useEffect(() => {
+    if (!scrollOnNextHighlight.current) return;
+    scrollOnNextHighlight.current = false;
     if (highlightIndex < 0 || !listRef.current) return;
     const items = listRef.current.children;
     if (items[highlightIndex]) {
@@ -129,12 +138,14 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
       switch (e.key) {
         case "ArrowDown":
           e.preventDefault();
+          scrollOnNextHighlight.current = true;
           setHighlightIndex((prev) =>
             prev < filteredOptions.length - 1 ? prev + 1 : 0,
           );
           break;
         case "ArrowUp":
           e.preventDefault();
+          scrollOnNextHighlight.current = true;
           setHighlightIndex((prev) =>
             prev > 0 ? prev - 1 : filteredOptions.length - 1,
           );


### PR DESCRIPTION
## Summary

- Bulk-edit Category/Tag dropdown in the transactions page no longer scrolls to the bottom when moving the mouse across options.
- Gated `scrollIntoView` so it only fires on keyboard navigation (ArrowUp/ArrowDown). Hovered items are visible by definition.
- Added an e2e regression test under `frontend/e2e/transactions.spec.ts`.

## Why

The `useEffect` in `SelectDropdown.tsx` called `scrollIntoView({ block: "nearest" })` on every `highlightIndex` change. That index updates from both keyboard nav (intended) and `onMouseEnter` (so Enter can select the hovered option). For options at the edge of the listbox, the chain was:

1. Hover an edge option → `setHighlightIndex(idx)`
2. Effect calls `scrollIntoView` → listbox scrolls a few pixels to fully reveal the item
3. Items shift under the still-stationary cursor → a *different* option is now under the pointer
4. `mouseenter` fires on the new option → goto 1

Reproduced: hovering Kids then Shopping in the bulk Category dropdown moved `listbox.scrollTop` from `0 → 33 → 156.5` and continued to walk the list down. After the fix, hovering visible options keeps `scrollTop` at `0`; keyboard arrows still scroll the list to follow the highlight (10 × ArrowDown moved `scrollTop` from `0 → 193`).

## Test plan

- [x] Reproduce the bug in Playwright on `/transactions` with demo mode + 3 selected rows + bulk Category dropdown.
- [x] Verify hovering multiple fully-visible options keeps `scrollTop` at `0`.
- [x] Verify keyboard arrows still scroll the listbox to track the highlight.
- [x] `npm test -- --run` — 175 / 175 unit tests pass.
- [x] `npm run lint` — clean.
- [x] `npx tsc -b` — clean.
- [x] `npx playwright test transactions.spec.ts` — 5 / 5 pass, including the new regression spec at [transactions.spec.ts:74](frontend/e2e/transactions.spec.ts#L74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)