### PR TITLE
fix(setup): auto-bootstrap .venv on first npm run backend in a worktree

### DIFF
--- a/.claude/scripts/bootstrap_venv.sh
+++ b/.claude/scripts/bootstrap_venv.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Bootstrap a Python venv with project dependencies if missing.
+#
+# Idempotent: exits 0 silently when the venv is already set up. Used by
+# `npm run backend` to auto-heal worktrees that haven't been bootstrapped
+# yet — the worktree creation flow only copies source files, not the
+# .venv, so a freshly created worktree's `npm run backend` would otherwise
+# fail with "sh: .venv/bin/activate: No such file or directory".
+#
+# Manual equivalent (per CLAUDE.md "Environment Setup"):
+#   python3.12 -m venv .venv && source .venv/bin/activate \
+#     && pip install poetry && poetry install --no-root
+#
+# Re-runs safely after a partial install — the "already bootstrapped" check
+# looks for .venv/bin/uvicorn (a project dependency that exists only after a
+# successful poetry install), so an interrupted bootstrap re-runs cleanly.
+
+set -euo pipefail
+
+# Run from the repo root regardless of where the script was invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Already bootstrapped — fast path, no output.
+if [ -x .venv/bin/uvicorn ]; then
+  exit 0
+fi
+
+echo "[bootstrap] No .venv found in this worktree (or previous bootstrap was interrupted)."
+echo "[bootstrap] Setting up the backend environment — this takes ~90s and only runs once per worktree."
+
+if ! command -v python3.12 >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+[bootstrap] ERROR: python3.12 not found on PATH.
+
+This project requires Python 3.12 (see CLAUDE.md). Install it with:
+  brew install python@3.12       # macOS
+
+Then re-run `npm run backend`.
+EOF
+  exit 1
+fi
+
+# Create the venv if missing — keep an existing partial venv if present so
+# we don't lose any in-progress poetry state.
+if [ ! -d .venv ]; then
+  python3.12 -m venv .venv
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+pip install --quiet --upgrade pip
+pip install --quiet poetry
+poetry install --no-root
+
+echo "[bootstrap] Done. Starting backend..."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,25 @@ python -m scraper <provider> --show-browser             # Run scraper with visib
 
 ## Environment Setup (New Clone / Worktree)
 
+`npm run backend` auto-bootstraps the Python venv via `.claude/scripts/bootstrap_venv.sh` if `.venv/` is missing — the first backend start in a fresh worktree takes ~90s, subsequent starts are instant. Frontend deps still install manually:
+
 ```bash
-python3.12 -m venv .venv && source .venv/bin/activate && pip install poetry && poetry install --no-root
 cd frontend && npm install
 ```
+
+To bootstrap the backend explicitly (without starting it), run the script directly:
+
+```bash
+./.claude/scripts/bootstrap_venv.sh
+```
+
+Manual equivalent if you'd rather see each step:
+
+```bash
+python3.12 -m venv .venv && source .venv/bin/activate && pip install poetry && poetry install --no-root
+```
+
+**Why the auto-bootstrap exists:** Git worktrees only contain source files — they don't inherit the parent's `.venv/`, and a missing venv breaks `npm run backend` with a cryptic `sh: .venv/bin/activate: No such file or directory`. The bootstrap script is idempotent (exits silently when `.venv/bin/uvicorn` already exists), so the hot path stays fast.
 
 User data lives in `~/.finance-analysis/` (SQLite DB at `data.db`). Auto-created on first run. Credentials and categories live in the DB; passwords are stored in the OS Keyring. Default categories ship bundled in `backend/resources/*.yaml` and are seeded into the DB on first run.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "backend": "source .venv/bin/activate && uvicorn backend.main:app --reload"
+    "backend": "./.claude/scripts/bootstrap_venv.sh && source .venv/bin/activate && uvicorn backend.main:app --reload"
   }
 }


### PR DESCRIPTION
## Problem

New git worktrees only contain source files — they don't inherit the parent repo's `.venv/`. So a freshly-created worktree's `npm run backend` fails with:

```
sh: .venv/bin/activate: No such file or directory
```

This has bitten many sessions. The fix used to be: stop, read CLAUDE.md, run `python3.12 -m venv .venv && source .venv/bin/activate && pip install poetry && poetry install --no-root`, retry. That's friction we shouldn't have.

## Fix

`.claude/scripts/bootstrap_venv.sh` is an idempotent setup script wired into `npm run backend`:

- **Already bootstrapped** (`.venv/bin/uvicorn` exists): exits silently in ~70 ms. Hot path unaffected.
- **Missing**: prints a one-time setup notice, creates the venv, installs poetry + project deps, then `npm run backend` chains into uvicorn as before. Takes ~30-90 s depending on pip cache state.

The "already bootstrapped" check looks for `.venv/bin/uvicorn` rather than just `.venv/` so an interrupted previous bootstrap re-runs cleanly.

## Test plan

- [x] Verified in a fresh worktree (`venv-bootstrap`): script ran end-to-end in 27 s, installed all 70-something packages, exited 0.
- [x] Verified idempotent fast path: second invocation took 70 ms with no output.
- [x] Verified the full `npm run backend` chain in the same worktree: bootstrap → activate → uvicorn launched (error was port already in use from the other worktree's server, which proves uvicorn started).
- [x] Verified python3.12-missing error path message reads cleanly.

## Files

- `.claude/scripts/bootstrap_venv.sh` — new
- `package.json` — prepended `./.claude/scripts/bootstrap_venv.sh && ` to the `backend` script
- `CLAUDE.md` — replaced the manual setup snippet in "Environment Setup" with an explanation of the auto-bootstrap (with the manual command kept as an "if you'd rather see each step" fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)