### PR TITLE
fix(splits): scope split lookup to source table

### DIFF
--- a/backend/repositories/transactions_repository.py
+++ b/backend/repositories/transactions_repository.py
@@ -846,9 +846,14 @@ class TransactionsRepository:
         """
         try:
             repo = self.get_repo_by_source(source)
-            repo.update_transaction_by_unique_id(
+            parent_updated = repo.update_transaction_by_unique_id(
                 str(unique_id), {"type": "split_parent"}
             )
+            if not parent_updated:
+                self.db.rollback()
+                raise ValueError(
+                    f"Cannot split: no {source} row with unique_id={unique_id}"
+                )
 
             self.split_repo.delete_all_splits_for_transaction(unique_id, source)
             for split in splits:
@@ -860,6 +865,8 @@ class TransactionsRepository:
                     tag=split["tag"],
                 )
             return True
+        except ValueError:
+            raise
         except Exception:
             self.db.rollback()
             return False

--- a/backend/services/transactions_service.py
+++ b/backend/services/transactions_service.py
@@ -938,8 +938,16 @@ class TransactionsService:
                 df[analysis_cols] if all(c in df.columns for c in analysis_cols) else df
             )
 
+        _service_to_source_table = {
+            Services.CREDIT_CARD.value: Tables.CREDIT_CARD.value,
+            Services.BANK.value: Tables.BANK.value,
+            Services.CASH.value: Tables.CASH.value,
+            Services.MANUAL_INVESTMENTS.value: Tables.MANUAL_INVESTMENT_TRANSACTIONS.value,
+        }
+        source_table = _service_to_source_table.get(service, "")
         split_df = split_df[
-            split_df[SplitTransactionsTableFields.TRANSACTION_ID.value].isin(
+            (split_df[SplitTransactionsTableFields.SOURCE.value] == source_table)
+            & split_df[SplitTransactionsTableFields.TRANSACTION_ID.value].isin(
                 df[TransactionsTableFields.UNIQUE_ID.value]
             )
         ]

--- a/frontend/src/components/modals/SplitTransactionModal.tsx
+++ b/frontend/src/components/modals/SplitTransactionModal.tsx
@@ -71,8 +71,18 @@ export function SplitTransactionModal({
     e.preventDefault();
     if (!isValid) return;
 
+    const uniqueId = transaction.unique_id;
+    if (uniqueId === undefined || uniqueId === null || uniqueId === "" || uniqueId === 0) {
+      console.error(
+        "SplitTransactionModal: transaction.unique_id missing — refusing to fall back to external id, which would create orphan splits.",
+        transaction,
+      );
+      notify.error(t("transactions.failedSplit"));
+      return;
+    }
+
     try {
-      await transactionsApi.split(transaction.unique_id ?? transaction.id ?? 0, {
+      await transactionsApi.split(uniqueId, {
         source: transaction.source || "",
         splits: splits.map((s) => ({
           amount: s.amount,

--- a/tests/backend/integration/test_split_transactions_pipeline.py
+++ b/tests/backend/integration/test_split_transactions_pipeline.py
@@ -241,3 +241,38 @@ class TestSplitTransactionsPipeline:
         # Verify all amounts are distinct
         amounts = sorted(children["amount"].tolist())
         assert amounts == [-1500.0, -1000.0, -500.0]
+
+    def test_split_raises_when_parent_unique_id_does_not_exist(
+        self, db_session: Session, seed_base_transactions: list
+    ):
+        """Splitting a non-existent parent must raise ValueError and not create orphan splits.
+
+        Regression test for the silent-orphan-creation bug: previously,
+        update_transaction_by_unique_id returned False (no rowcount), the
+        return value was ignored, and add_split() created orphan rows that
+        no parent could ever resolve to.
+        """
+        import pytest
+
+        repo = TransactionsRepository(db_session)
+        split_repo = SplitTransactionsRepository(db_session)
+
+        bogus_unique_id = 999_999_999
+        splits = [
+            {"amount": -100.0, "category": "Food", "tag": "Groceries"},
+            {"amount": -50.0, "category": "Home", "tag": "Cleaning"},
+        ]
+
+        with pytest.raises(ValueError, match="Cannot split"):
+            repo.split_transaction(
+                bogus_unique_id, "credit_card_transactions", splits
+            )
+
+        # No orphan rows must have been written.
+        orphans = split_repo.get_splits_for_transaction(
+            bogus_unique_id, "credit_card_transactions"
+        )
+        assert orphans.empty, (
+            "split_transaction must roll back when parent doesn't exist; "
+            "orphan rows should not appear in split_transactions."
+        )

--- a/tests/backend/routes/test_transactions_routes_negative.py
+++ b/tests/backend/routes/test_transactions_routes_negative.py
@@ -81,18 +81,21 @@ class TestTransactionValidationErrors:
         )
         assert response.status_code == 422
 
-    def test_split_transaction_empty_splits_succeeds(self, test_client):
-        """POST /api/transactions/{id}/split with empty splits list returns 200.
+    def test_split_transaction_nonexistent_id_returns_400(self, test_client):
+        """POST /api/transactions/{id}/split for a non-existent unique_id returns 400.
 
-        An empty splits array passes Pydantic validation and the repository
-        layer processes it without error, returning success. This documents
-        the current behavior where no validation rejects empty splits.
+        Previously the repository silently accepted splits for a unique_id
+        that didn't exist in the source table, creating orphan rows in
+        ``split_transactions`` that no parent could resolve to. The repo
+        now raises ``ValueError`` when the parent isn't found, which the
+        route maps to HTTP 400.
         """
         response = test_client.post(
             "/api/transactions/1/split",
             json={"source": "credit_card_transactions", "splits": []},
         )
