### PR TITLE
fix(rules): allow typing negative amounts in auto-tagging rule editor

### DIFF
--- a/frontend/src/components/transactions/RuleBuilder.test.tsx
+++ b/frontend/src/components/transactions/RuleBuilder.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { useState } from "react";
+import { screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../../test-utils";
+import { RuleBuilder } from "./RuleBuilder";
+import type { ConditionNode } from "../../services/api";
+
+function StatefulRuleBuilder({ initial }: { initial: ConditionNode }) {
+    const [node, setNode] = useState<ConditionNode>(initial);
+    return (
+        <>
+            <RuleBuilder value={node} onChange={setNode} />
+            <div data-testid="captured-value">{JSON.stringify(node.value)}</div>
+        </>
+    );
+}
+
+describe("RuleBuilder amount input", () => {
+    it("captures a negative number typed into the amount value input", async () => {
+        const user = userEvent.setup();
+        const initial: ConditionNode = {
+            type: "CONDITION",
+            field: "amount",
+            operator: "lt",
+            value: "",
+        };
+
+        renderWithProviders(<StatefulRuleBuilder initial={initial} />);
+
+        const valueInput = screen.getByPlaceholderText("Value");
+        await user.type(valueInput, "-100");
+
+        expect(screen.getByTestId("captured-value").textContent).toBe("-100");
+    });
+
+    it("captures a negative number typed into the 'between' min input", async () => {
+        const user = userEvent.setup();
+        const initial: ConditionNode = {
+            type: "CONDITION",
+            field: "amount",
+            operator: "between",
+            value: ["", ""],
+        };
+
+        renderWithProviders(<StatefulRuleBuilder initial={initial} />);
+
+        const minInput = screen.getByPlaceholderText("Min");
+        await user.type(minInput, "-50");
+
+        expect(screen.getByTestId("captured-value").textContent).toBe('[-50,""]');
+    });
+
+    it("captures a positive number typed into the amount value input", async () => {
+        const user = userEvent.setup();
+        const initial: ConditionNode = {
+            type: "CONDITION",
+            field: "amount",
+            operator: "gt",
+            value: "",
+        };
+
+        renderWithProviders(<StatefulRuleBuilder initial={initial} />);
+
+        const valueInput = screen.getByPlaceholderText("Value");
+        await user.type(valueInput, "250");
+
+        expect(screen.getByTestId("captured-value").textContent).toBe("250");
+    });
+
+    it("captures a decimal number typed into the amount value input", async () => {
+        const user = userEvent.setup();
+        const initial: ConditionNode = {
+            type: "CONDITION",
+            field: "amount",
+            operator: "gt",
+            value: "",
+        };
+
+        renderWithProviders(<StatefulRuleBuilder initial={initial} />);
+
+        const valueInput = screen.getByPlaceholderText("Value");
+        await user.type(valueInput, "-12.5");
+
+        expect(screen.getByTestId("captured-value").textContent).toBe("-12.5");
+    });
+
+    it("uses a text input that preserves a lone '-' character during typing", () => {
+        const initial: ConditionNode = {
+            type: "CONDITION",
+            field: "amount",
+            operator: "lt",
+            value: "",
+        };
+
+        renderWithProviders(<StatefulRuleBuilder initial={initial} />);
+
+        const valueInput = screen.getByPlaceholderText("Value") as HTMLInputElement;
+        expect(valueInput.type).toBe("text");
+        expect(valueInput.inputMode).toBe("decimal");
+
+        fireEvent.input(valueInput, { target: { value: "-" } });
+        expect(valueInput.value).toBe("-");
+    });
+});

--- a/frontend/src/components/transactions/RuleBuilder.tsx
+++ b/frontend/src/components/transactions/RuleBuilder.tsx
@@ -156,8 +156,21 @@ export function RuleBuilder({ value, onChange, depth = 0, onRemove }: RuleBuilde
 
     // Single Condition View
     const fieldDef = FIELDS.find(f => f.value === value.field) || FIELDS[0];
-    const inputType = fieldDef.type === "number" ? "number" : "text";
+    const isNumberField = fieldDef.type === "number";
     const operators = OPERATORS[fieldDef.type] || OPERATORS.text;
+
+    // Controlled type="number" inputs silently drop a lone "-" between keystrokes
+    // (browsers omit it from e.target.value), making it impossible to type negative
+    // numbers. Use type="text" with inputMode="decimal" for the mobile keypad, and
+    // keep the raw string for partial input ("", "-", "12.", "-12.0") so the user
+    // can finish typing — convert to Number only once the string round-trips.
+    const parseNumericInput = (raw: string): string | number => {
+        if (raw === "" || raw === "-") return raw;
+        const num = Number(raw);
+        if (isNaN(num)) return raw;
+        if (String(num) !== raw) return raw;
+        return num;
+    };
 
     return (
         <div className="grid grid-cols-[auto_1fr_auto] sm:flex sm:items-center gap-2 p-2 rounded-lg bg-[var(--surface-base)] border border-[var(--surface-light)] hover:border-[var(--primary)]/30 transition-all">
@@ -186,36 +199,36 @@ export function RuleBuilder({ value, onChange, depth = 0, onRemove }: RuleBuilde
             {value.operator === "between" ? (
                 <div className="row-start-3 col-span-3 sm:row-auto sm:col-span-1 flex items-center gap-1 sm:flex-1">
                     <input
-                        type="number"
+                        type="text"
                         inputMode="decimal"
                         placeholder={t("ruleBuilder.min")}
                         value={Array.isArray(value.value) ? value.value[0] : ""}
                         onChange={(e) => onChange({
                             ...value,
-                            value: [Number(e.target.value), Array.isArray(value.value) ? value.value[1] : 0]
+                            value: [parseNumericInput(e.target.value), Array.isArray(value.value) ? value.value[1] : 0]
                         })}
                         className="flex-1 min-w-0 sm:w-20 sm:flex-initial bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1.5 text-sm sm:text-xs outline-none focus:border-[var(--primary)]"
                     />
                     <span className="text-xs text-[var(--text-muted)]">-</span>
                     <input
-                        type="number"
+                        type="text"
                         inputMode="decimal"
                         placeholder={t("ruleBuilder.max")}
                         value={Array.isArray(value.value) ? value.value[1] : ""}
                         onChange={(e) => onChange({
                             ...value,
-                            value: [Array.isArray(value.value) ? value.value[0] : 0, Number(e.target.value)]
+                            value: [Array.isArray(value.value) ? value.value[0] : 0, parseNumericInput(e.target.value)]
                         })}
                         className="flex-1 min-w-0 sm:w-20 sm:flex-initial bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1.5 text-sm sm:text-xs outline-none focus:border-[var(--primary)]"
                     />
                 </div>
             ) : (
                 <input
-                    type={inputType}
-                    inputMode={inputType === "number" ? "decimal" : undefined}
+                    type="text"
+                    inputMode={isNumberField ? "decimal" : undefined}
                     placeholder={t("ruleBuilder.value")}
                     value={value.value != null && typeof value.value !== "boolean" && !Array.isArray(value.value) ? value.value : ""}
-                    onChange={(e) => onChange({ ...value, value: inputType === 'number' ? Number(e.target.value) : e.target.value })}
+                    onChange={(e) => onChange({ ...value, value: isNumberField ? parseNumericInput(e.target.value) : e.target.value })}
                     className="row-start-3 col-span-3 sm:row-auto sm:col-span-1 sm:flex-1 sm:min-w-[100px] bg-[var(--surface)] border border-[var(--surface-light)] rounded px-2 py-1.5 text-sm sm:text-xs outline-none focus:border-[var(--primary)]"
                 />
             )}


### PR DESCRIPTION
## Summary

- The amount value input in the auto-tagging rule editor silently dropped a typed `-` character, so users couldn't enter a negative number by typing. Workaround was the spinner arrows.
- Root cause: a controlled `type="number"` input. Browsers omit the lone `-` from `e.target.value`, so each React re-render replaced the dash with the previous numeric value before the user could finish typing.
- Switched the value input and the `between` min/max inputs to `type="text"` with `inputMode="decimal"` (mobile keypad still shows numbers).
- Added a `parseNumericInput` helper that keeps the raw string for partial states (`""`, `"-"`, `"12."`, `"-12.0"`) and converts to `Number` only once the string round-trips, so decimals like `-12.5` survive typing.

## Trade-off

Native HTML5 up/down spinner arrows are no longer available on these inputs. Since they were a workaround for the typing bug, this should be a net win for the primary input method.

## Test plan

- [x] New vitest coverage in `frontend/src/components/transactions/RuleBuilder.test.tsx`: typing `-100`, `-50` into a `between` min, positive `250`, decimal `-12.5`, and a regression assertion that the input is `type="text"` and preserves a lone `-`.
- [x] `npm test` — 180/180 passing.
- [x] `npm run lint` — clean.
- [x] Manual Playwright check in a real browser via demo mode: typed `-100`, `-12.5`, `-250`, and `[-50, -10]` for a `between` condition; "Matching Transactions" preview correctly evaluated the numeric range (50 matches in demo data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)