### PR TITLE
fix(i18n): flip horizontal chevron and arrow icons in RTL

### DIFF
--- a/frontend/e2e/rtl-chevrons.spec.ts
+++ b/frontend/e2e/rtl-chevrons.spec.ts
@@ -1,0 +1,191 @@
+import { test, expect } from "@playwright/test";
+import { enableDemoMode, disableDemoMode, navigateTo } from "./helpers";
+
+test.describe("RTL chevrons", () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await enableDemoMode(page);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await disableDemoMode(page);
+    await page.close();
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (page.url().startsWith("http")) {
+      await page.evaluate(() => localStorage.setItem("language", "en"));
+    }
+  });
+
+  test("flips pagination chevron icons in Hebrew so arrows point the way the user navigates", async ({
+    page,
+  }) => {
+    await navigateTo(page, "/transactions");
+    await page.evaluate(() => localStorage.setItem("language", "he"));
+    await navigateTo(page, "/transactions");
+
+    await expect(page.getByText(/עמוד\s+\d+\s+מתוך/)).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator("html")).toHaveAttribute("dir", "rtl");
+
+    const icons = await page.evaluate(() => {
+      const pageSpan = Array.from(
+        document.querySelectorAll("span.px-4.text-sm.whitespace-nowrap"),
+      ).find((s) => /עמוד/.test(s.textContent ?? ""));
+      if (!pageSpan) return null;
+      const btns = Array.from(
+        pageSpan.parentElement!.querySelectorAll("button"),
+      );
+      return btns.map((b) => {
+        const svg = b.querySelector("svg");
+        return svg ? svg.getAttribute("class") ?? "" : "";
+      });
+    });
+
+    expect(icons).not.toBeNull();
+    expect(icons!).toHaveLength(4);
+    expect(icons![0]).toContain("lucide-chevrons-right");
+    expect(icons![1]).toContain("lucide-chevron-right");
+    expect(icons![1]).not.toContain("lucide-chevrons");
+    expect(icons![2]).toContain("lucide-chevron-left");
+    expect(icons![2]).not.toContain("lucide-chevrons");
+    expect(icons![3]).toContain("lucide-chevrons-left");
+  });
+
+  test("Hebrew next-page button (chevron-left) advances the page", async ({ page }) => {
+    await navigateTo(page, "/transactions");
+    await page.evaluate(() => localStorage.setItem("language", "he"));
+    await navigateTo(page, "/transactions");
+
+    await expect(page.getByText("עמוד 1 מתוך", { exact: false })).toBeVisible({ timeout: 30_000 });
+
+    const nextBtn = page
+      .locator("span.px-4.text-sm.whitespace-nowrap", { hasText: /עמוד/ })
+      .locator("..")
+      .locator("button")
+      .nth(2);
+    await nextBtn.click();
+
+    await expect(page.getByText("עמוד 2 מתוך", { exact: false })).toBeVisible();
+  });
+
+  test("English pagination still uses LTR chevrons", async ({ page }) => {
+    await navigateTo(page, "/transactions");
+    await page.evaluate(() => localStorage.setItem("language", "en"));
+    await navigateTo(page, "/transactions");
+
+    await expect(page.getByText(/Page\s+\d+\s+of/)).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator("html")).toHaveAttribute("dir", "ltr");
+
+    const icons = await page.evaluate(() => {
+      const pageSpan = Array.from(
+        document.querySelectorAll("span.px-4.text-sm.whitespace-nowrap"),
+      ).find((s) => /Page/.test(s.textContent ?? ""));
+      if (!pageSpan) return null;
+      const btns = Array.from(
+        pageSpan.parentElement!.querySelectorAll("button"),
+      );
+      return btns.map((b) => {
+        const svg = b.querySelector("svg");
+        return svg ? svg.getAttribute("class") ?? "" : "";
+      });
+    });
+
+    expect(icons).not.toBeNull();
+    expect(icons!).toHaveLength(4);
+    expect(icons![0]).toContain("lucide-chevrons-left");
+    expect(icons![1]).toContain("lucide-chevron-left");
+    expect(icons![1]).not.toContain("lucide-chevrons");
+    expect(icons![2]).toContain("lucide-chevron-right");
+    expect(icons![2]).not.toContain("lucide-chevrons");
+    expect(icons![3]).toContain("lucide-chevrons-right");
+  });
+
+  test("dashboard monthly-budget month switcher flips chevrons in Hebrew", async ({ page }) => {
+    await navigateTo(page, "/");
+    await page.evaluate(() => localStorage.setItem("language", "he"));
+    await navigateTo(page, "/");
+
+    const monthLabel = page.locator("p.w-36").first();
+    await expect(monthLabel).toBeVisible({ timeout: 30_000 });
+
+    const icons = await page.evaluate(() => {
+      const label = document.querySelector("p.w-36");
+      if (!label || !label.parentElement) return null;
+      return Array.from(label.parentElement.querySelectorAll("button")).map(
+        (b) => b.querySelector("svg")?.getAttribute("class") ?? "",
+      );
+    });
+
+    expect(icons).not.toBeNull();
+    expect(icons!).toHaveLength(2);
+    // Previous month button (DOM-first) sits visually on the right in RTL — chevron-right.
+    expect(icons![0]).toContain("lucide-chevron-right");
+    // Next month button sits visually on the left in RTL — chevron-left.
+    expect(icons![1]).toContain("lucide-chevron-left");
+  });
+
+  test("AutoTaggingPanel flips its chevron in Hebrew", async ({ page }) => {
+    await navigateTo(page, "/transactions");
+    await page.evaluate(() => localStorage.setItem("language", "he"));
+    await navigateTo(page, "/transactions");
+
+    const panel = page.locator('[class*="sticky top-4"]').first();
+    await expect(panel).toBeVisible({ timeout: 30_000 });
+
+    const state = await page.evaluate(() => {
+      const p = document.querySelector('[class*="sticky top-4"]') as HTMLElement | null;
+      if (!p) return null;
+      const collapsed = p.getBoundingClientRect().width < 100;
+      return {
+        collapsed,
+        icon: p.querySelector("svg")?.getAttribute("class") ?? "",
+      };
+    });
+
+    expect(state).not.toBeNull();
+    if (state!.collapsed) {
+      // Collapsed strip on the LEFT in RTL — chevron points right (toward content area).
+      expect(state!.icon).toContain("lucide-chevron-right");
+    } else {
+      // Open panel on the LEFT in RTL — chevron points left (collapse back to the wall).
+      expect(state!.icon).toContain("lucide-chevron-left");
+    }
+  });
+
+  test("DataSources connect-account flow flips proceed chevrons in Hebrew", async ({ page }) => {
+    await navigateTo(page, "/data-sources");
+    await page.evaluate(() => localStorage.setItem("language", "he"));
+    await navigateTo(page, "/data-sources");
+
+    await page.getByRole("button", { name: "חבר חשבון" }).click();
+
+    // The three service-type buttons each carry a "proceed forward" chevron at
+    // the end of the row. (Each button also contains an unrelated category
+    // icon — Landmark / CreditCard / Shield — so we must pick the chevron
+    // specifically, not the first SVG.)
+    const proceedIcons = await page.evaluate(() => {
+      const labels = ["חשבון בנק", "כרטיס אשראי", "ביטוח"];
+      return labels.map((label) => {
+        const heading = Array.from(document.querySelectorAll("p")).find(
+          (p) => p.textContent?.trim() === label,
+        );
+        if (!heading) return null;
+        const btn = heading.closest("button");
+        if (!btn) return null;
+        const chevron = btn.querySelector(
+          "svg.lucide-chevron-left, svg.lucide-chevron-right",
+        );
+        return chevron?.getAttribute("class") ?? "";
+      });
+    });
+
+    expect(proceedIcons).toHaveLength(3);
+    for (const icon of proceedIcons) {
+      expect(icon).not.toBeNull();
+      expect(icon!).toContain("lucide-chevron-left");
+    }
+  });
+});

