### PR TITLE
fix(tagging-rules): show all matching transactions in rule editor

### DIFF
--- a/backend/routes/tagging_rules.py
+++ b/backend/routes/tagging_rules.py
@@ -216,7 +216,7 @@ async def validate_rule_conflicts(
 
 class RulePreview(BaseModel):
     conditions: Dict[str, Any]
-    limit: int = 100
+    limit: Optional[int] = None
 
 
 @router.post("/rules/preview")
@@ -230,8 +230,9 @@ async def preview_rule_matches(
     Parameters
     ----------
     preview : RulePreview
-        ``conditions`` dict defining match criteria and ``limit`` (default 100)
-        capping the number of returned matches.
+        ``conditions`` dict defining match criteria and optional ``limit``
+        capping the number of returned matches. When ``limit`` is omitted or
+        ``null``, all matches are returned.
 
     Returns
     -------

--- a/backend/services/tagging_rules_service.py
+++ b/backend/services/tagging_rules_service.py
@@ -304,11 +304,12 @@ class TaggingRulesService:
         return self._apply_single_rule(rule_dict, overwrite=overwrite)
 
     def preview_rule(
-        self, conditions: Dict[str, Any], limit: int = 100
+        self, conditions: Dict[str, Any], limit: Optional[int] = None
     ) -> List[Dict[str, Any]]:
         """
         Preview which transactions would match given conditions without modifying them.
-        Returns list of matching transactions with key fields.
+        Returns list of matching transactions with key fields. When ``limit`` is None,
+        all matches are returned.
         """
         conditions = self._normalize_conditions(conditions)
         tables = self._get_tables_names_for_conditions(conditions)
@@ -321,7 +322,9 @@ class TaggingRulesService:
                 model.id, model.unique_id, model.date, model.description,
                 model.amount, model.category, model.tag, model.account_name,
                 model.provider,
-            ).where(filter_expr).limit(limit)
+            ).where(filter_expr)
+            if limit is not None:
+                stmt = stmt.limit(limit)
             df = pd.read_sql(stmt, self.db.bind)
             if not df.empty:
                 df["source"] = table
@@ -331,7 +334,9 @@ class TaggingRulesService:
             return []
 
         combined = pd.concat(results, ignore_index=True)
-        combined = combined.sort_values("date", ascending=False).head(limit)
+        combined = combined.sort_values("date", ascending=False)
+        if limit is not None:
+            combined = combined.head(limit)
         return combined.to_dict(orient="records")
 
     def validate_rule_integrity(self, conditions: Dict[str, Any]):

--- a/frontend/e2e/rule-editor-preview.spec.ts
+++ b/frontend/e2e/rule-editor-preview.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "@playwright/test";
+import { enableDemoMode, disableDemoMode, navigateTo } from "./helpers";
+
+test.describe("Rule editor matching transactions preview", () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await enableDemoMode(page);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await disableDemoMode(page);
+    await page.close();
+  });
+
+  test("matching transactions table is not capped at 50", async ({ page }) => {
+    await navigateTo(page, "/transactions");
+    await page.waitForLoadState("networkidle");
+
+    // Open the Auto Tagging panel
+    await page.getByRole("button", { name: /^Auto Tagging$/ }).click();
+
+    // Click the visible "New Rule" button (the one inside the open panel)
+    await page.getByRole("button", { name: /^New Rule$/ }).click();
+
+    // Wait for the editor modal to render and pick the visible Value input
+    // inside it (there can be a duplicate hidden one for the mobile layout).
+    const modal = page.locator(".modal-overlay").last();
+    await expect(modal).toBeVisible();
+    const valueInput = modal.locator('input[placeholder="Value"]:visible').first();
+    await expect(valueInput).toBeVisible();
+    await valueInput.fill("WOLT");
+
+    // Debounce in the modal is 300ms; wait for the preview query.
+    await page.waitForResponse(
+      (res) =>
+        res.url().includes("/api/tagging-rules/rules/preview") &&
+        res.request().method() === "POST",
+    );
+
+    // The matches count and the rendered row count should both exceed 50,
+    // proving the previous 50-row cap is gone.
+    const matchesLabel = modal.getByText(/\d+\s*matches/).first();
+    await expect(matchesLabel).toBeVisible();
+    const labelText = await matchesLabel.textContent();
+    const matchCount = parseInt(labelText?.match(/(\d+)/)?.[1] ?? "0", 10);
+    expect(matchCount).toBeGreaterThan(50);
+
+    // The modal's preview table should render every match.
+    const previewRows = modal.locator("table tbody tr");
+    await expect(previewRows).toHaveCount(matchCount);
+  });
+});

