### PR TITLE
feat: remove category/tag from transactions tables

### DIFF
--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -70,4 +70,41 @@ test.describe("Transactions", () => {
       await page.waitForTimeout(300);
     }
   });
+
+  test("per-row eraser clears category and tag from a transaction", async ({ page }) => {
+    await navigateTo(page, "/transactions");
+
+    // Wait for the table to populate
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+    await page.waitForLoadState("networkidle");
+
+    // Find the first row that has the eraser button (i.e., has a category or tag).
+    const clearButton = page
+      .getByRole("button", { name: /clear category and tag/i })
+      .first();
+    await expect(clearButton).toBeVisible({ timeout: 10_000 });
+
+    // Capture the data-testid of the ancestor row so we can re-locate it after
+    // the query invalidation triggers a re-render.
+    const row = clearButton.locator("xpath=ancestor::tr[1]");
+    const rowTestId = await row.getAttribute("data-testid");
+    expect(rowTestId).toBeTruthy();
+
+    // Click the eraser button.
+    await clearButton.click();
+
+    // The global MutationCache.onSuccess debounced invalidator fires ~200 ms
+    // after the mutation succeeds, then React Query refetches the transactions.
+    // Wait for the network to settle so the re-render completes.
+    await page.waitForLoadState("networkidle");
+
+    // Re-locate the same row by its stable data-testid. The button must now be
+    // absent — the category and tag were cleared, so the conditional render
+    // `{(tx.category || tx.tag) && <button ...>}` no longer renders it.
+    const updatedRow = page.locator(`[data-testid="${rowTestId}"]`);
+    await expect(
+      updatedRow.getByRole("button", { name: /clear category and tag/i }),
+    ).toHaveCount(0);
+  });
 });

--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -107,4 +107,73 @@ test.describe("Transactions", () => {
       updatedRow.getByRole("button", { name: /clear category and tag/i }),
     ).toHaveCount(0);
   });
+
+  test("bulk eraser clears category and tag from selected transactions", async ({ page }) => {
+    await navigateTo(page, "/transactions");
+
+    // Wait for the table to populate.
+    const rows = page.locator("table tbody tr");
+    await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+    await page.waitForLoadState("networkidle");
+
+    // Find rows that have a per-row eraser button — these are the rows with
+    // a category or tag assigned. We need at least two such rows.
+    const candidateRows = page
+      .locator("table tbody tr")
+      .filter({ has: page.getByRole("button", { name: /clear category and tag/i }) });
+
+    const firstRow = candidateRows.nth(0);
+    const secondRow = candidateRows.nth(1);
+
+    await expect(firstRow).toBeVisible({ timeout: 10_000 });
+    await expect(secondRow).toBeVisible({ timeout: 10_000 });
+
+    // Capture stable data-testid for both rows so we can re-locate them after
+    // the query invalidation triggers a re-render.
+    const firstRowId = await firstRow.getAttribute("data-testid");
+    const secondRowId = await secondRow.getAttribute("data-testid");
+    expect(firstRowId).toBeTruthy();
+    expect(secondRowId).toBeTruthy();
+
+    // Select both rows via their checkboxes. Checkboxes are hidden on mobile
+    // (hidden md:table-cell) but Playwright uses the default desktop viewport
+    // (1280 × 720), so the checkboxes are reachable.
+    await firstRow.locator('input[type="checkbox"]').check();
+    await secondRow.locator('input[type="checkbox"]').check();
+
+    // BulkActionsBar appears as a fixed div at the bottom. The bulk eraser
+    // button lives inside that bar — outside the <table> — and shares the
+    // same aria-label ("Clear category and tag") as the per-row erasers.
+    // We target it by scoping to the bar's container div (identified by its
+    // unique fixed-position styling class).
+    const bulkBar = page.locator("div.fixed.bottom-4, div.fixed.md\\:bottom-8").last();
+    const bulkEraser = bulkBar.getByRole("button", { name: /clear category and tag/i });
+    await expect(bulkEraser).toBeVisible({ timeout: 5_000 });
+    await bulkEraser.click();
+
+    // A confirmation dialog opens (rendered by DialogContext / useConfirm).
+    // The confirm button is labeled with transactions.clearConfirm.confirm = "Clear".
+    const confirmButton = page.getByRole("button", { name: /^clear$/i }).last();
+    await expect(confirmButton).toBeVisible({ timeout: 5_000 });
+    await confirmButton.click();
+
+    // The global MutationCache.onSuccess debounced invalidator fires ~200 ms
+    // after the mutation succeeds, then React Query refetches the transactions.
+    // Wait for the network to settle so the re-render completes.
+    await page.waitForLoadState("networkidle");
+
+    // Both rows now have no per-row eraser button — the category and tag have
+    // been cleared, so the conditional render `{(tx.category || tx.tag) && …}`
+    // no longer renders the button.
+    await expect(
+      page.locator(`[data-testid="${firstRowId}"]`).getByRole("button", {
+        name: /clear category and tag/i,
+      }),
+    ).toHaveCount(0);
+    await expect(
+      page.locator(`[data-testid="${secondRowId}"]`).getByRole("button", {
+        name: /clear category and tag/i,
+      }),
+    ).toHaveCount(0);
+  });
 });

