### PR TITLE
feat: native double-tap zoom mode for charts on touch (persistent, no scroll hijack)

### DIFF
--- a/frontend/e2e/chart-touch-scroll.spec.ts
+++ b/frontend/e2e/chart-touch-scroll.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect, type Page } from "@playwright/test";
+import { enableDemoMode, disableDemoMode, navigateTo } from "./helpers";
+
+/**
+ * Guards the touch-scroll fix in utils/plotlyLocale.ts.
+ *
+ * On touch devices Plotly's default `dragmode: "zoom"` hijacks a single-finger
+ * drag to draw a zoom box, so dragging over a chart zooms it instead of
+ * scrolling the page. The shared chartTheme sets `dragmode: false` on touch
+ * devices (and config `scrollZoom: false`) so the gesture falls through to page
+ * scroll; desktop keeps drag-to-zoom.
+ *
+ * `isTouchDevice` (in plotlyLocale.ts) is computed at module load from
+ * `navigator.maxTouchPoints`, so these tests flip Playwright's `hasTouch`
+ * emulation to exercise both branches and read the computed `_fullLayout` off
+ * the Plotly graph div.
+ *
+ * Run via with_server.py so both backend + frontend are up. Demo Mode supplies
+ * the Cohen-family data the dashboard charts need.
+ */
+
+/** Read the computed Plotly dragmode off the first rendered graph div. */
+async function firstChartDragmode(page: Page): Promise<unknown> {
+  const plot = page.locator(".js-plotly-plot").first();
+  await expect(plot).toBeVisible({ timeout: 15_000 });
+  return plot.evaluate(
+    (el) => (el as unknown as { _fullLayout?: { dragmode?: unknown } })._fullLayout?.dragmode,
+  );
+}
+
+test.describe("Chart touch-scroll (dragmode)", () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await enableDemoMode(page);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await disableDemoMode(page);
+    await page.close();
+  });
+
+  test.describe("on a touch device", () => {
+    test.use({ hasTouch: true, isMobile: true });
+
+    test("charts disable drag so a finger scroll passes through", async ({ page }) => {
+      await navigateTo(page, "/");
+      // Plotly normalizes a disabled dragmode to the boolean false.
+      expect(await firstChartDragmode(page)).toBe(false);
+    });
+  });
+
+  test.describe("on a desktop (non-touch) device", () => {
+    test.use({ hasTouch: false, isMobile: false });
+
+    test("charts keep drag-to-zoom", async ({ page }) => {
+      await navigateTo(page, "/");
+      // Desktop has no scroll/zoom conflict, so the default zoom drag stays on.
+      expect(await firstChartDragmode(page)).not.toBe(false);
+    });
+  });
+});

--- a/frontend/e2e/chart-touch-zoom.spec.ts
+++ b/frontend/e2e/chart-touch-zoom.spec.ts
@@ -2,17 +2,18 @@ import { test, expect, type Page } from "@playwright/test";
 import { enableDemoMode, disableDemoMode, navigateTo } from "./helpers";
 
 /**
- * Drives the double-tap-then-drag figure zoom (utils/chartTouchZoom.ts).
+ * Drives the double-tap-to-enter native zoom mode (utils/chartTouchZoom.ts).
  *
- * On touch devices a plain swipe scrolls the page (dragmode is off); zoom is
- * offered behind an explicit gesture: tap, then on the second tap keep the
- * finger down and drag up to zoom in. A plain double-tap resets to autorange.
+ * A plain swipe scrolls the page (dragmode off). Double-tapping a chart enters
+ * Plotly's native zoom mode (`dragmode: "zoom"`); a one-finger drag then marks
+ * a rectangle and zooms into it, and the zoom persists after lifting the finger
+ * (native GUI interaction + `chartTheme.uirevision`). Touching outside the
+ * chart leaves zoom mode.
  *
- * The handler is installed from App on touch devices only, so the suite runs
- * with `hasTouch` emulation and dispatches real TouchEvents at the first
- * zoomable (cartesian) chart, then reads the axis range Plotly computed.
+ * Runs under `hasTouch` emulation (the handler installs on touch devices only)
+ * and dispatches real TouchEvents.
  */