--- a/frontend/src/components/transactions/RuleEditorModal.tsx
+++ b/frontend/src/components/transactions/RuleEditorModal.tsx
@@ -97,7 +97,7 @@ export function RuleEditorModal({ isOpen, onClose, editingRule, onSaved }: RuleE
     // Preview query
     const { data: preview, isLoading: previewLoading } = useQuery({
         queryKey: ["rule-preview", debouncedConditions],
-        queryFn: () => taggingApi.previewRule(debouncedConditions, 50).then(res => res.data),
+        queryFn: () => taggingApi.previewRule(debouncedConditions).then(res => res.data),
         enabled: isOpen && hasValidCondition(debouncedConditions),
         staleTime: 5000,
     });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -202,10 +202,10 @@ export const taggingApi = {
       tag,
       rule_id: ruleId
     }),
-  previewRule: (conditions: ConditionNode, limit = 100) =>
+  previewRule: (conditions: ConditionNode, limit?: number) =>
     api.post<{ matches: Record<string, unknown>[]; count: number }>("/tagging-rules/rules/preview", {
       conditions,
-      limit
+      ...(limit !== undefined ? { limit } : {})
     }),
 };
 

--- a/tests/backend/unit/services/test_tagging_rules_service.py
+++ b/tests/backend/unit/services/test_tagging_rules_service.py
@@ -632,6 +632,18 @@ class TestPreviewRule:
 
         assert len(results) == 1
 
+    def test_preview_no_limit_returns_all_matches(self, service, seed_preview_data):
+        """Verify preview returns all matches when limit is None."""
+        conditions = {
+            "type": "CONDITION",
+            "field": "amount",
+            "operator": "lt",
+            "value": 0,
+        }
+        results = service.preview_rule(conditions, limit=None)
+
+        assert len(results) == 3
+
     def test_preview_includes_source_column(self, service, seed_preview_data):
         """Verify preview results include the source table name."""
         conditions = {


### PR DESCRIPTION
## Summary

- Remove the 50-row cap on the "Matching Transactions" table inside the auto-tagging rule editor — users can now see every transaction a rule would affect, not just the first 50.
- Make the `preview_rule` limit truly optional end-to-end so the cap can be lifted without imposing a different magic number; the modal omits the parameter, the API client only sends it when provided, and the service skips `.limit()` / `.head()` when the value is `None`.

## Why

Hard-coded preview cap left users without full visibility into how a rule would behave at apply-time. With ~80 WOLT transactions in the demo dataset (and many more in real datasets), the truncated list could hide both intended matches and accidental ones, making rule-tuning guesswork.

## Test plan

- [x] Unit: `pytest tests/backend/unit/services/test_tagging_rules_service.py::TestPreviewRule` — added `test_preview_no_limit_returns_all_matches`; all 5 tests pass.
- [x] Full tagging suite: `pytest tests/backend/unit/services/test_tagging_rules_service.py tests/backend/routes/test_tagging_rules_routes.py tests/backend/integration/test_tagging_pipeline.py` — 107 tests pass.
- [x] TS build: `tsc -b` clean.
- [x] E2E: new spec `frontend/e2e/rule-editor-preview.spec.ts` asserts the matches count exceeds 50 and that every match renders as a row; passes in 4.2s.
- [x] Manual: drove the flow with Playwright MCP against the worktree backend in Demo Mode — entering `WOLT` as a "description contains" rule now shows all 80 matches in the modal table (previously capped at 50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)