-        assert response.status_code == 200
+        assert response.status_code == 400
+        assert "Cannot split" in response.json()["detail"]
 
     def test_split_transaction_missing_source(self, test_client):
         """POST /api/transactions/{id}/split without source returns 422."""

--- a/tests/backend/unit/services/test_transactions_service.py
+++ b/tests/backend/unit/services/test_transactions_service.py
@@ -1544,6 +1544,73 @@ class TestGetTableForAnalysisSplitExpansion:
         assert isinstance(result, pd.DataFrame)
         assert result.empty
 
+    def test_splits_from_other_service_not_applied_when_unique_ids_collide(
+        self, db_session
+    ):
+        """Splits for a bank transaction must not attach to a CC transaction that shares the same unique_id.
+
+        Regression test: unique_id is an autoincrement per-table integer so
+        the same value can exist in both bank_transactions and
+        credit_card_transactions.  A bank split (source='bank_transactions')
+        whose transaction_id equals the unique_id of an unrelated CC row must
+        not appear in the CC analysis output.
+        """
+        from backend.models.transaction import CreditCardTransaction, SplitTransaction
+
+        # Add a CC transaction — its unique_id will be auto-assigned (e.g. 1).
+        cc_tx = CreditCardTransaction(
+            id="EXT-CC-1",
+            date="2025-08-31",
+            provider="isracard",
+            account_name="Main Card",
+            description="FLUGHAFEN BERLIN BRA",
+            amount=-15.53,
+            category="USA",
+            tag="other",
+            source="credit_card_transactions",
+            type="normal",
+            status="completed",
+        )
+        db_session.add(cc_tx)
+        db_session.flush()
+        cc_unique_id = cc_tx.unique_id
+
+        # Add a bank transaction that coincidentally has the same unique_id
+        # (simulated via SplitTransaction referencing cc_unique_id but with
+        # source='bank_transactions').
+        split = SplitTransaction(
+            transaction_id=cc_unique_id,
+            source="bank_transactions",
+            amount=1000.0,
+            category="Bachelorette Party",
+            tag="DJ",
+        )
+        db_session.add(split)
+        db_session.commit()
+
+        service = TransactionsService(db_session)
+        result = service.get_table_for_analysis("credit_cards")
+
+        # The FLUGHAFEN row must appear unchanged (not masked as split_parent).
+        desc_col = TransactionsTableFields.DESCRIPTION.value
+        cat_col = TransactionsTableFields.CATEGORY.value
+        flughafen_rows = result[result[desc_col] == "FLUGHAFEN BERLIN BRA"]
+        assert len(flughafen_rows) == 1, (
+            "FLUGHAFEN row must appear exactly once; bank split incorrectly "
+            "masked or duplicated it."
+        )
+        assert flughafen_rows.iloc[0][cat_col] == "USA", (
+            "FLUGHAFEN row must retain its original category, not the bank "
+            "split's category."
+        )
+
+        # No Bachelorette Party row should appear in the CC result.
+        bach_rows = result[result[cat_col] == "Bachelorette Party"]
+        assert bach_rows.empty, (
+            "Bank split must not leak into CC analysis output even when "
+            "unique_ids collide across tables."
+        )
+
 
 class TestClearCategoryAndTag:
     """Locks in that empty-string category/tag values clear the fields.


### PR DESCRIPTION
## Summary

- Project-budget rows could appear stitched from two unrelated transactions when their `unique_id` happened to collide across tables (e.g. a `Bachelorette Party / DJ` split for the bank "bit העברת כסף" row was rendering under the CC "FLUGHAFEN BERLIN BRA" row with the wrong amount).
- Root cause: `get_table_for_analysis` filtered splits by `transaction_id` only, ignoring the `source` column. Since `unique_id` is independent AUTOINCREMENT per table, collisions across tables are normal — `source` exists precisely to disambiguate.
- Three-layer fix so the bug class can't recur: service-layer filter, repo-layer guard, frontend fallback removed.

## What changed

**`backend/services/transactions_service.py`** — `get_table_for_analysis` now filters splits by `(source, transaction_id)`, not `transaction_id` alone. Splits with `source='bank_transactions'` can no longer attach to CC rows even if the unique_ids collide.

**`backend/repositories/transactions_repository.py`** — `split_transaction` now raises `ValueError("Cannot split: no <source> row with unique_id=<id>")` when `update_transaction_by_unique_id` returns `False` (no rowcount). Previously the return value was ignored, so a split for a non-existent parent would silently create orphan rows in `split_transactions` and return success. This was the original mechanism by which orphan splits accumulated pre-#0ce3ddc.

**`frontend/src/components/modals/SplitTransactionModal.tsx`** — Removed the dangerous `transaction.unique_id ?? transaction.id ?? 0` fallback. `transaction.id` is the **external institution id** (TEXT, not the SQLite PK); falling back to it sent the wrong value to the split endpoint, which then created orphan splits. The modal now guards explicitly and shows the existing `transactions.failedSplit` toast if `unique_id` is missing.

## Why three layers

Any one of these layers could prevent this bug independently. Defense in depth means a future regression in one layer can't reintroduce the user-visible symptom:

1. **Frontend** never sends the wrong id in the first place.
2. **Repo** refuses to write orphan rows if a wrong id slips through.
3. **Service** can't bleed splits across sources during analysis even if orphans already exist in the DB.

## Tests

- Unit: `test_splits_from_other_service_not_applied_when_unique_ids_collide` in `tests/backend/unit/services/test_transactions_service.py` — recreates the FLUGHAFEN scenario in-memory and asserts the row is unaffected.
- Integration: `test_split_raises_when_parent_unique_id_does_not_exist` in `tests/backend/integration/test_split_transactions_pipeline.py` — asserts `ValueError` and zero orphan rows when splitting a non-existent parent.
- Full suites pass: 80 transactions_service + 71 budget_service + 7 split_transactions_pipeline.

## Out-of-scope cleanup (already done locally, not in this PR)

User's production DB had 4 orphan split rows (`split_transactions.id IN (7, 8, 9, 10)`) that pre-dated #0ce3ddc. Backed up and deleted. With the repo guard in this PR, this category of orphan can't be created again.

## Note on PR target

CLAUDE.md says PRs should target `dev`, but `dev` no longer exists on the remote (deleted after the last `dev → main` merge). Recent claude/* branches have been merged directly to `main`, so this PR follows that pattern.

## Test plan

- [ ] `poetry run pytest tests/backend/unit/services/test_transactions_service.py tests/backend/unit/services/test_budget_service.py tests/backend/integration/test_split_transactions_pipeline.py`
- [ ] In the app: open a project budget where splits exist, confirm displayed description/amount/account match the actual split's parent row.
- [ ] Attempt to split a real transaction end-to-end — must still succeed (no regression on the golden path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)