--- a/frontend/e2e/transactions.spec.ts
+++ b/frontend/e2e/transactions.spec.ts
@@ -191,8 +191,10 @@ test.describe("Transactions", () => {
       await checkboxes.nth(i).check();
     }
 
-    // Open the bulk Category dropdown.
-    await page.getByRole("button", { name: "Category" }).click();
+    // Open the bulk Category dropdown. Use exact match — otherwise the per-row
+    // eraser buttons (aria-label="Clear category and tag") also match the
+    // substring "Category" and Playwright's strict mode fails on 9+ matches.
+    await page.getByRole("button", { name: "Category", exact: true }).click();
     const listbox = page.getByRole("listbox");
     await expect(listbox).toBeVisible();
 

--- a/frontend/src/components/TransactionsTable.test.tsx
+++ b/frontend/src/components/TransactionsTable.test.tsx
@@ -193,7 +193,7 @@ describe("TransactionsTable", () => {
     });
 
     it("hides the eraser button when a row has neither category nor tag", () => {
-      const tx = makeTx({ category: null, tag: null });
+      const tx = makeTx({ category: undefined, tag: undefined });
       renderWithProviders(
         <TransactionsTable transactions={[tx]} showActions />,
       );

--- a/frontend/src/components/TransactionsTable.test.tsx
+++ b/frontend/src/components/TransactionsTable.test.tsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
-import { screen, within } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../test-utils";
 import { TransactionsTable } from "./TransactionsTable";
 import type { Transaction } from "../types/transaction";
+import { server } from "../mocks/server";
 
 const makeTx = (overrides: Partial<Transaction> = {}): Transaction => ({
   id: 1,
@@ -176,6 +178,60 @@ describe("TransactionsTable", () => {
     it("shows add button when onAddTransaction is provided with showFilter", () => {
       renderTable({ showFilter: true, onAddTransaction: vi.fn() });
       expect(screen.getByText("Add Transaction")).toBeInTheDocument();
+    });
+  });
+
+  describe("clear category/tag", () => {
+    it("renders the eraser button when a row has a category", () => {
+      const tx = makeTx({ category: "Food", tag: "Groceries" });
+      renderWithProviders(
+        <TransactionsTable transactions={[tx]} showActions />,
+      );
+      expect(
+        screen.getByRole("button", { name: "Clear category and tag" }),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the eraser button when a row has neither category nor tag", () => {
+      const tx = makeTx({ category: null, tag: null });
+      renderWithProviders(
+        <TransactionsTable transactions={[tx]} showActions />,
+      );
+      expect(
+        screen.queryByRole("button", { name: "Clear category and tag" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("calls PUT /api/transactions/:id with empty strings on per-row click", async () => {
+      const capturedBody = vi.fn();
+      server.use(
+        http.put("/api/transactions/:id", async ({ request }) => {
+          const body = await request.json();
+          capturedBody(body);
+          return HttpResponse.json({ status: "ok" });
+        }),
+      );
+
+      const tx = makeTx({
+        unique_id: "42",
+        source: "bank_transactions",
+        category: "Food",
+        tag: "Groceries",
+      });
+      renderWithProviders(
+        <TransactionsTable transactions={[tx]} showActions />,
+      );
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Clear category and tag" }),
+      );
+
+      await waitFor(() => expect(capturedBody).toHaveBeenCalledOnce());
+      expect(capturedBody).toHaveBeenCalledWith({
+        source: "bank_transactions",
+        category: "",
+        tag: "",
+      });
     });
   });
 });

--- a/frontend/src/components/TransactionsTable.tsx
+++ b/frontend/src/components/TransactionsTable.tsx
@@ -268,6 +268,28 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
     // mutation hot paths"), do not add another.
   });
 
+  const bulkClearMutation = useMutation({
+    mutationFn: async (groupsBySource: Record<string, (string | number)[]>) => {
+      // Fire one bulkTag request per source group; let all settle so a
+      // single failing source doesn't abort the others.
+      const results = await Promise.allSettled(
+        Object.entries(groupsBySource).map(([source, ids]) =>
+          transactionsApi.bulkTag({
+            transaction_ids: ids,
+            source,
+            category: "",
+            tag: "",
+          }),
+        ),
+      );
+      const failed = results.filter((r) => r.status === "rejected");
+      if (failed.length > 0) {
+        throw new Error(`${failed.length} of ${results.length} clear requests failed`);
+      }
+    },
+    // No per-mutation onSuccess: global MutationCache.onSuccess handles invalidation.
+  });
+
   // Reset page when transactions or filter changes
   useEffect(() => {
     setCurrentPage(1);
@@ -481,6 +503,29 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
     } catch {
       notify.error(t("transactions.bulkDeletePartialFailure"));
     }
+  };
+
+  const handleBulkClearCategoryTag = async () => {
+    const ok = await confirm({
+      title: t("transactions.clearConfirm.title"),
+      message: t("transactions.clearConfirm.message", { count: selectedIds.size }),
+      confirmLabel: t("transactions.clearConfirm.confirm"),
+      isDestructive: true,
+    });
+    if (!ok) return;
+    const selectedTxs = transactions.filter((tx) =>
+      selectedIds.has(getTransactionId(tx)),
+    );
+    const groupsBySource = selectedTxs.reduce(
+      (acc: Record<string, (string | number)[]>, tx) => {
+        const source = tx.source || "unknown";
+        if (!acc[source]) acc[source] = [];
+        acc[source].push(tx.unique_id || tx.id || 0);
+        return acc;
+      },
+      {},
+    );
+    bulkClearMutation.mutate(groupsBySource);
   };
 
   // Sort icon component
@@ -1047,6 +1092,7 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
           cashBalances={cashBalances}
           onApply={handleBulkApply}
           onBulkDelete={handleBulkDelete}
+          onClearCategoryTag={handleBulkClearCategoryTag}
           onClearSelection={() => setSelectedIds(new Set())}
           onCreateCategory={createCategory}
           onCreateTag={createTag}

--- a/frontend/src/components/TransactionsTable.tsx
+++ b/frontend/src/components/TransactionsTable.tsx
@@ -17,6 +17,7 @@ import {
   ChevronDown,
   Settings2,
   Pencil,
+  Eraser,
 } from "lucide-react";
 import { SplitTransactionModal } from "./modals/SplitTransactionModal";
 import { LinkRefundModal } from "./modals/LinkRefundModal";
@@ -256,6 +257,15 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
       invalidateAnalytics();
       onTransactionUpdated?.();
     },
+  });
+
+  const clearCategoryTagMutation = useMutation({
+    mutationFn: ({ uniqueId, source }: { uniqueId: string; source: string }) =>
+      transactionsApi.update(uniqueId, { source, category: "", tag: "" }),
+    // No per-mutation onSuccess: the global MutationCache.onSuccess in
+    // queryClient.ts already runs a debounced invalidateQueries 200ms after
+    // success. Per frontend_components.md ("Don't fan out invalidation in
+    // mutation hot paths"), do not add another.
   });
 
   // Reset page when transactions or filter changes
@@ -828,6 +838,23 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
                         >
                           <Pencil size={14} />
                         </button>
+                        {(tx.category || tx.tag) && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              clearCategoryTagMutation.mutate({
+                                uniqueId: String(tx.unique_id ?? tx.id),
+                                source: tx.source || "",
+                              });
+                            }}
+                            className="p-1.5 rounded-md hover:bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-white transition-colors disabled:opacity-50"
+                            disabled={clearCategoryTagMutation.isPending}
+                            title={t("transactions.actions.clearCategoryTag")}
+                            aria-label={t("transactions.actions.clearCategoryTag")}
+                          >
+                            <Eraser size={14} />
+                          </button>
+                        )}
                         <button
                           className="p-1.5 rounded-md hover:bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-white transition-colors"
                           title={t("tooltips.splitTransaction")}