-test.describe("Chart double-tap-drag zoom (touch)", () => {
+test.describe("Chart double-tap native zoom mode (touch)", () => {
   test.use({ hasTouch: true, isMobile: true });
 
   test.beforeAll(async ({ browser }) => {
@@ -27,13 +28,10 @@ test.describe("Chart double-tap-drag zoom (touch)", () => {
     await page.close();
   });
 
-  /** Linear-space width of the first zoomable chart's x-axis, or null. */
-  async function xSpan(page: Page): Promise<number | null> {
+  /** Mark the first zoomable (cartesian) chart and return its x-span, or null. */
+  async function markChart(page: Page): Promise<number | null> {
     return page.evaluate(() => {
-      const plots = Array.from(
-        document.querySelectorAll<HTMLElement>(".js-plotly-plot"),
-      );
-      for (const el of plots) {
+      for (const el of document.querySelectorAll<HTMLElement>(".js-plotly-plot")) {
         const xa = (el as { _fullLayout?: { xaxis?: { range?: [unknown, unknown]; r2l?: (v: unknown) => number } } })
           ._fullLayout?.xaxis;
         if (xa?.range && typeof xa.r2l === "function") {
@@ -45,81 +43,96 @@ test.describe("Chart double-tap-drag zoom (touch)", () => {
     });
   }
 
-  /**
-   * Dispatch a tap, then a tap-and-drag of `dyUp` pixels (positive = up = zoom
-   * in) on the marked chart. Mirrors a real one-finger double-tap-drag.
-   */
-  async function doubleTapDrag(page: Page, dyUp: number) {
-    await page.evaluate((dy) => {
+  const xSpan = (page: Page) =>
+    page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>('[data-zoom-test="1"]')!;
+      const xa = (el as { _fullLayout?: { xaxis?: { range?: [unknown, unknown]; r2l?: (v: unknown) => number } } })
+        ._fullLayout!.xaxis!;
+      return Math.abs(xa.r2l!(xa.range![1]) - xa.r2l!(xa.range![0]));
+    });
+
+  const dragmode = (page: Page) =>
+    page.evaluate(
+      () =>
+        (document.querySelector('[data-zoom-test="1"]') as { _fullLayout?: { dragmode?: unknown } })
+          ._fullLayout?.dragmode,
+    );
+
+  /** Double-tap the marked chart's center to toggle zoom mode on. */
+  async function doubleTap(page: Page) {
+    await page.evaluate(() => {
       const el = document.querySelector<HTMLElement>('[data-zoom-test="1"]')!;
       const r = el.getBoundingClientRect();
-      const cx = r.left + r.width / 2;
-      const cy = r.top + r.height / 2;
-      const touchAt = (y: number) =>
-        new Touch({ identifier: 0, target: el, clientX: cx, clientY: y });
-      const fire = (type: string, y: number, list: Touch[]) =>
-        el.dispatchEvent(
-          new TouchEvent(type, {
-            bubbles: true,
-            cancelable: true,
-            touches: list,
-            targetTouches: list,
-            changedTouches: [touchAt(y)],
-          }),
-        );
-      // First tap.
-      fire("touchstart", cy, [touchAt(cy)]);
-      fire("touchend", cy, []);
-      // Second tap — held — then dragged up to zoom in.
-      fire("touchstart", cy, [touchAt(cy)]);
-      fire("touchmove", cy - dy, [touchAt(cy - dy)]);
-      fire("touchend", cy - dy, []);
-    }, dyUp);
-    // Plotly.relayout resolves on the next tick; let the range settle.
-    await page.waitForTimeout(300);
+      const x = r.left + r.width / 2;
+      const y = r.top + r.height / 2;
+      const t = () => new Touch({ identifier: 0, target: el, clientX: x, clientY: y });
+      const tap = () => {
+        el.dispatchEvent(new TouchEvent("touchstart", { bubbles: true, cancelable: true, touches: [t()], changedTouches: [t()] }));
+        el.dispatchEvent(new TouchEvent("touchend", { bubbles: true, cancelable: true, touches: [], changedTouches: [t()] }));
+      };
+      tap();
+      tap();
+    });
+    await page.waitForTimeout(150);
   }
 
-  test("double-tap-drag up zooms the figure in", async ({ page }) => {
+  test("double-tap enters zoom mode; native drag zooms and persists", async ({ page }) => {
     await navigateTo(page, "/");
-    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({
-      timeout: 15_000,
-    });
-    const before = await xSpan(page);
+    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({ timeout: 15_000 });
+    const before = await markChart(page);
     expect(before, "expected a zoomable cartesian chart").not.toBeNull();
 
-    await doubleTapDrag(page, 120);
+    await doubleTap(page);
+    expect(await dragmode(page)).toBe("zoom");
+    await expect(page.locator('[data-zoom-test="1"].chart-zoom-active')).toBeVisible();
 
-    const after = await page.evaluate(() => {
+    // Drag a rectangle on Plotly's native drag layer — its own zoom interaction.
+    await page.evaluate(() => {
       const el = document.querySelector<HTMLElement>('[data-zoom-test="1"]')!;
-      const xa = (el as { _fullLayout?: { xaxis?: { range?: [unknown, unknown]; r2l?: (v: unknown) => number } } })
-        ._fullLayout!.xaxis!;
-      return Math.abs(xa.r2l!(xa.range![1]) - xa.r2l!(xa.range![0]));
+      const nsew = el.querySelector(".nsewdrag")!;
+      const r = nsew.getBoundingClientRect();
+      const x1 = r.left + r.width * 0.35;
+      const y1 = r.top + r.height * 0.4;
+      const x2 = r.left + r.width * 0.65;
+      const y2 = r.top + r.height * 0.6;
+      const T = (x: number, y: number) =>
+        new Touch({ identifier: 1, target: nsew, clientX: x, clientY: y, pageX: x, pageY: y } as TouchInit);
+      const fire = (type: string, x: number, y: number, list: Touch[]) =>
+        nsew.dispatchEvent(
+          new TouchEvent(type, { bubbles: true, cancelable: true, touches: list, targetTouches: list, changedTouches: [T(x, y)] }),
+        );
+      fire("touchstart", x1, y1, [T(x1, y1)]);
+      fire("touchmove", x2, y2, [T(x2, y2)]);
+      fire("touchend", x2, y2, []);
     });
+    await page.waitForTimeout(250);
 
-    // Zooming in shrinks the visible x-range.
-    expect(after).toBeLessThan((before as number) * 0.95);
+    const afterDrag = await xSpan(page);
+    expect(afterDrag).toBeLessThan((before as number) * 0.95);
+
+    // Lifting the finger keeps the zoom; a re-render must not reset it.
+    await page.evaluate(() => window.dispatchEvent(new Event("resize")));
+    await page.waitForTimeout(150);
+    expect(await xSpan(page)).toBeLessThan((before as number) * 0.95);
   });
 
-  test("a plain double-tap resets the zoom", async ({ page }) => {
+  test("touching outside the chart leaves zoom mode", async ({ page }) => {
     await navigateTo(page, "/");
-    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({
-      timeout: 15_000,
+    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({ timeout: 15_000 });
+    await markChart(page);
+
+    await doubleTap(page);
+    expect(await dragmode(page)).toBe("zoom");
+
+    // A touch outside any chart exits zoom mode (back to scroll).
+    await page.evaluate(() => {
+      const target = document.body;
+      const t = new Touch({ identifier: 2, target, clientX: 5, clientY: 5 });
+      target.dispatchEvent(new TouchEvent("touchstart", { bubbles: true, cancelable: true, touches: [t], changedTouches: [t] }));
     });
-    const before = await xSpan(page);
-    expect(before).not.toBeNull();
+    await page.waitForTimeout(150);
 
-    // Zoom in first, then double-tap (no drag) to reset.
-    await doubleTapDrag(page, 120);
-    await doubleTapDrag(page, 0);
-
-    const after = await page.evaluate(() => {
-      const el = document.querySelector<HTMLElement>('[data-zoom-test="1"]')!;
-      const xa = (el as { _fullLayout?: { xaxis?: { range?: [unknown, unknown]; r2l?: (v: unknown) => number } } })
-        ._fullLayout!.xaxis!;
-      return Math.abs(xa.r2l!(xa.range![1]) - xa.r2l!(xa.range![0]));
-    });
-
-    // Reset restores (autoranges back to) roughly the original span.
-    expect(after).toBeGreaterThan((before as number) * 0.9);
+    expect(await dragmode(page)).toBe(false);
+    await expect(page.locator('[data-zoom-test="1"].chart-zoom-active')).toHaveCount(0);
   });
 });

--- a/frontend/e2e/chart-touch-zoom.spec.ts
+++ b/frontend/e2e/chart-touch-zoom.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect, type Page } from "@playwright/test";
+import { enableDemoMode, disableDemoMode, navigateTo } from "./helpers";
+
+/**
+ * Drives the double-tap-then-drag figure zoom (utils/chartTouchZoom.ts).
+ *
+ * On touch devices a plain swipe scrolls the page (dragmode is off); zoom is
+ * offered behind an explicit gesture: tap, then on the second tap keep the
+ * finger down and drag up to zoom in. A plain double-tap resets to autorange.
+ *
+ * The handler is installed from App on touch devices only, so the suite runs
+ * with `hasTouch` emulation and dispatches real TouchEvents at the first
+ * zoomable (cartesian) chart, then reads the axis range Plotly computed.
+ */
+test.describe("Chart double-tap-drag zoom (touch)", () => {
+  test.use({ hasTouch: true, isMobile: true });
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await enableDemoMode(page);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await disableDemoMode(page);
+    await page.close();
+  });
+
+  /** Linear-space width of the first zoomable chart's x-axis, or null. */
+  async function xSpan(page: Page): Promise<number | null> {
+    return page.evaluate(() => {
+      const plots = Array.from(
+        document.querySelectorAll<HTMLElement>(".js-plotly-plot"),
+      );
+      for (const el of plots) {
+        const xa = (el as { _fullLayout?: { xaxis?: { range?: [unknown, unknown]; r2l?: (v: unknown) => number } } })
+          ._fullLayout?.xaxis;
+        if (xa?.range && typeof xa.r2l === "function") {
+          el.setAttribute("data-zoom-test", "1");
+          return Math.abs(xa.r2l(xa.range[1]) - xa.r2l(xa.range[0]));
+        }
+      }
+      return null;
+    });
+  }
+
+  /**
+   * Dispatch a tap, then a tap-and-drag of `dyUp` pixels (positive = up = zoom
+   * in) on the marked chart. Mirrors a real one-finger double-tap-drag.
+   */
+  async function doubleTapDrag(page: Page, dyUp: number) {
+    await page.evaluate((dy) => {
+      const el = document.querySelector<HTMLElement>('[data-zoom-test="1"]')!;
+      const r = el.getBoundingClientRect();
+      const cx = r.left + r.width / 2;
+      const cy = r.top + r.height / 2;
+      const touchAt = (y: number) =>
+        new Touch({ identifier: 0, target: el, clientX: cx, clientY: y });
+      const fire = (type: string, y: number, list: Touch[]) =>
+        el.dispatchEvent(
+          new TouchEvent(type, {
+            bubbles: true,
+            cancelable: true,
+            touches: list,
+            targetTouches: list,
+            changedTouches: [touchAt(y)],
+          }),
+        );
+      // First tap.
+      fire("touchstart", cy, [touchAt(cy)]);
+      fire("touchend", cy, []);
+      // Second tap — held — then dragged up to zoom in.
+      fire("touchstart", cy, [touchAt(cy)]);
+      fire("touchmove", cy - dy, [touchAt(cy - dy)]);
+      fire("touchend", cy - dy, []);
+    }, dyUp);
+    // Plotly.relayout resolves on the next tick; let the range settle.
+    await page.waitForTimeout(300);
+  }
+
+  test("double-tap-drag up zooms the figure in", async ({ page }) => {
+    await navigateTo(page, "/");
+    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({
+      timeout: 15_000,
+    });
+    const before = await xSpan(page);
+    expect(before, "expected a zoomable cartesian chart").not.toBeNull();
+
+    await doubleTapDrag(page, 120);
+
+    const after = await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>('[data-zoom-test="1"]')!;
+      const xa = (el as { _fullLayout?: { xaxis?: { range?: [unknown, unknown]; r2l?: (v: unknown) => number } } })
+        ._fullLayout!.xaxis!;
+      return Math.abs(xa.r2l!(xa.range![1]) - xa.r2l!(xa.range![0]));
+    });
+
+    // Zooming in shrinks the visible x-range.
+    expect(after).toBeLessThan((before as number) * 0.95);
+  });
+
+  test("a plain double-tap resets the zoom", async ({ page }) => {
+    await navigateTo(page, "/");
+    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({
+      timeout: 15_000,
+    });
+    const before = await xSpan(page);
+    expect(before).not.toBeNull();
+
+    // Zoom in first, then double-tap (no drag) to reset.
+    await doubleTapDrag(page, 120);
+    await doubleTapDrag(page, 0);
+
+    const after = await page.evaluate(() => {
+      const el = document.querySelector<HTMLElement>('[data-zoom-test="1"]')!;
+      const xa = (el as { _fullLayout?: { xaxis?: { range?: [unknown, unknown]; r2l?: (v: unknown) => number } } })
+        ._fullLayout!.xaxis!;
+      return Math.abs(xa.r2l!(xa.range![1]) - xa.r2l!(xa.range![0]));
+    });
+
+    // Reset restores (autoranges back to) roughly the original span.
+    expect(after).toBeGreaterThan((before as number) * 0.9);
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,9 +32,10 @@ import {
 } from "./pages";
 
 function App() {
-  // On touch devices, enable double-tap-then-drag zoom on every Plotly chart.
-  // Charts disable Plotly's own drag (so a plain swipe scrolls the page); this
-  // restores figure zoom behind an explicit gesture. No-op on desktop.
+  // On touch devices, let a double-tap put a Plotly chart into native zoom mode
+  // (drag a rectangle to zoom). Charts disable Plotly's own drag by default so a
+  // plain swipe scrolls the page; this restores zoom behind an explicit gesture.
+  // No-op on desktop.
   useEffect(() => {
     if (!isTouchDevice) return;
     return installChartTouchZoom();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,8 @@
+import { useEffect } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import { isTouchDevice } from "./utils/plotlyLocale";
+import { installChartTouchZoom } from "./utils/chartTouchZoom";
 import { Layout } from "./components/layout";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { OnboardingGate } from "./components/OnboardingGate";
@@ -29,6 +32,14 @@ import {
 } from "./pages";
 
 function App() {
+  // On touch devices, enable double-tap-then-drag zoom on every Plotly chart.
+  // Charts disable Plotly's own drag (so a plain swipe scrolls the page); this
+  // restores figure zoom behind an explicit gesture. No-op on desktop.
+  useEffect(() => {
+    if (!isTouchDevice) return;
+    return installChartTouchZoom();
+  }, []);
+
   return (
     <PersistQueryClientProvider
       client={queryClient}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -188,3 +188,31 @@ body.modal-open {
   opacity: 1;
   transition-delay: 0.5s;
 }
+
+/* Touch chart zoom mode (utils/chartTouchZoom.ts): a chart entered via
+   double-tap shows a ring + a hint pill while Plotly's native rectangle
+   zoom is active. */
+.chart-zoom-active {
+  box-shadow: 0 0 0 2px var(--primary);
+  border-radius: 10px;
+}
+.chart-zoom-hint {
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  pointer-events: none;
+  max-width: calc(100% - 16px);
+  padding: 3px 10px;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--background) 88%, transparent);
+  border: 1px solid var(--surface-light);
+  color: var(--text);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -902,6 +902,9 @@
     "selectDateRange": "Select Date Range",
     "customRange": "Custom Range"
   },
+  "charts": {
+    "zoomHint": "Drag to zoom · double-tap to reset · tap away to exit"
+  },
   "tooltips": {
     "editCategoryTag": "Edit category / tag",
     "editTransaction": "Edit transaction",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -902,6 +902,9 @@
     "selectDateRange": "בחר טווח תאריכים",
     "customRange": "טווח מותאם"
   },
+  "charts": {
+    "zoomHint": "גררו כדי להתקרב · הקשה כפולה לאיפוס · הקישו בחוץ ליציאה"
+  },
   "tooltips": {
     "editCategoryTag": "ערוך קטגוריה / תגית",
     "editTransaction": "ערוך תנועה",

--- a/frontend/src/types/plotly-dist.d.ts
+++ b/frontend/src/types/plotly-dist.d.ts
@@ -1,0 +1,15 @@
+/**
+ * `react-plotly.js` bundles Plotly from `plotly.js/dist/plotly`. Importing that
+ * same path elsewhere (e.g. utils/chartTouchZoom.ts) reuses the one bundled
+ * instance instead of pulling a second ~3 MB Plotly build. That dist entry ships
+ * no types, so re-expose the typed default from the package root.
+ *
+ * Kept script-style (no top-level import) so the ambient module declaration is
+ * picked up globally; the inline import-type below is the only way to reference
+ * the package types from inside that ambient block.
+ */
+declare module "plotly.js/dist/plotly" {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const Plotly: typeof import("plotly.js");
+  export default Plotly;
+}

--- a/frontend/src/utils/chartTouchZoom.ts
+++ b/frontend/src/utils/chartTouchZoom.ts
@@ -1,0 +1,234 @@
+import Plotly from "plotly.js/dist/plotly";
+
+/**
+ * Touch "double-tap-then-drag" zoom for Plotly charts.
+ *
+ * On touch devices the shared chart theme sets `dragmode: false` so a normal
+ * one-finger drag scrolls the page instead of being hijacked into a Plotly zoom
+ * box (see utils/plotlyLocale.ts). That trades away the ability to zoom a
+ * figure at all. This module gives it back behind an explicit gesture, the same
+ * one map apps use for one-finger zoom:
+ *
+ *   tap once, then on the second tap keep the finger down and drag —
+ *   drag up zooms in, drag down zooms out, centered on where you tapped.
+ *
+ * A plain double-tap (no drag) resets the figure to autorange. A single drag is
+ * left untouched, so the page keeps scrolling.
+ *
+ * It's installed once globally and works on every chart via event delegation
+ * (`closest(".js-plotly-plot")`), so individual chart components need no wiring.
+ * Pie / donut / Sankey charts have no cartesian axes and are skipped — the
+ * gesture falls through to a normal tap/scroll there.
+ */
+
+/** ms between the two taps to count as a double-tap. */
+const DOUBLE_TAP_MS = 300;
+/** px the second tap may sit from the first and still pair as a double-tap. */
+const TAP_RADIUS = 30;
+/** px of movement on a pending first tap that reclassifies it as a scroll. */
+const MOVE_CANCEL = 12;
+/** px of vertical drag that halves / doubles the visible range. */
+const ZOOM_SENSITIVITY = 220;
+/** below this total drag the gesture is treated as a plain double-tap (reset). */
+const RESET_MOVE = 8;
+/** clamp the per-gesture zoom factor so a frantic drag can't invert the axes. */
+const MIN_SCALE = 1 / 40;
+const MAX_SCALE = 40;
+
+interface PlotlyAxis {
+  range?: [number | string, number | string];
+  _offset?: number;
+  _length?: number;
+  r2l?: (v: number | string) => number;
+  l2r?: (v: number) => number | string;
+}
+
+interface PlotlyGraphDiv extends HTMLElement {
+  _fullLayout?: { xaxis?: PlotlyAxis; yaxis?: PlotlyAxis };
+}
+
+/** A cartesian axis we can zoom needs a 2-point range and the lin/range maps. */
+function zoomableAxis(ax: PlotlyAxis | undefined): ax is Required<
+  Pick<PlotlyAxis, "range" | "r2l" | "l2r">
+> &
+  PlotlyAxis {
+  return (
+    !!ax &&
+    Array.isArray(ax.range) &&
+    ax.range.length === 2 &&
+    typeof ax.r2l === "function" &&
+    typeof ax.l2r === "function"
+  );
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, v));
+}
+
+interface AxisState {
+  ax: PlotlyAxis;
+  key: "xaxis" | "yaxis";
+  /** range endpoints in linear space, captured at gesture start. */
+  base0: number;
+  base1: number;
+  /** the tapped point in linear space — the zoom stays anchored here. */
+  anchor: number;
+}
+
+interface ActiveGesture {
+  gd: PlotlyGraphDiv;
+  axes: AxisState[];
+  startY: number;
+  maxMove: number;
+}
+
+/** Build the per-axis zoom state, anchored at the second tap's pixel position. */
+function axisState(
+  ax: PlotlyAxis | undefined,
+  key: "xaxis" | "yaxis",
+  gdRect: DOMRect,
+  clientPx: number,
+  /** y axes grow upward in data but downward in pixels — flip the fraction. */
+  invert: boolean,
+): AxisState | null {
+  if (!zoomableAxis(ax)) return null;
+  const base0 = ax.r2l(ax.range[0]);
+  const base1 = ax.r2l(ax.range[1]);
+  const offset = ax._offset ?? 0;
+  const length = ax._length ?? 1;
+  const start = (key === "xaxis" ? gdRect.left : gdRect.top) + offset;
+  let frac = clamp((clientPx - start) / length, 0, 1);
+  if (invert) frac = 1 - frac;
+  const anchor = base0 + frac * (base1 - base0);
+  return { ax, key, base0, base1, anchor };
+}
+
+export function installChartTouchZoom(): () => void {
+  let pendingTime = 0;
+  let pendingX = 0;
+  let pendingY = 0;
+  let pendingGd: PlotlyGraphDiv | null = null;
+  let active: ActiveGesture | null = null;
+
+  const clearPending = () => {
+    pendingTime = 0;
+    pendingGd = null;
+  };
+
+  const endGesture = () => {
+    if (!active) return;
+    const { gd, axes, maxMove } = active;
+    // A double-tap with (almost) no drag means "reset" — restore autorange.
+    // The range must be nulled alongside autorange; setting autorange alone
+    // leaves the explicit zoomed range in place on these charts.
+    if (maxMove < RESET_MOVE) {
+      const reset: Record<string, null | true> = {};
+      for (const a of axes) {
+        reset[`${a.key}.range`] = null;
+        reset[`${a.key}.autorange`] = true;
+      }
+      void Plotly.relayout(gd, reset);
+    }
+    active = null;
+    window.removeEventListener("touchmove", onMove);
+    window.removeEventListener("touchend", onEnd);
+    window.removeEventListener("touchcancel", onEnd);
+  };
+
+  const onMove = (e: TouchEvent) => {
+    if (!active) return;
+    if (e.touches.length !== 1) {
+      endGesture();
+      return;
+    }
+    // We own this gesture now — stop the page from scrolling underneath it.
+    e.preventDefault();
+    const touch = e.touches[0];
+    const dy = active.startY - touch.clientY;
+    active.maxMove = Math.max(active.maxMove, Math.abs(dy));
+    // Sub-pixel jitter isn't a zoom. Skipping it also keeps a plain double-tap
+    // (all dy≈0) from emitting an explicit-range relayout that would otherwise
+    // race the autorange reset issued on touchend.
+    if (Math.abs(dy) < 2) return;
+    const scale = clamp(Math.pow(2, -dy / ZOOM_SENSITIVITY), MIN_SCALE, MAX_SCALE);
+
+    const update: Record<string, [number | string, number | string]> = {};
+    for (const a of active.axes) {
+      const lo = a.anchor - (a.anchor - a.base0) * scale;
+      const hi = a.anchor + (a.base1 - a.anchor) * scale;
+      update[`${a.key}.range`] = [a.ax.l2r!(lo), a.ax.l2r!(hi)];
+    }
+    void Plotly.relayout(active.gd, update);
+  };
+
+  const onEnd = (e: TouchEvent) => {
+    if (e.touches.length === 0) endGesture();
+  };
+
+  const onStart = (e: TouchEvent) => {
+    if (active) return;
+    if (e.touches.length !== 1) {
+      clearPending();
+      return;
+    }
+    const touch = e.touches[0];
+    const target = e.target as Element | null;
+    const gd = (target?.closest?.(".js-plotly-plot") as PlotlyGraphDiv | null) ?? null;
+    if (!gd) {
+      clearPending();
+      return;
+    }
+    const now = performance.now();
+    const isDoubleTap =
+      pendingTime > 0 &&
+      gd === pendingGd &&
+      now - pendingTime < DOUBLE_TAP_MS &&
+      Math.hypot(touch.clientX - pendingX, touch.clientY - pendingY) < TAP_RADIUS;
+
+    if (!isDoubleTap) {
+      // First tap — remember it so the next tap can pair with it. Charts with no
+      // zoomable axes still record a tap, but begin-zoom below filters them out.
+      pendingTime = now;
+      pendingX = touch.clientX;
+      pendingY = touch.clientY;
+      pendingGd = gd;
+      return;
+    }
+    clearPending();
+
+    const fl = gd._fullLayout;
+    const rect = gd.getBoundingClientRect();
+    const axes: AxisState[] = [];
+    const xs = axisState(fl?.xaxis, "xaxis", rect, touch.clientX, false);
+    if (xs) axes.push(xs);
+    const ys = axisState(fl?.yaxis, "yaxis", rect, touch.clientY, true);
+    if (ys) axes.push(ys);
+    if (axes.length === 0) return; // pie / sankey / not ready — leave the tap alone
+
+    e.preventDefault();
+    active = { gd, axes, startY: touch.clientY, maxMove: 0 };
+    window.addEventListener("touchmove", onMove, { passive: false });
+    window.addEventListener("touchend", onEnd, { passive: false });
+    window.addEventListener("touchcancel", onEnd, { passive: false });
+  };
+
+  // Cancel a pending first tap if the finger actually drags (i.e. it was a
+  // scroll, not a tap). Passive — we never block scrolling here.
+  const onScrollCancel = (e: TouchEvent) => {
+    if (active || pendingTime === 0) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    if (Math.hypot(touch.clientX - pendingX, touch.clientY - pendingY) > MOVE_CANCEL) {
+      clearPending();
+    }
+  };
+
+  document.addEventListener("touchstart", onStart, { passive: false });
+  document.addEventListener("touchmove", onScrollCancel, { passive: true });
+
+  return () => {
+    document.removeEventListener("touchstart", onStart);
+    document.removeEventListener("touchmove", onScrollCancel);
+    endGesture();
+  };
+}

--- a/frontend/src/utils/chartTouchZoom.ts
+++ b/frontend/src/utils/chartTouchZoom.ts
@@ -1,24 +1,27 @@
 import Plotly from "plotly.js/dist/plotly";
+import i18n from "../i18n";
 
 /**
- * Touch "double-tap-then-drag" zoom for Plotly charts.
+ * Touch "double-tap to enter zoom mode" for Plotly charts.
  *
  * On touch devices the shared chart theme sets `dragmode: false` so a normal
- * one-finger drag scrolls the page instead of being hijacked into a Plotly zoom
- * box (see utils/plotlyLocale.ts). That trades away the ability to zoom a
- * figure at all. This module gives it back behind an explicit gesture, the same
- * one map apps use for one-finger zoom:
+ * one-finger swipe scrolls the page instead of being hijacked into a Plotly
+ * zoom box (see utils/plotlyLocale.ts). That trades away the ability to zoom a
+ * figure. This module gives it back behind an explicit gesture without
+ * reinventing the interaction:
  *
- *   tap once, then on the second tap keep the finger down and drag —
- *   drag up zooms in, drag down zooms out, centered on where you tapped.
+ *   Double-tap a chart → it enters Plotly's native zoom mode
+ *   (`dragmode: "zoom"`). Now a one-finger drag marks a rectangle and zooms
+ *   into it, exactly like Plotly on desktop. Double-tap again (inside) resets
+ *   to autorange — Plotly's own double-click behaviour. Touch anywhere outside
+ *   the chart leaves zoom mode; the page scrolls normally again.
  *
- * A plain double-tap (no drag) resets the figure to autorange. A single drag is
- * left untouched, so the page keeps scrolling.
+ * The zoom persists after lifting the finger because it's a native Plotly GUI
+ * interaction and `chartTheme.uirevision` keeps it across re-renders.
  *
- * It's installed once globally and works on every chart via event delegation
- * (`closest(".js-plotly-plot")`), so individual chart components need no wiring.
- * Pie / donut / Sankey charts have no cartesian axes and are skipped — the
- * gesture falls through to a normal tap/scroll there.
+ * Installed once globally and wired to every chart via event delegation
+ * (`closest(".js-plotly-plot")`), so chart components need no changes. Pie /
+ * donut / Sankey charts have no cartesian axes and never enter zoom mode.
  */
 
 /** ms between the two taps to count as a double-tap. */
@@ -27,80 +30,14 @@ const DOUBLE_TAP_MS = 300;
 const TAP_RADIUS = 30;
 /** px of movement on a pending first tap that reclassifies it as a scroll. */
 const MOVE_CANCEL = 12;
-/** px of vertical drag that halves / doubles the visible range. */
-const ZOOM_SENSITIVITY = 220;
-/** below this total drag the gesture is treated as a plain double-tap (reset). */
-const RESET_MOVE = 8;
-/** clamp the per-gesture zoom factor so a frantic drag can't invert the axes. */
-const MIN_SCALE = 1 / 40;
-const MAX_SCALE = 40;
-
-interface PlotlyAxis {
-  range?: [number | string, number | string];
-  _offset?: number;
-  _length?: number;
-  r2l?: (v: number | string) => number;
-  l2r?: (v: number) => number | string;
-}
 
 interface PlotlyGraphDiv extends HTMLElement {
-  _fullLayout?: { xaxis?: PlotlyAxis; yaxis?: PlotlyAxis };
+  _fullLayout?: { xaxis?: { range?: unknown }; dragmode?: unknown };
 }
 
-/** A cartesian axis we can zoom needs a 2-point range and the lin/range maps. */
-function zoomableAxis(ax: PlotlyAxis | undefined): ax is Required<
-  Pick<PlotlyAxis, "range" | "r2l" | "l2r">
-> &
-  PlotlyAxis {
-  return (
-    !!ax &&
-    Array.isArray(ax.range) &&
-    ax.range.length === 2 &&
-    typeof ax.r2l === "function" &&
-    typeof ax.l2r === "function"
-  );
-}
-
-function clamp(v: number, lo: number, hi: number): number {
-  return Math.min(hi, Math.max(lo, v));
-}
-
-interface AxisState {
-  ax: PlotlyAxis;
-  key: "xaxis" | "yaxis";
-  /** range endpoints in linear space, captured at gesture start. */
-  base0: number;
-  base1: number;
-  /** the tapped point in linear space — the zoom stays anchored here. */
-  anchor: number;
-}
-
-interface ActiveGesture {
-  gd: PlotlyGraphDiv;
-  axes: AxisState[];
-  startY: number;
-  maxMove: number;
-}
-
-/** Build the per-axis zoom state, anchored at the second tap's pixel position. */
-function axisState(
-  ax: PlotlyAxis | undefined,
-  key: "xaxis" | "yaxis",
-  gdRect: DOMRect,
-  clientPx: number,
-  /** y axes grow upward in data but downward in pixels — flip the fraction. */
-  invert: boolean,
-): AxisState | null {
-  if (!zoomableAxis(ax)) return null;
-  const base0 = ax.r2l(ax.range[0]);
-  const base1 = ax.r2l(ax.range[1]);
-  const offset = ax._offset ?? 0;
-  const length = ax._length ?? 1;
-  const start = (key === "xaxis" ? gdRect.left : gdRect.top) + offset;
-  let frac = clamp((clientPx - start) / length, 0, 1);
-  if (invert) frac = 1 - frac;
-  const anchor = base0 + frac * (base1 - base0);
-  return { ax, key, base0, base1, anchor };
+/** Only cartesian charts (with an x-axis range) can be zoomed. */
+function isCartesian(gd: PlotlyGraphDiv): boolean {
+  return Array.isArray(gd._fullLayout?.xaxis?.range);
 }
 
 export function installChartTouchZoom(): () => void {
@@ -108,76 +45,64 @@ export function installChartTouchZoom(): () => void {
   let pendingX = 0;
   let pendingY = 0;
   let pendingGd: PlotlyGraphDiv | null = null;
-  let active: ActiveGesture | null = null;
+  let zoomGd: PlotlyGraphDiv | null = null;
+  let hint: HTMLDivElement | null = null;
 
   const clearPending = () => {
     pendingTime = 0;
     pendingGd = null;
   };
 
-  const endGesture = () => {
-    if (!active) return;
-    const { gd, axes, maxMove } = active;
-    // A double-tap with (almost) no drag means "reset" — restore autorange.
-    // The range must be nulled alongside autorange; setting autorange alone
-    // leaves the explicit zoomed range in place on these charts.
-    if (maxMove < RESET_MOVE) {
-      const reset: Record<string, null | true> = {};
-      for (const a of axes) {
-        reset[`${a.key}.range`] = null;
-        reset[`${a.key}.autorange`] = true;
-      }
-      void Plotly.relayout(gd, reset);
-    }
-    active = null;
-    window.removeEventListener("touchmove", onMove);
-    window.removeEventListener("touchend", onEnd);
-    window.removeEventListener("touchcancel", onEnd);
+  const showHint = (gd: PlotlyGraphDiv) => {
+    hint = document.createElement("div");
+    hint.className = "chart-zoom-hint";
+    hint.dir = document.documentElement.dir || "ltr";
+    hint.textContent = i18n.t("charts.zoomHint");
+    if (getComputedStyle(gd).position === "static") gd.style.position = "relative";
+    gd.appendChild(hint);
   };
 
-  const onMove = (e: TouchEvent) => {
-    if (!active) return;
-    if (e.touches.length !== 1) {
-      endGesture();
-      return;
-    }
-    // We own this gesture now — stop the page from scrolling underneath it.
-    e.preventDefault();
-    const touch = e.touches[0];
-    const dy = active.startY - touch.clientY;
-    active.maxMove = Math.max(active.maxMove, Math.abs(dy));
-    // Sub-pixel jitter isn't a zoom. Skipping it also keeps a plain double-tap
-    // (all dy≈0) from emitting an explicit-range relayout that would otherwise
-    // race the autorange reset issued on touchend.
-    if (Math.abs(dy) < 2) return;
-    const scale = clamp(Math.pow(2, -dy / ZOOM_SENSITIVITY), MIN_SCALE, MAX_SCALE);
-
-    const update: Record<string, [number | string, number | string]> = {};
-    for (const a of active.axes) {
-      const lo = a.anchor - (a.anchor - a.base0) * scale;
-      const hi = a.anchor + (a.base1 - a.anchor) * scale;
-      update[`${a.key}.range`] = [a.ax.l2r!(lo), a.ax.l2r!(hi)];
-    }
-    void Plotly.relayout(active.gd, update);
+  const enterZoom = (gd: PlotlyGraphDiv) => {
+    zoomGd = gd;
+    gd.classList.add("chart-zoom-active");
+    showHint(gd);
+    void Plotly.relayout(gd, { dragmode: "zoom" });
   };
 
-  const onEnd = (e: TouchEvent) => {
-    if (e.touches.length === 0) endGesture();
+  const exitZoom = () => {
+    if (!zoomGd) return;
+    const gd = zoomGd;
+    zoomGd = null;
+    gd.classList.remove("chart-zoom-active");
+    hint?.remove();
+    hint = null;
+    // Drop back to scroll mode; the zoom itself stays (uirevision preserves it).
+    void Plotly.relayout(gd, { dragmode: false });
   };
 
   const onStart = (e: TouchEvent) => {
-    if (active) return;
-    if (e.touches.length !== 1) {
-      clearPending();
-      return;
-    }
-    const touch = e.touches[0];
     const target = e.target as Element | null;
     const gd = (target?.closest?.(".js-plotly-plot") as PlotlyGraphDiv | null) ?? null;
-    if (!gd) {
+
+    if (zoomGd) {
+      // Inside the active chart: let Plotly handle the drag (zoom box) and a
+      // double-tap (its native reset). Re-assert dragmode in case a re-render
+      // reset it back to the themed default.
+      if (gd === zoomGd) {
+        if (gd._fullLayout?.dragmode !== "zoom") void Plotly.relayout(gd, { dragmode: "zoom" });
+        return;
+      }
+      // Touched elsewhere → leave zoom mode, then fall through so this touch is
+      // handled normally (scroll, or arming a double-tap on another chart).
+      exitZoom();
+    }
+
+    if (e.touches.length !== 1 || !gd || !isCartesian(gd)) {
       clearPending();
       return;
     }
+
+    const touch = e.touches[0];
     const now = performance.now();
     const isDoubleTap =
       pendingTime > 0 &&
@@ -185,37 +110,21 @@ export function installChartTouchZoom(): () => void {
       now - pendingTime < DOUBLE_TAP_MS &&
       Math.hypot(touch.clientX - pendingX, touch.clientY - pendingY) < TAP_RADIUS;
 
-    if (!isDoubleTap) {
-      // First tap — remember it so the next tap can pair with it. Charts with no
-      // zoomable axes still record a tap, but begin-zoom below filters them out.
-      pendingTime = now;
-      pendingX = touch.clientX;
-      pendingY = touch.clientY;
-      pendingGd = gd;
+    if (isDoubleTap) {
+      clearPending();
+      enterZoom(gd);
       return;
     }
-    clearPending();
-
-    const fl = gd._fullLayout;
-    const rect = gd.getBoundingClientRect();
-    const axes: AxisState[] = [];
-    const xs = axisState(fl?.xaxis, "xaxis", rect, touch.clientX, false);
-    if (xs) axes.push(xs);
-    const ys = axisState(fl?.yaxis, "yaxis", rect, touch.clientY, true);
-    if (ys) axes.push(ys);
-    if (axes.length === 0) return; // pie / sankey / not ready — leave the tap alone
-
-    e.preventDefault();
-    active = { gd, axes, startY: touch.clientY, maxMove: 0 };
-    window.addEventListener("touchmove", onMove, { passive: false });
-    window.addEventListener("touchend", onEnd, { passive: false });
-    window.addEventListener("touchcancel", onEnd, { passive: false });
+    pendingTime = now;
+    pendingX = touch.clientX;
+    pendingY = touch.clientY;
+    pendingGd = gd;
   };
 
   // Cancel a pending first tap if the finger actually drags (i.e. it was a
-  // scroll, not a tap). Passive — we never block scrolling here.
+  // scroll, not a tap) so a later tap can't pair into a false double-tap.
   const onScrollCancel = (e: TouchEvent) => {
-    if (active || pendingTime === 0) return;
+    if (zoomGd || pendingTime === 0) return;
     const touch = e.touches[0];
     if (!touch) return;
     if (Math.hypot(touch.clientX - pendingX, touch.clientY - pendingY) > MOVE_CANCEL) {
@@ -223,12 +132,12 @@ export function installChartTouchZoom(): () => void {
     }
   };
 
-  document.addEventListener("touchstart", onStart, { passive: false });
+  document.addEventListener("touchstart", onStart, { passive: true });
   document.addEventListener("touchmove", onScrollCancel, { passive: true });
 
   return () => {
     document.removeEventListener("touchstart", onStart);
     document.removeEventListener("touchmove", onScrollCancel);
-    endGesture();
+    exitZoom();
   };
 }

--- a/frontend/src/utils/plotlyLocale.ts
+++ b/frontend/src/utils/plotlyLocale.ts
@@ -156,9 +156,11 @@ export const chartTheme: Partial<Plotly.Layout> = {
   },
   hovermode: isTouchDevice ? "closest" : "x unified",
   // On touch devices Plotly's default `dragmode: "zoom"` hijacks a single-finger
-  // gesture to draw a zoom box, so dragging over a chart zooms it instead of
-  // scrolling the page. Disabling drag lets the touch fall through to page
-  // scroll; tapping still shows the hover tooltip. Desktop keeps drag-to-zoom.
+  // swipe to draw a zoom box, so dragging over a chart zooms it instead of
+  // scrolling the page. Disabling drag lets a plain swipe fall through to page
+  // scroll; figure zoom is instead offered behind an explicit double-tap-then-
+  // drag gesture (utils/chartTouchZoom.ts). Tapping still shows the hover
+  // tooltip. Desktop keeps drag-to-zoom.
   dragmode: isTouchDevice ? false : "zoom",
   legend: { orientation: "h", y: -0.18, x: 0.5, xanchor: "center", font: { size: 11 }, itemwidth: 30 },
   xaxis: {

--- a/frontend/src/utils/plotlyLocale.ts
+++ b/frontend/src/utils/plotlyLocale.ts
@@ -145,6 +145,11 @@ export function donutMarker(
 export const chartTheme: Partial<Plotly.Layout> = {
   paper_bgcolor: "rgba(0,0,0,0)",
   plot_bgcolor: "rgba(0,0,0,0)",
+  // Keep user-driven zoom/pan across re-renders. react-plotly re-runs
+  // Plotly.react on every parent render (e.g. React Query refetch); without a
+  // constant uirevision that would reset a zoom the user made on touch back to
+  // autorange. The value just has to stay constant — see utils/chartTouchZoom.ts.
+  uirevision: "persist",
   font: { color: "#94a3b8", family: "Inter, sans-serif", size: 12 },
   colorway: CHART_COLORS,
   margin: { t: 24, b: 36, l: 48, r: 16 },

--- a/frontend/src/utils/plotlyLocale.ts
+++ b/frontend/src/utils/plotlyLocale.ts
@@ -155,6 +155,11 @@ export const chartTheme: Partial<Plotly.Layout> = {
     namelength: -1,
   },
   hovermode: isTouchDevice ? "closest" : "x unified",
+  // On touch devices Plotly's default `dragmode: "zoom"` hijacks a single-finger
+  // gesture to draw a zoom box, so dragging over a chart zooms it instead of
+  // scrolling the page. Disabling drag lets the touch fall through to page
+  // scroll; tapping still shows the hover tooltip. Desktop keeps drag-to-zoom.
+  dragmode: isTouchDevice ? false : "zoom",
   legend: { orientation: "h", y: -0.18, x: 0.5, xanchor: "center", font: { size: 11 }, itemwidth: 30 },
   xaxis: {
     showspikes: false,
@@ -185,6 +190,8 @@ export function plotlyConfig(
     locale: i18n.language,
     locales: { he: heLocale },
     doubleClick: "reset+autosize",
+    // Keep pinch / wheel from zooming the chart instead of scrolling the page.
+    scrollZoom: false,
     ...extra,
   };
 }


### PR DESCRIPTION
## Problem

On touch devices, Plotly's default `dragmode: "zoom"` treats a single-finger
drag over a chart as a zoom-box gesture. Scrolling the page while a finger
passed over a figure zoomed the chart instead of scrolling — the figure
"entered zoom mode" and interrupted the scroll.

## Solution

1. **Stop the scroll hijack.** On touch devices `chartTheme` sets
   `dragmode: false` and `plotlyConfig()` sets `scrollZoom: false`, so a plain
   one-finger swipe scrolls the page. Tap still shows the hover tooltip.
   Desktop keeps native drag-to-zoom.

2. **Restore zoom using Plotly's *native* interaction, behind a gesture.**
   **Double-tap a chart** → it enters Plotly's native zoom mode
   (`dragmode: "zoom"`). A one-finger drag then **marks a rectangle and zooms
   into it**, exactly like Plotly on desktop. **Double-tap again** resets
   (Plotly's native double-click); **touching outside** the chart leaves zoom
   mode and the page scrolls normally again. A ring + hint pill show while zoom
   mode is active.

3. **Persist the zoom after lifting the finger.** Added a constant
   `chartTheme.uirevision`. react-plotly re-runs `Plotly.react` on every parent
   render (e.g. a React Query refetch), which otherwise reset the zoom back to
   autorange; `uirevision` keeps the user's native zoom/pan across re-renders.

## How it's built

- **`frontend/src/utils/chartTouchZoom.ts`** — a single globally-installed,
  event-delegated touch handler. It finds the chart under the finger via
  `closest(".js-plotly-plot")`, so **every** Plotly chart gets the gesture with
  zero per-chart wiring. Mode toggling is done with `Plotly.relayout`, reusing
  the exact bundle `react-plotly.js` already loads (`plotly.js/dist/plotly`) so
  no second Plotly is bundled. Pie/donut/Sankey (no cartesian axes) never enter
  zoom mode.
- **`App.tsx`** installs it in a `useEffect`, **touch devices only**.
- Build confirms no bloat: main bundle ~5.9 MB, precache 6.3 MiB (under the
  10 MiB Workbox limit).
- New `charts.zoomHint` i18n key in both `en.json` and `he.json`; ring + pill
  styles in `index.css`.

## Verification

- `tsc`, ESLint, `npm run build`, and **189 vitest** unit tests — all green.
- Browser probes confirmed the two load-bearing behaviours before building:
  native synthetic touch-drag zooms the figure, and a constant `uirevision`
  preserves that native zoom across `Plotly.react` (a code-driven relayout is
  *not* preserved — only GUI interactions are, which is why we use native zoom).
- **e2e** under `hasTouch` emulation, dispatching real `TouchEvent`s
  (`chart-touch-zoom.spec.ts`):
  - double-tap enters zoom mode (`dragmode === "zoom"`, ring shown); native
    drag shrinks the x-range; zoom **persists** across a re-render.
  - touching outside exits zoom mode (`dragmode === false`, ring removed).
  - `chart-touch-scroll.spec.ts` (dragmode default per device) and
    `chart-styling.spec.ts` still pass — 7/7 total.

https://claude.ai/code/session_01WgBTbvRDyPjTYAn1kj8L8G