--- a/frontend/src/components/dashboard/BudgetSection.tsx
+++ b/frontend/src/components/dashboard/BudgetSection.tsx
@@ -108,7 +108,8 @@ export function BudgetSpendingGauge({
 }: {
   categoryIcons: Record<string, string> | undefined;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const isRtl = i18n.language === "he";
   const now = new Date();
   const currentYear = now.getFullYear();
   const currentMonth = now.getMonth() + 1;
@@ -321,18 +322,20 @@ export function BudgetSpendingGauge({
                 <div className="flex items-center gap-2">
                   <button
                     onClick={handlePreviousMonth}
+                    aria-label={t("common.previous")}
                     className="p-1 rounded-lg hover:bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-[var(--text)] transition-colors"
                   >
-                    <ChevronLeft size={16} />
+                    {isRtl ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
                   </button>
                   <p className="text-xs font-semibold uppercase tracking-wider text-[var(--text-muted)] w-36 text-center">
                     {monthName}
                   </p>
                   <button
                     onClick={handleNextMonth}
+                    aria-label={t("common.next")}
                     className="p-1 rounded-lg hover:bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-[var(--text)] transition-colors"
                   >
-                    <ChevronRight size={16} />
+                    {isRtl ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
                   </button>
                 </div>
                 {isCurrentMonth && (

--- a/frontend/src/components/transactions/AutoTaggingPanel.tsx
+++ b/frontend/src/components/transactions/AutoTaggingPanel.tsx
@@ -21,7 +21,8 @@ import { useAppStore } from "../../stores/appStore";
 import { useConfirm } from "../../context/DialogContext";
 
 export function AutoTaggingPanel() {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
+    const isRtl = i18n.language === "he";
     const { autoTaggingPanelOpen, toggleAutoTaggingPanel } = useAppStore();
     const queryClient = useQueryClient();
     const confirm = useConfirm();
@@ -122,7 +123,7 @@ export function AutoTaggingPanel() {
                                 className="p-1.5 rounded-lg hover:bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-white transition-colors"
                                 title="Collapse panel"
                             >
-                                <ChevronRight size={18} />
+                                {isRtl ? <ChevronLeft size={18} /> : <ChevronRight size={18} />}
                             </button>
                         </div>
 
@@ -229,7 +230,9 @@ export function AutoTaggingPanel() {
                         className="w-12 h-full flex flex-col items-center justify-center gap-3 bg-[var(--surface)] border border-[var(--surface-light)] rounded-xl shadow-xl hover:border-[var(--primary)]/30 transition-colors cursor-pointer group"
                         title="Expand Auto Tagging panel"
                     >
-                        <ChevronLeft size={18} className="text-[var(--text-muted)] group-hover:text-[var(--primary)] transition-colors" />
+                        {isRtl
+                            ? <ChevronRight size={18} className="text-[var(--text-muted)] group-hover:text-[var(--primary)] transition-colors" />
+                            : <ChevronLeft size={18} className="text-[var(--text-muted)] group-hover:text-[var(--primary)] transition-colors" />}
                         <ShieldCheck size={20} className="text-[var(--primary)]" />
                         <span className="text-xs font-bold text-[var(--text-muted)] [writing-mode:vertical-lr] rotate-180 tracking-wider uppercase">
                             {t("transactions.autoTagging.title")}
@@ -263,7 +266,7 @@ export function AutoTaggingPanel() {
                                 onClick={toggleAutoTaggingPanel}
                                 className="p-1.5 rounded-lg hover:bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-white transition-colors"
                             >
-                                <ChevronRight size={18} />
+                                {isRtl ? <ChevronLeft size={18} /> : <ChevronRight size={18} />}
                             </button>
                         </div>
                         <div className="flex-1 overflow-y-auto p-4 space-y-4">

--- a/frontend/src/components/transactions/Pagination.tsx
+++ b/frontend/src/components/transactions/Pagination.tsx
@@ -31,7 +31,9 @@ export function Pagination({
   onRowsPerPageChange,
   compact = false,
 }: PaginationProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const isRtl = i18n.language === "he";
+  const iconSize = compact ? 16 : 20;
 
   if (totalPages <= 0) return null;
 
@@ -82,14 +84,14 @@ export function Pagination({
           disabled={currentPage === 1}
           className="p-1 rounded hover:bg-[var(--surface-light)] text-[var(--text-muted)] disabled:opacity-30 transition-colors"
         >
-          <ChevronsLeft size={compact ? 16 : 20} />
+          {isRtl ? <ChevronsRight size={iconSize} /> : <ChevronsLeft size={iconSize} />}
         </button>
         <button
           onClick={() => onPageChange(Math.max(1, currentPage - 1))}
           disabled={currentPage === 1}
           className="p-1 rounded hover:bg-[var(--surface-light)] text-[var(--text-muted)] disabled:opacity-30 transition-colors"
         >
-          <ChevronLeft size={compact ? 16 : 20} />
+          {isRtl ? <ChevronRight size={iconSize} /> : <ChevronLeft size={iconSize} />}
         </button>
         <span className="px-4 text-sm whitespace-nowrap">
           {t("transactions.pagination.page")} <span className="text-white font-medium">{currentPage}</span>{" "}
@@ -101,14 +103,14 @@ export function Pagination({
           disabled={currentPage === totalPages || totalPages === 0}
           className="p-1 rounded hover:bg-[var(--surface-light)] text-[var(--text-muted)] disabled:opacity-30 transition-colors"
         >
-          <ChevronRight size={compact ? 16 : 20} />
+          {isRtl ? <ChevronLeft size={iconSize} /> : <ChevronRight size={iconSize} />}
         </button>
         <button
           onClick={() => onPageChange(totalPages)}
           disabled={currentPage === totalPages || totalPages === 0}
           className="p-1 rounded hover:bg-[var(--surface-light)] text-[var(--text-muted)] disabled:opacity-30 transition-colors"
         >
-          <ChevronsRight size={compact ? 16 : 20} />
+          {isRtl ? <ChevronsLeft size={iconSize} /> : <ChevronsRight size={iconSize} />}
         </button>
       </div>
     </div>

--- a/frontend/src/pages/DataSources.tsx
+++ b/frontend/src/pages/DataSources.tsx
@@ -8,6 +8,7 @@ import {
   Globe,
   Landmark,
   CreditCard,
+  ChevronLeft,
   ChevronRight,
   X,
   AlertCircle,
@@ -72,7 +73,8 @@ interface CredentialAccount {
 }
 
 export function DataSources() {
-  const { t } = useTranslation();
+  const { t, i18n: i18nInstance } = useTranslation();
+  const isRtl = i18nInstance.language === "he";
   const { isDemoMode } = useDemoMode();
   const queryClient = useQueryClient();
   const confirm = useConfirm();
@@ -743,7 +745,7 @@ export function DataSources() {
                       </p>
                     </div>
                   </div>
-                  <ChevronRight className="text-[var(--text-muted)]" />
+                  {isRtl ? <ChevronLeft className="text-[var(--text-muted)]" /> : <ChevronRight className="text-[var(--text-muted)]" />}
                 </button>
                 <button
                   onClick={() => {
@@ -765,7 +767,7 @@ export function DataSources() {
                       </p>
                     </div>
                   </div>
-                  <ChevronRight className="text-[var(--text-muted)]" />
+                  {isRtl ? <ChevronLeft className="text-[var(--text-muted)]" /> : <ChevronRight className="text-[var(--text-muted)]" />}
                 </button>
                 <button
                   onClick={() => {
@@ -787,7 +789,7 @@ export function DataSources() {
                       </p>
                     </div>
                   </div>
-                  <ChevronRight className="text-[var(--text-muted)]" />
+                  {isRtl ? <ChevronLeft className="text-[var(--text-muted)]" /> : <ChevronRight className="text-[var(--text-muted)]" />}
                 </button>
               </div>
             )}

--- a/frontend/src/pages/Onboarding.tsx
+++ b/frontend/src/pages/Onboarding.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
-import { Languages, Sparkles, Check, ArrowRight, Database, Wand2 } from "lucide-react";
+import { Languages, Sparkles, Check, ArrowLeft, ArrowRight, Database, Wand2 } from "lucide-react";
 import { useDemoMode } from "../context/DemoModeContext";
 
 type Step = "language" | "path" | "done";
@@ -231,6 +231,8 @@ function PathButton({
   disabled: boolean;
   onClick: () => void;
 }) {
+  const { i18n } = useTranslation();
+  const Arrow = i18n.language === "he" ? ArrowLeft : ArrowRight;
   return (
     <button
       type="button"
@@ -245,7 +247,7 @@ function PathButton({
         <div className="font-bold mb-1">{title}</div>
         <div className="text-sm text-[var(--text-muted)]">{description}</div>
       </div>
-      <ArrowRight
+      <Arrow
         size={18}
         className="text-[var(--text-muted)] mt-3 transition-transform group-hover:translate-x-1 rtl:group-hover:-translate-x-1"
       />


### PR DESCRIPTION
## Summary

Several navigation controls kept their LTR chevron / arrow direction in Hebrew (RTL), so the icons pointed the opposite way the user actually navigates. Each site now picks the icon based on `i18n.language === \"he\"`, matching the existing pattern in `Sidebar.tsx` and `MonthlyBudgetView.tsx`.

Affected:

- **Transactions pagination** — first / previous / next / last buttons (the original report).
- **Dashboard monthly-budget month switcher** (`BudgetSection.tsx`).
- **DataSources "Connect Account" modal** — the three service-type rows (bank / credit card / insurance).
- **Onboarding path-selector** arrow (`PathButton`).
- **AutoTaggingPanel** collapse / expand chevrons — the panel sits on the visual *left* in RTL (because `ms-4` flips), so all three chevrons needed to flip too.

## Verification

- Drove each surface in Hebrew via Playwright MCP and confirmed the icons now point in the natural RTL navigation direction; clicking the visually-left "next" arrow on Transactions correctly advances עמוד 1 → עמוד 2, and the "previous month" arrow on the dashboard correctly walks מאי 2026 → אפריל 2026.
- New `frontend/e2e/rtl-chevrons.spec.ts` locks in the orientations (6 specs, both Hebrew and English).
- Existing regression e2e suites (dashboard, transactions, navigation, data-sources) pass.
- `npm test` (175 vitest tests), `npm run lint`, `npm run build`, `npx tsc -b --noEmit` all green.

## Test plan

- [x] Pagination in Hebrew shows `⏩ ▶ עמוד … ◀ ⏪`
- [x] Dashboard monthly-budget month switcher in Hebrew shows `< חודש >` with `<` advancing forward
- [x] DataSources "Connect Account" modal in Hebrew shows `<` at the end of each row
- [x] AutoTaggingPanel collapsed strip on the left edge in RTL points `>` toward content; open panel points `<` toward the wall
- [x] English mode unchanged for all of the above
- [x] `npm test`, `npm run lint`, `npm run build` clean
- [x] e2e suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)