--- a/frontend/src/components/TransactionsTable.tsx
+++ b/frontend/src/components/TransactionsTable.tsx
@@ -895,8 +895,8 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
                             }}
                             className="p-1.5 rounded-md hover:bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-white transition-colors disabled:opacity-50"
                             disabled={clearCategoryTagMutation.isPending}
-                            title={t("transactions.actions.clearCategoryTag")}
-                            aria-label={t("transactions.actions.clearCategoryTag")}
+                            title={t("transactions.bulk.clearCategoryTag")}
+                            aria-label={t("transactions.bulk.clearCategoryTag")}
                           >
                             <Eraser size={14} />
                           </button>

--- a/frontend/src/components/TransactionsTable.tsx
+++ b/frontend/src/components/TransactionsTable.tsx
@@ -791,6 +791,7 @@ export const TransactionsTable: React.FC<TransactionsTableProps> = ({
               return (
                 <tr
                   key={id || idx}
+                  data-testid={`transaction-row-${id || idx}`}
                   className={`hover:bg-[var(--surface-light)]/50 transition-colors ${isSelected ? "bg-[var(--primary)]/5" : ""} ${showSelection ? "cursor-pointer" : ""}`}
                   onClick={(e) => {
                     if (!showSelection) return;

--- a/frontend/src/components/transactions/BulkActionsBar.tsx
+++ b/frontend/src/components/transactions/BulkActionsBar.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, Trash2, X } from "lucide-react";
+import { CheckCircle2, Eraser, Trash2, X } from "lucide-react";
 import { SelectDropdown } from "../common/SelectDropdown";
 import { useTranslation } from "react-i18next";
 
@@ -23,6 +23,7 @@ interface BulkActionsBarProps {
   cashBalances: { account_name: string }[];
   onApply: () => void;
   onBulkDelete: () => void;
+  onClearCategoryTag: () => void;
   onClearSelection: () => void;
   onCreateCategory: (name: string) => Promise<string>;
   onCreateTag: (category: string, name: string) => Promise<string>;
@@ -42,6 +43,7 @@ export function BulkActionsBar({
   cashBalances,
   onApply,
   onBulkDelete,
+  onClearCategoryTag,
   onClearSelection,
   onCreateCategory,
   onCreateTag,
@@ -159,6 +161,14 @@ export function BulkActionsBar({
           title={t("tooltips.applyChanges")}
         >
           <CheckCircle2 size={20} />
+        </button>
+        <button
+          className="p-1.5 rounded-lg bg-[var(--surface-light)]/40 hover:bg-[var(--surface-light)] text-[var(--text-muted)] hover:text-white transition-all"
+          onClick={onClearCategoryTag}
+          title={t("transactions.bulk.clearCategoryTag")}
+          aria-label={t("transactions.bulk.clearCategoryTag")}
+        >
+          <Eraser size={20} />
         </button>
         {showDelete && (
           <button

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -218,10 +218,16 @@
       "expense": "Expense",
       "income": "Income",
       "tags": "Tags",
-      "recategorize": "Set category & tag"
+      "recategorize": "Set category & tag",
+      "clearCategoryTag": "Clear category and tag"
     },
     "actions": {
       "clearCategoryTag": "Clear category and tag"
+    },
+    "clearConfirm": {
+      "title": "Clear category and tag",
+      "message": "Clear the category and tag from {{count}} transactions?",
+      "confirm": "Clear"
     },
     "pagination": {
       "showing": "Showing",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -221,9 +221,6 @@
       "recategorize": "Set category & tag",
       "clearCategoryTag": "Clear category and tag"
     },
-    "actions": {
-      "clearCategoryTag": "Clear category and tag"
-    },
     "clearConfirm": {
       "title": "Clear category and tag",
       "message": "Clear the category and tag from {{count}} transactions?",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -220,6 +220,9 @@
       "tags": "Tags",
       "recategorize": "Set category & tag"
     },
+    "actions": {
+      "clearCategoryTag": "Clear category and tag"
+    },
     "pagination": {
       "showing": "Showing",
       "of": "of",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -221,9 +221,6 @@
       "recategorize": "הגדר קטגוריה ותגית",
       "clearCategoryTag": "נקה קטגוריה ותגית"
     },
-    "actions": {
-      "clearCategoryTag": "נקה קטגוריה ותגית"
-    },
     "clearConfirm": {
       "title": "נקה קטגוריה ותגית",
       "message": "האם לנקות את הקטגוריה והתגית מ-{{count}} עסקאות?",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -218,10 +218,16 @@
       "expense": "הוצאה",
       "income": "הכנסה",
       "tags": "תגיות",
-      "recategorize": "הגדר קטגוריה ותגית"
+      "recategorize": "הגדר קטגוריה ותגית",
+      "clearCategoryTag": "נקה קטגוריה ותגית"
     },
     "actions": {
       "clearCategoryTag": "נקה קטגוריה ותגית"
+    },
+    "clearConfirm": {
+      "title": "נקה קטגוריה ותגית",
+      "message": "האם לנקות את הקטגוריה והתגית מ-{{count}} עסקאות?",
+      "confirm": "נקה"
     },
     "pagination": {
       "showing": "מציג",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -220,6 +220,9 @@
       "tags": "תגיות",
       "recategorize": "הגדר קטגוריה ותגית"
     },
+    "actions": {
+      "clearCategoryTag": "נקה קטגוריה ותגית"
+    },
     "pagination": {
       "showing": "מציג",
       "of": "מתוך",

--- a/tests/backend/unit/services/test_transactions_service.py
+++ b/tests/backend/unit/services/test_transactions_service.py
@@ -1543,3 +1543,69 @@ class TestGetTableForAnalysisSplitExpansion:
         result = service.get_table_for_analysis("credit_cards")
         assert isinstance(result, pd.DataFrame)
         assert result.empty
+
+
+class TestClearCategoryAndTag:
+    """Locks in that empty-string category/tag values clear the fields.
+
+    The service normalises empty strings to None at
+    ``_normalize_empty_string``. Routes that wrap this service strip
+    ``None`` values via Pydantic ``exclude_none=True``, so the frontend
+    must send ``""`` to clear. These tests pin that contract so a future
+    refactor cannot silently break the per-row / bulk clear actions.
+    """
+
+    def _insert_bank_tx_with_tags(self, db_session) -> BankTransaction:
+        """Insert a BankTransaction with category='Food' and tag='Groceries'."""
+        tx = BankTransaction(
+            id="clear_tag_test_1",
+            date="2024-05-01",
+            provider="hapoalim",
+            account_name="Checking",
+            description="Tagged transaction",
+            amount=-100.0,
+            category="Food",
+            tag="Groceries",
+            source="bank_transactions",
+            type="normal",
+            status="completed",
+        )
+        db_session.add(tx)
+        db_session.commit()
+        db_session.refresh(tx)
+        return tx
+
+    def test_update_transaction_clears_category_and_tag_via_empty_string(self, db_session):
+        """Empty strings on both fields wipe category and tag to None."""
+        service = TransactionsService(db_session)
+        tx = self._insert_bank_tx_with_tags(db_session)
+
+        updated = service.update_transaction(
+            tx.unique_id,
+            "bank_transactions",
+            {"category": "", "tag": ""},
+        )
+        assert updated is True
+        refreshed = service.transactions_repository.get_transaction_by_id(
+            tx.unique_id
+        )
+        assert pd.isna(refreshed.category)
+        assert pd.isna(refreshed.tag)
+
+    def test_update_transaction_clears_only_tag_when_only_tag_is_empty(self, db_session):
+        """Clearing only the tag preserves the category."""
+        service = TransactionsService(db_session)
+        tx = self._insert_bank_tx_with_tags(db_session)
+        original_category = tx.category
+
+        updated = service.update_transaction(
+            tx.unique_id,
+            "bank_transactions",
+            {"tag": ""},
+        )
+        assert updated is True
+        refreshed = service.transactions_repository.get_transaction_by_id(
+            tx.unique_id
+        )
+        assert refreshed.category == original_category
+        assert pd.isna(refreshed.tag)

--- a/tests/backend/unit/services/test_transactions_service.py
+++ b/tests/backend/unit/services/test_transactions_service.py
@@ -1609,3 +1609,71 @@ class TestClearCategoryAndTag:
         )
         assert refreshed.category == original_category
         assert pd.isna(refreshed.tag)
+
+    def _insert_bank_tx_with_id(self, db_session, tx_id: str) -> BankTransaction:
+        """Insert a BankTransaction with category='Food' and tag='Groceries' using the given id."""
+        tx = BankTransaction(
+            id=tx_id,
+            date="2024-05-01",
+            provider="hapoalim",
+            account_name="Checking",
+            description="Tagged transaction",
+            amount=-100.0,
+            category="Food",
+            tag="Groceries",
+            source="bank_transactions",
+            type="normal",
+            status="completed",
+        )
+        db_session.add(tx)
+        db_session.commit()
+        db_session.refresh(tx)
+        return tx
+
+    def test_bulk_tag_transactions_clears_category_and_tag_via_empty_string(self, db_session):
+        """Bulk-tag with empty strings clears category and tag on all listed IDs.
+
+        ``bulk_tag_transactions`` calls ``update_transaction`` per ID. If
+        we passed ``None`` it would be filtered out by the
+        ``if updates.get('category') is not None`` guard; empty string
+        passes the guard and gets normalised to None.
+        """
+        tx1 = self._insert_bank_tx_with_id(db_session, "bulk_clear_1")
+        tx2 = self._insert_bank_tx_with_id(db_session, "bulk_clear_2")
+
+        service = TransactionsService(db_session)
+        ids = [tx1.unique_id, tx2.unique_id]
+        service.bulk_tag_transactions(
+            ids,
+            "bank_transactions",
+            category="",
+            tag="",
+        )
+        for tx in [tx1, tx2]:
+            refreshed = service.transactions_repository.get_transaction_by_id(tx.unique_id)
+            assert pd.isna(refreshed.category)
+            assert pd.isna(refreshed.tag)
+
+    def test_bulk_tag_transactions_with_none_does_not_clear(self, db_session):
+        """Regression guard: passing None to the bulk endpoint must NOT clear.
+
+        This documents the asymmetry that motivates sending ``""`` from the
+        frontend. If this test ever starts failing (i.e. None DOES clear),
+        the frontend implementation needs to be revisited — sending None
+        from the UI would suddenly become destructive.
+        """
+        tx1 = self._insert_bank_tx_with_id(db_session, "bulk_none_1")
+        tx2 = self._insert_bank_tx_with_id(db_session, "bulk_none_2")
+
+        service = TransactionsService(db_session)
+        original_categories = [tx1.category, tx2.category]
+        ids = [tx1.unique_id, tx2.unique_id]
+        service.bulk_tag_transactions(
+            ids,
+            "bank_transactions",
+            category=None,
+            tag=None,
+        )
+        for tx, original_cat in zip([tx1, tx2], original_categories):
+            refreshed = service.transactions_repository.get_transaction_by_id(tx.unique_id)
+            assert refreshed.category == original_cat  # unchanged


### PR DESCRIPTION
## Summary
- Per-row eraser icon in the transactions table clears both category and tag in one click (hidden when row has neither).
- Bulk variant in `BulkActionsBar` (next to Apply / Delete / Cancel) opens a confirmation dialog ("Clear the category and tag from N transactions?"), then dispatches one `bulkTag` request per source group via `Promise.allSettled`.
- No new backend routes — frontend sends `category: ""` and `tag: ""` (empty strings) to the existing endpoints; the service's `_normalize_empty_string` converts them to `None`.
- Locked the empty-string-clear contract with new backend tests in `TestClearCategoryAndTag`, including a regression guard documenting that `None` is a no-op (so a future "fix" to send null can't silently become destructive).

## Pre-flight results
- **Backend pytest:** 148 passed
- **Frontend lint:** clean
- **Frontend build:** ✓ (tsc + vite)
- **Vitest:** 178 passed (21 test files)
- **Playwright e2e:** 6/6 passed (`e2e/transactions.spec.ts`)

## Fixes made during pre-flight
- `TransactionsTable.test.tsx`: Changed `null` to `undefined` for category/tag in the "hides eraser" test — TypeScript strict mode rejects `null` for `string | undefined` fields.
- i18n: Consolidated per-row eraser `aria-label` to reuse `transactions.bulk.clearCategoryTag` instead of a separate `transactions.actions.clearCategoryTag` sub-namespace. The `actions` sub-namespace was not being resolved by i18next in the dev-server environment (returned the raw key path), causing Playwright to fail to locate the button by accessible name.

## Test plan
- [x] `poetry run pytest tests/backend/unit/services/test_transactions_service.py tests/backend/routes/test_transactions_routes.py tests/backend/routes/test_transactions_routes_negative.py tests/backend/unit/repositories/test_transactions_repository.py`
- [x] `cd frontend && npm run lint && npm run build && npm test -- --run`
- [x] `cd frontend && npx playwright test e2e/transactions.spec.ts`
- [x] Manual: Demo Mode → Transactions → per-row eraser clears the badge; bulk eraser + confirm clears all selected rows; both en + he tooltips render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)