### PR TITLE
fix(transactions): split modal sends unique_id, not source-institution id

### DIFF
--- a/frontend/e2e/flows/transaction-split.spec.ts
+++ b/frontend/e2e/flows/transaction-split.spec.ts
@@ -50,11 +50,25 @@ test.describe("Transaction split flow", () => {
     }
 
     // The split totals balance, so the dialog header marker reads
-    // "Balanced" and the Save button enables. We don't actually submit:
-    // splitting a CC-bill transaction has special-case server validation
-    // that varies by demo dataset and isn't the unit being tested here.
+    // "Balanced" and the Save button enables.
     await expect(dialog.getByText(/^balanced$/i)).toBeVisible();
     const saveBtn = dialog.getByRole("button", { name: /^split transaction$/i });
     await expect(saveBtn).toBeEnabled();
+
+    // Submit and confirm the backend accepted the request. The route is
+    // /api/transactions/{unique_id}/split, and {unique_id} must be the
+    // integer DB primary key — not the source-institution `id` column.
+    // A regression that passes the wrong field returns 422 here.
+    const splitResponse = page.waitForResponse(
+      (res) =>
+        /\/api\/transactions\/\d+\/split$/.test(res.url()) &&
+        res.request().method() === "POST",
+    );
+    await saveBtn.click();
+    const response = await splitResponse;
+    expect(response.status()).toBe(200);
+
+    // Dialog closes on success.
+    await expect(dialog).toBeHidden();
   });
 });

--- a/frontend/src/components/modals/SplitTransactionModal.tsx
+++ b/frontend/src/components/modals/SplitTransactionModal.tsx
@@ -10,7 +10,7 @@ import { formatCurrency } from "../../utils/numberFormatting";
 import { useNotify } from "../../context/DialogContext";
 
 interface SplitTransactionModalProps {
-  transaction: { id?: number; unique_id?: string; amount: number; source?: string; description?: string; desc?: string; category?: string; tag?: string };
+  transaction: { id?: string | number; unique_id?: string | number; amount: number; source?: string; description?: string; desc?: string; category?: string; tag?: string };
   onClose: () => void;
   onSuccess: () => void;
 }
@@ -72,7 +72,7 @@ export function SplitTransactionModal({
     if (!isValid) return;
 
     try {
-      await transactionsApi.split(transaction.id ?? 0, {
+      await transactionsApi.split(transaction.unique_id ?? transaction.id ?? 0, {
         source: transaction.source || "",
         splits: splits.map((s) => ({
           amount: s.amount,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -60,14 +60,14 @@ export const transactionsApi = {
     amount?: number;
   }) => api.post("/transactions/bulk-tag", data),
   split: (
-    id: number,
+    uniqueId: string | number,
     data: {
       source: string;
       splits: { amount: number; category: string; tag: string }[];
     },
-  ) => api.post(`/transactions/${id}/split`, data),
-  revertSplit: (id: number, source: string) =>
-    api.delete(`/transactions/${id}/split`, { params: { source } }),
+  ) => api.post(`/transactions/${encodeURIComponent(String(uniqueId))}/split`, data),
+  revertSplit: (uniqueId: string | number, source: string) =>
+    api.delete(`/transactions/${encodeURIComponent(String(uniqueId))}/split`, { params: { source } }),
 };
 
 // Budget API


### PR DESCRIPTION
## Summary

- Splitting a transaction from the Transactions table was silently broken — the modal POSTed to `/transactions/{id}/split` with the source-institution string ID (e.g. `"demo-cc-0001"`), but the FastAPI route expects an integer `unique_id` (the DB primary key) and returned 422.
- Every other transaction operation (`delete`, `bulkTag`, refunds) already used `unique_id` correctly. Only split was wrong.
- Existing e2e test stopped at "Save button enabled" and never submitted, which is how this regression slipped through. The test now asserts a 200 response and that the dialog closes.

## Root cause

The `Transaction` shape has two identifiers:
- `id` — the original ID from the financial institution (string column, e.g. `"926444369"` or `"demo-cc-0001"`)
- `unique_id` — the autoincrement DB primary key (integer)

`SplitTransactionModal` passed `transaction.id ?? 0` as the path segment. Sometimes `id` happens to be parseable as an int (so it hit some unrelated row); usually it doesn't (422). Either way, the user-intended transaction was not split.

## Changes

| File | Change |
|---|---|
| `frontend/src/components/modals/SplitTransactionModal.tsx` | Send `transaction.unique_id ?? transaction.id ?? 0`; widen prop type so `unique_id` can be `string \| number` |
| `frontend/src/services/api.ts` | `split` / `revertSplit` accept `string \| number` and `encodeURIComponent` the path segment, matching the existing `delete` / `update` pattern |
| `frontend/e2e/flows/transaction-split.spec.ts` | Actually click Save, await the network response, assert 200 + dialog hidden |

## Test plan

- [x] Direct curl: `POST /transactions/demo-cc-0001/split` → 422 (reproduces bug); `POST /transactions/1/split` → 200 (fix path)
- [x] Browser via demo mode: split goes through, network log shows `POST /api/transactions/710/split → 200 OK`, dialog closes, list refetches
- [x] `npx playwright test flows/transaction-split` → 1 passed (4.9s)
- [x] `npm run lint`, `tsc -b`, `npm test` (175 tests), `npm run build`
- [x] `pytest -k split` (43 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)