### PR TITLE
Add budget data freshness badge, banner, and stale-KPI treatment

### DIFF
--- a/frontend/e2e/budget-freshness.spec.ts
+++ b/frontend/e2e/budget-freshness.spec.ts
@@ -78,9 +78,11 @@ test.describe("Budget data freshness", () => {
     await navigateTo(page, "/budget");
     await page.waitForLoadState("networkidle");
 
-    // The chip is the only freshness element for mild staleness.
+    // The chip is the only freshness element for mild staleness, and it names
+    // the un-scraped window rather than a vague "N ago".
     const badge = page.getByRole("button", { name: /Show sync details/i });
     await expect(badge).toBeVisible({ timeout: 30_000 });
+    await expect(badge).toContainText(/Missing/i);
     await expect(page.getByText(/Budget may be incomplete/i)).toHaveCount(0);
 
     // Popover names the account and links to Data Sources.

--- a/frontend/e2e/budget-freshness.spec.ts
+++ b/frontend/e2e/budget-freshness.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect, type Page } from "@playwright/test";
+import { disableDemoMode, navigateTo } from "./helpers";
+
+/**
+ * The budget data-freshness UX: a "last synced" badge, a stale-KPI
+ * treatment, and a very-stale sync banner, all driven by the *oldest*
+ * successful scrape across accounts (the weakest link).
+ *
+ * Freshness is intentionally suppressed in Demo Mode (scrape recency is
+ * meaningless there), so these tests run with Demo Mode OFF and stub the
+ * `/scraping/last-scrapes` endpoint to place the data at a chosen age.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgoIso = (days: number) => new Date(Date.now() - days * DAY_MS).toISOString();
+
+async function mockLastScrapes(
+  page: Page,
+  accounts: { provider: string; account_name: string; last_scrape_date: string | null }[],
+) {
+  await page.route("**/scraping/last-scrapes", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        accounts.map((a) => ({
+          service: "banks",
+          provider: a.provider,
+          account_name: a.account_name,
+          last_scrape_date: a.last_scrape_date,
+        })),
+      ),
+    });
+  });
+}
+
+test.describe("Budget data freshness", () => {
+  test.beforeAll(async () => {
+    // Freshness only renders outside Demo Mode.
+    await disableDemoMode();
+  });
+
+  test("very-stale sync shows the badge and the incomplete-budget banner", async ({
+    page,
+  }) => {
+    await mockLastScrapes(page, [
+      { provider: "hapoalim", account_name: "Checking", last_scrape_date: daysAgoIso(10) },
+    ]);
+    await navigateTo(page, "/budget");
+    await page.waitForLoadState("networkidle");
+
+    // Badge surfaces a relative "Updated …" label.
+    const badge = page.getByRole("button", { name: /Show sync details/i });
+    await expect(badge).toBeVisible({ timeout: 30_000 });
+    await expect(badge).toContainText(/Updated/i);
+
+    // Very-stale escalates to the amber banner with a Sync now CTA.
+    await expect(page.getByText(/Budget may be incomplete/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /Sync now/i }).first()).toBeVisible();
+  });
+
+  test("badge popover names the stale account and links to Data Sources", async ({
+    page,
+  }) => {
+    await mockLastScrapes(page, [
+      { provider: "hapoalim", account_name: "Checking", last_scrape_date: daysAgoIso(8) },
+    ]);
+    await navigateTo(page, "/budget");
+    await page.waitForLoadState("networkidle");
+
+    const badge = page.getByRole("button", { name: /Show sync details/i });
+    await expect(badge).toBeVisible({ timeout: 30_000 });
+    await badge.click();
+
+    // Popover lists the offending account and offers a sync link.
+    await expect(page.getByText(/Out-of-date sources/i)).toBeVisible();
+    await expect(page.getByText(/Checking/i).first()).toBeVisible();
+    const syncLink = page.getByRole("link", { name: /Sync now/i }).first();
+    await expect(syncLink).toHaveAttribute("href", "/data-sources");
+  });
+
+  test("fresh sync shows an up-to-date badge and no banner", async ({ page }) => {
+    await mockLastScrapes(page, [
+      { provider: "hapoalim", account_name: "Checking", last_scrape_date: daysAgoIso(0) },
+    ]);
+    await navigateTo(page, "/budget");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByText(/Up to date/i)).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(/Budget may be incomplete/i)).toHaveCount(0);
+  });
+
+  test("the banner can be dismissed", async ({ page }) => {
+    await mockLastScrapes(page, [
+      { provider: "hapoalim", account_name: "Checking", last_scrape_date: null },
+    ]);
+    await navigateTo(page, "/budget");
+    await page.waitForLoadState("networkidle");
+
+    const banner = page.getByText(/Budget may be incomplete/i);
+    await expect(banner).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole("button", { name: /Dismiss/i }).first().click();
+    await expect(banner).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/budget-freshness.spec.ts
+++ b/frontend/e2e/budget-freshness.spec.ts
@@ -144,22 +144,35 @@ test.describe("Budget data freshness", () => {
     // current one) could still be missing transactions; two months ago cannot.
     const now = new Date();
     const prevMonthFirst = new Date(now.getFullYear(), now.getMonth() - 1, 1, 12).toISOString();
+    const curMonthShort = now.toLocaleString("en-US", { month: "short" });
+    const prevMonthShort = new Date(now.getFullYear(), now.getMonth() - 1, 1).toLocaleString(
+      "en-US",
+      { month: "short" },
+    );
     await mockLastScrapes(page, [
       { provider: "hapoalim", account_name: "Checking", last_scrape_date: prevMonthFirst },
     ]);
     await navigateTo(page, "/budget");
     await page.waitForLoadState("networkidle");
 
-    const banner = page.getByText(/Budget may be incomplete/i);
+    const banner = page.locator("div", { hasText: /Budget may be incomplete/i }).last();
     await expect(banner).toBeVisible({ timeout: 30_000 }); // current month
+    // Current-month view clamps to the current month only.
+    await expect(banner).toContainText(curMonthShort);
 
     const prev = page.getByRole("button", { name: /Previous/i }).first();
     await prev.click();
     await page.waitForLoadState("networkidle");
     await expect(banner).toBeVisible(); // previous month — still affected
+    // The range is clamped to the previous month — it must not bleed into the
+    // current month.
+    await expect(banner).toContainText(prevMonthShort);
+    if (prevMonthShort !== curMonthShort) {
+      await expect(banner).not.toContainText(curMonthShort);
+    }
 
     await prev.click();
     await page.waitForLoadState("networkidle");
-    await expect(banner).toHaveCount(0); // two months ago — settled
+    await expect(page.getByText(/Budget may be incomplete/i)).toHaveCount(0); // settled
   });
 });

--- a/frontend/e2e/budget-freshness.spec.ts
+++ b/frontend/e2e/budget-freshness.spec.ts
@@ -104,6 +104,28 @@ test.describe("Budget data freshness", () => {
     await expect(page.getByText(/Budget may be incomplete/i)).toHaveCount(0);
   });
 
+  test("accounts sharing a window collapse into one row", async ({ page }) => {
+    // Three accounts with the same last scrape → identical missing window →
+    // a single grouped row listing all three, not three repeated ranges.
+    const sameDay = daysAgoIso(10);
+    await mockLastScrapes(page, [
+      { provider: "hapoalim", account_name: "Shir", last_scrape_date: sameDay },
+      { provider: "one_zero", account_name: "Tomer", last_scrape_date: sameDay },
+      { provider: "isracard", account_name: "Joint", last_scrape_date: sameDay },
+    ]);
+    await navigateTo(page, "/budget");
+    await page.waitForLoadState("networkidle");
+
+    const banner = page.locator("div", { hasText: /Budget may be incomplete/i }).last();
+    await expect(banner).toBeVisible({ timeout: 30_000 });
+
+    // One window row, all three accounts named within it.
+    await expect(banner.locator("li")).toHaveCount(1);
+    await expect(banner.locator("li")).toContainText(/Shir/);
+    await expect(banner.locator("li")).toContainText(/Tomer/);
+    await expect(banner.locator("li")).toContainText(/Joint/);
+  });
+
   test("the banner can be dismissed", async ({ page }) => {
     await mockLastScrapes(page, [
       { provider: "hapoalim", account_name: "Checking", last_scrape_date: null },

--- a/frontend/e2e/budget-freshness.spec.ts
+++ b/frontend/e2e/budget-freshness.spec.ts
@@ -2,13 +2,15 @@ import { test, expect, type Page } from "@playwright/test";
 import { disableDemoMode, navigateTo } from "./helpers";
 
 /**
- * The budget data-freshness UX: a "last synced" badge, a stale-KPI
- * treatment, and a very-stale sync banner, all driven by the *oldest*
+ * The budget data-freshness UX: an in-header "last synced" chip for mildly
+ * aging data, a stale-KPI treatment, and a banner (listing every behind
+ * account) for very-stale / never-synced data. Driven by the *oldest*
  * successful scrape across accounts (the weakest link).
  *
- * Freshness is intentionally suppressed in Demo Mode (scrape recency is
- * meaningless there), so these tests run with Demo Mode OFF and stub the
- * `/scraping/last-scrapes` endpoint to place the data at a chosen age.
+ * Freshness is suppressed in Demo Mode, so these run with Demo Mode OFF and
+ * stub `/scraping/last-scrapes` to place the data at a chosen age. The chip
+ * and the banner are mutually exclusive — mild ages get the chip, severe ages
+ * get the banner, never both.
  */
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -40,46 +42,51 @@ test.describe("Budget data freshness", () => {
     await disableDemoMode();
   });
 
-  test("very-stale sync shows the badge and the incomplete-budget banner", async ({
+  test("very-stale shows the banner with every behind account and no chip", async ({
     page,
   }) => {
     await mockLastScrapes(page, [
       { provider: "hapoalim", account_name: "Checking", last_scrape_date: daysAgoIso(10) },
+      { provider: "leumi", account_name: "Savings", last_scrape_date: daysAgoIso(12) },
     ]);
     await navigateTo(page, "/budget");
     await page.waitForLoadState("networkidle");
 
-    // Badge surfaces a relative "Updated …" label.
-    const badge = page.getByRole("button", { name: /Show sync details/i });
-    await expect(badge).toBeVisible({ timeout: 30_000 });
-    await expect(badge).toContainText(/Updated/i);
-
-    // Very-stale escalates to the amber banner with a Sync now CTA.
-    await expect(page.getByText(/Budget may be incomplete/i)).toBeVisible();
+    // Banner lists ALL out-of-sync accounts and offers a single Sync now CTA.
+    await expect(page.getByText(/Budget may be incomplete/i)).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByText(/Checking/i)).toBeVisible();
+    await expect(page.getByText(/Savings/i)).toBeVisible();
     await expect(page.getByRole("link", { name: /Sync now/i }).first()).toBeVisible();
+
+    // No redundant chip alongside the banner.
+    await expect(page.getByRole("button", { name: /Show sync details/i })).toHaveCount(0);
   });
 
-  test("badge popover names the stale account and links to Data Sources", async ({
+  test("mildly-stale shows an in-header chip with a details popover, no banner", async ({
     page,
   }) => {
     await mockLastScrapes(page, [
-      { provider: "hapoalim", account_name: "Checking", last_scrape_date: daysAgoIso(8) },
+      { provider: "hapoalim", account_name: "Checking", last_scrape_date: daysAgoIso(5) },
     ]);
     await navigateTo(page, "/budget");
     await page.waitForLoadState("networkidle");
 
+    // The chip is the only freshness element for mild staleness.
     const badge = page.getByRole("button", { name: /Show sync details/i });
     await expect(badge).toBeVisible({ timeout: 30_000 });
-    await badge.click();
+    await expect(page.getByText(/Budget may be incomplete/i)).toHaveCount(0);
 
-    // Popover lists the offending account and offers a sync link.
+    // Popover names the account and links to Data Sources.
+    await badge.click();
     await expect(page.getByText(/Out-of-date sources/i)).toBeVisible();
     await expect(page.getByText(/Checking/i).first()).toBeVisible();
     const syncLink = page.getByRole("link", { name: /Sync now/i }).first();
     await expect(syncLink).toHaveAttribute("href", "/data-sources");
   });
 
-  test("fresh sync shows an up-to-date badge and no banner", async ({ page }) => {
+  test("fresh sync shows an up-to-date chip and no banner", async ({ page }) => {
     await mockLastScrapes(page, [
       { provider: "hapoalim", account_name: "Checking", last_scrape_date: daysAgoIso(0) },
     ]);
@@ -102,5 +109,31 @@ test.describe("Budget data freshness", () => {
 
     await page.getByRole("button", { name: /Dismiss/i }).first().click();
     await expect(banner).toHaveCount(0);
+  });
+
+  test("staleness shows on affected past months but not fully-settled ones", async ({
+    page,
+  }) => {
+    // Sync at the first day of the previous month: the previous month (and the
+    // current one) could still be missing transactions; two months ago cannot.
+    const now = new Date();
+    const prevMonthFirst = new Date(now.getFullYear(), now.getMonth() - 1, 1, 12).toISOString();
+    await mockLastScrapes(page, [
+      { provider: "hapoalim", account_name: "Checking", last_scrape_date: prevMonthFirst },
+    ]);
+    await navigateTo(page, "/budget");
+    await page.waitForLoadState("networkidle");
+
+    const banner = page.getByText(/Budget may be incomplete/i);
+    await expect(banner).toBeVisible({ timeout: 30_000 }); // current month
+
+    const prev = page.getByRole("button", { name: /Previous/i }).first();
+    await prev.click();
+    await page.waitForLoadState("networkidle");
+    await expect(banner).toBeVisible(); // previous month — still affected
+
+    await prev.click();
+    await page.waitForLoadState("networkidle");
+    await expect(banner).toHaveCount(0); // two months ago — settled
   });
 });

--- a/frontend/e2e/budget-freshness.spec.ts
+++ b/frontend/e2e/budget-freshness.spec.ts
@@ -18,7 +18,12 @@ const daysAgoIso = (days: number) => new Date(Date.now() - days * DAY_MS).toISOS
 
 async function mockLastScrapes(
   page: Page,
-  accounts: { provider: string; account_name: string; last_scrape_date: string | null }[],
+  accounts: {
+    provider: string;
+    account_name: string;
+    last_scrape_date: string | null;
+    service?: string;
+  }[],
 ) {
   await page.route("**/scraping/last-scrapes", async (route) => {
     await route.fulfill({
@@ -26,7 +31,7 @@ async function mockLastScrapes(
       contentType: "application/json",
       body: JSON.stringify(
         accounts.map((a) => ({
-          service: "banks",
+          service: a.service ?? "banks",
           provider: a.provider,
           account_name: a.account_name,
           last_scrape_date: a.last_scrape_date,
@@ -109,6 +114,25 @@ test.describe("Budget data freshness", () => {
 
     await page.getByRole("button", { name: /Dismiss/i }).first().click();
     await expect(banner).toHaveCount(0);
+  });
+
+  test("a stale insurance sync does not flag the budget", async ({ page }) => {
+    // Insurance is scraped but unrelated to budget transactions — even a
+    // never-synced insurance account must not raise a freshness warning.
+    await mockLastScrapes(page, [
+      {
+        provider: "menora",
+        account_name: "Pension",
+        last_scrape_date: daysAgoIso(40),
+        service: "insurances",
+      },
+    ]);
+    await navigateTo(page, "/budget");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByText(/Budget may be incomplete/i)).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /Show sync details/i })).toHaveCount(0);
+    await expect(page.getByText(/Up to date/i)).toHaveCount(0);
   });
 
   test("staleness shows on affected past months but not fully-settled ones", async ({

--- a/frontend/src/components/budget/BudgetFreshnessBanner.tsx
+++ b/frontend/src/components/budget/BudgetFreshnessBanner.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { AlertTriangle, X, ArrowRight } from "lucide-react";
+import type { BudgetFreshness } from "../../hooks/useBudgetFreshness";
+import { humanizeProvider } from "../../utils/textFormatting";
+import { formatRelativeDate } from "../../utils/dateFormatting";
+
+interface BudgetFreshnessBannerProps {
+  freshness: BudgetFreshness;
+  isSyncing: boolean;
+  /** Only the current month gets the staleness nudge; history is settled. */
+  show: boolean;
+}
+
+/**
+ * Amber nudge shown when the budget's weakest-link sync is very stale (≥ 7
+ * days) or an account has never synced — i.e. the KPI figures are materially
+ * incomplete. Dismissible for the session; re-appears if the staleness state
+ * changes. Always mounted (visibility is internal) so the dismissal survives
+ * month navigation.
+ */
+export const BudgetFreshnessBanner: React.FC<BudgetFreshnessBannerProps> = ({
+  freshness,
+  isSyncing,
+  show,
+}) => {
+  const { t } = useTranslation();
+  const [dismissedKey, setDismissedKey] = useState<string | null>(null);
+
+  const { tier, staleAccounts, oldestSyncDate } = freshness;
+  const isSevere = tier === "veryStale" || tier === "never";
+  const dismissKey = `${tier}:${oldestSyncDate ?? "never"}`;
+
+  if (!show || isSyncing || !isSevere || dismissedKey === dismissKey) {
+    return null;
+  }
+
+  const worst = staleAccounts[0];
+  const worstLabel = worst
+    ? `${humanizeProvider(worst.provider)} · ${worst.accountName}`
+    : "";
+  const message =
+    tier === "never"
+      ? t("budget.freshness.bannerNeverSynced", { account: worstLabel })
+      : t("budget.freshness.bannerStale", {
+          account: worstLabel,
+          time: oldestSyncDate ? formatRelativeDate(oldestSyncDate) : "",
+        });
+
+  return (
+    <div className="flex items-start justify-between gap-3 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-3 rounded-xl text-sm font-medium">
+      <div className="flex items-start gap-2 min-w-0">
+        <AlertTriangle size={18} className="shrink-0 mt-0.5" />
+        <div className="min-w-0">
+          <p dir="auto">{message}</p>
+          <Link
+            to="/data-sources"
+            className="inline-flex items-center gap-1.5 mt-1 text-xs font-semibold hover:underline"
+          >
+            {t("budget.freshness.syncNow")}
+            <ArrowRight size={13} className="shrink-0 rtl:rotate-180" />
+          </Link>
+        </div>
+      </div>
+      <button
+        onClick={() => setDismissedKey(dismissKey)}
+        aria-label={t("common.dismiss")}
+        className="shrink-0 text-amber-400/60 hover:text-amber-400 transition-colors"
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/components/budget/BudgetFreshnessBanner.tsx
+++ b/frontend/src/components/budget/BudgetFreshnessBanner.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { AlertTriangle, X, ArrowRight } from "lucide-react";
 import type { BudgetFreshness } from "../../hooks/useBudgetFreshness";
 import { humanizeProvider } from "../../utils/textFormatting";
-import { formatRelativeDate } from "../../utils/dateFormatting";
+import { formatMissingRange } from "../../utils/dateFormatting";
 
 interface BudgetFreshnessBannerProps {
   freshness: BudgetFreshness;
@@ -53,11 +53,13 @@ export const BudgetFreshnessBanner: React.FC<BudgetFreshnessBannerProps> = ({
                   <span className="opacity-60"> · </span>
                   <span dir="auto">{acc.accountName}</span>
                 </span>
-                <span className="shrink-0 opacity-60" dir="auto">
-                  —{" "}
+                <span
+                  className="shrink-0 opacity-60"
+                  dir={acc.lastScrapeDate ? "ltr" : "auto"}
+                >
                   {acc.lastScrapeDate
-                    ? formatRelativeDate(acc.lastScrapeDate)
-                    : t("budget.freshness.neverSynced")}
+                    ? `— ${formatMissingRange(acc.lastScrapeDate)}`
+                    : `— ${t("budget.freshness.neverSynced")}`}
                 </span>
               </li>
             ))}

--- a/frontend/src/components/budget/BudgetFreshnessBanner.tsx
+++ b/frontend/src/components/budget/BudgetFreshnessBanner.tsx
@@ -11,6 +11,9 @@ interface BudgetFreshnessBannerProps {
   isSyncing: boolean;
   /** Only the current month gets the staleness nudge; history is settled. */
   show: boolean;
+  /** Viewed month — missing ranges are clamped to it. */
+  year: number;
+  month: number;
 }
 
 /**
@@ -24,6 +27,8 @@ export const BudgetFreshnessBanner: React.FC<BudgetFreshnessBannerProps> = ({
   freshness,
   isSyncing,
   show,
+  year,
+  month,
 }) => {
   const { t } = useTranslation();
   const [dismissedKey, setDismissedKey] = useState<string | null>(null);
@@ -32,7 +37,18 @@ export const BudgetFreshnessBanner: React.FC<BudgetFreshnessBannerProps> = ({
   const isSevere = tier === "veryStale" || tier === "never";
   const dismissKey = `${tier}:${oldestSyncDate ?? "never"}`;
 
-  if (!show || isSyncing || !isSevere || dismissedKey === dismissKey) {
+  // Each account's missing window, clamped to the viewed month. Accounts fully
+  // covered for this month (synced after its end) drop out of the list.
+  const rows = staleAccounts
+    .map((acc) => ({
+      acc,
+      range: acc.lastScrapeDate
+        ? formatMissingRange(acc.lastScrapeDate, year, month)
+        : null,
+    }))
+    .filter(({ acc, range }) => acc.lastScrapeDate === null || range !== null);
+
+  if (!show || isSyncing || !isSevere || rows.length === 0 || dismissedKey === dismissKey) {
     return null;
   }
 
@@ -43,7 +59,7 @@ export const BudgetFreshnessBanner: React.FC<BudgetFreshnessBannerProps> = ({
         <div className="min-w-0">
           <p>{t("budget.freshness.bannerTitle")}</p>
           <ul className="mt-1.5 space-y-1">
-            {staleAccounts.map((acc) => (
+            {rows.map(({ acc, range }) => (
               <li
                 key={`${acc.provider}_${acc.accountName}`}
                 className="flex items-center gap-1.5 text-xs font-normal text-amber-400/90"
@@ -55,10 +71,10 @@ export const BudgetFreshnessBanner: React.FC<BudgetFreshnessBannerProps> = ({
                 </span>
                 <span
                   className="shrink-0 opacity-60"
-                  dir={acc.lastScrapeDate ? "ltr" : "auto"}
+                  dir={range ? "ltr" : "auto"}
                 >
-                  {acc.lastScrapeDate
-                    ? `— ${formatMissingRange(acc.lastScrapeDate)}`
+                  {range
+                    ? `— ${range}`
                     : `— ${t("budget.freshness.neverSynced")}`}
                 </span>
               </li>

--- a/frontend/src/components/budget/BudgetFreshnessBanner.tsx
+++ b/frontend/src/components/budget/BudgetFreshnessBanner.tsx
@@ -36,27 +36,35 @@ export const BudgetFreshnessBanner: React.FC<BudgetFreshnessBannerProps> = ({
     return null;
   }
 
-  const worst = staleAccounts[0];
-  const worstLabel = worst
-    ? `${humanizeProvider(worst.provider)} · ${worst.accountName}`
-    : "";
-  const message =
-    tier === "never"
-      ? t("budget.freshness.bannerNeverSynced", { account: worstLabel })
-      : t("budget.freshness.bannerStale", {
-          account: worstLabel,
-          time: oldestSyncDate ? formatRelativeDate(oldestSyncDate) : "",
-        });
-
   return (
     <div className="flex items-start justify-between gap-3 bg-amber-500/10 border border-amber-500/20 text-amber-400 px-4 py-3 rounded-xl text-sm font-medium">
       <div className="flex items-start gap-2 min-w-0">
         <AlertTriangle size={18} className="shrink-0 mt-0.5" />
         <div className="min-w-0">
-          <p dir="auto">{message}</p>
+          <p>{t("budget.freshness.bannerTitle")}</p>
+          <ul className="mt-1.5 space-y-1">
+            {staleAccounts.map((acc) => (
+              <li
+                key={`${acc.provider}_${acc.accountName}`}
+                className="flex items-center gap-1.5 text-xs font-normal text-amber-400/90"
+              >
+                <span className="truncate" dir="auto">
+                  {humanizeProvider(acc.provider)}
+                  <span className="opacity-60"> · </span>
+                  <span dir="auto">{acc.accountName}</span>
+                </span>
+                <span className="shrink-0 opacity-60" dir="auto">
+                  —{" "}
+                  {acc.lastScrapeDate
+                    ? formatRelativeDate(acc.lastScrapeDate)
+                    : t("budget.freshness.neverSynced")}
+                </span>
+              </li>
+            ))}
+          </ul>
           <Link
             to="/data-sources"
-            className="inline-flex items-center gap-1.5 mt-1 text-xs font-semibold hover:underline"
+            className="inline-flex items-center gap-1.5 mt-2 text-xs font-semibold hover:underline"
           >
             {t("budget.freshness.syncNow")}
             <ArrowRight size={13} className="shrink-0 rtl:rotate-180" />

--- a/frontend/src/components/budget/BudgetFreshnessBanner.tsx
+++ b/frontend/src/components/budget/BudgetFreshnessBanner.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { AlertTriangle, X, ArrowRight } from "lucide-react";
 import type { BudgetFreshness } from "../../hooks/useBudgetFreshness";
+import { groupStaleAccountsByMonth } from "../../hooks/useBudgetFreshness";
 import { humanizeProvider } from "../../utils/textFormatting";
-import { formatMissingRange } from "../../utils/dateFormatting";
 
 interface BudgetFreshnessBannerProps {
   freshness: BudgetFreshness;
@@ -37,18 +37,11 @@ export const BudgetFreshnessBanner: React.FC<BudgetFreshnessBannerProps> = ({
   const isSevere = tier === "veryStale" || tier === "never";
   const dismissKey = `${tier}:${oldestSyncDate ?? "never"}`;
 
-  // Each account's missing window, clamped to the viewed month. Accounts fully
-  // covered for this month (synced after its end) drop out of the list.
-  const rows = staleAccounts
-    .map((acc) => ({
-      acc,
-      range: acc.lastScrapeDate
-        ? formatMissingRange(acc.lastScrapeDate, year, month)
-        : null,
-    }))
-    .filter(({ acc, range }) => acc.lastScrapeDate === null || range !== null);
+  // Accounts sharing a missing window (clamped to the viewed month) collapse
+  // into one row, so a common window is shown once instead of per account.
+  const groups = groupStaleAccountsByMonth(staleAccounts, year, month);
 
-  if (!show || isSyncing || !isSevere || rows.length === 0 || dismissedKey === dismissKey) {
+  if (!show || isSyncing || !isSevere || groups.length === 0 || dismissedKey === dismissKey) {
     return null;
   }
 
@@ -58,24 +51,20 @@ export const BudgetFreshnessBanner: React.FC<BudgetFreshnessBannerProps> = ({
         <AlertTriangle size={18} className="shrink-0 mt-0.5" />
         <div className="min-w-0">
           <p>{t("budget.freshness.bannerTitle")}</p>
-          <ul className="mt-1.5 space-y-1">
-            {rows.map(({ acc, range }) => (
+          <ul className="mt-1.5 space-y-1.5">
+            {groups.map((group) => (
               <li
-                key={`${acc.provider}_${acc.accountName}`}
-                className="flex items-center gap-1.5 text-xs font-normal text-amber-400/90"
+                key={group.range ?? "__never__"}
+                className="text-xs font-normal text-amber-400/90"
               >
-                <span className="truncate" dir="auto">
-                  {humanizeProvider(acc.provider)}
-                  <span className="opacity-60"> · </span>
-                  <span dir="auto">{acc.accountName}</span>
+                <span className="font-medium" dir={group.range ? "ltr" : "auto"}>
+                  {group.range ?? t("budget.freshness.neverSynced")}
                 </span>
-                <span
-                  className="shrink-0 opacity-60"
-                  dir={range ? "ltr" : "auto"}
-                >
-                  {range
-                    ? `— ${range}`
-                    : `— ${t("budget.freshness.neverSynced")}`}
+                <span className="opacity-70" dir="auto">
+                  {" — "}
+                  {group.accounts
+                    .map((acc) => `${humanizeProvider(acc.provider)} · ${acc.accountName}`)
+                    .join(", ")}
                 </span>
               </li>
             ))}

--- a/frontend/src/components/budget/BudgetSummaryStrip.tsx
+++ b/frontend/src/components/budget/BudgetSummaryStrip.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { Clock } from "lucide-react";
 
 interface BudgetSummaryStripProps {
   onTrackCount: number;
@@ -7,6 +8,12 @@ interface BudgetSummaryStripProps {
   biggestOverspend?: { name: string; percentage: number };
   daysLeft: number;
   monthLabel: string;
+  /**
+   * When the underlying scrape data is stale, the figures are provisional —
+   * dim the values and flag the Budget Health tile so the numbers don't read
+   * as authoritative.
+   */
+  isStale?: boolean;
 }
 
 /**
@@ -20,16 +27,25 @@ export const BudgetSummaryStrip: React.FC<BudgetSummaryStripProps> = ({
   biggestOverspend,
   daysLeft,
   monthLabel,
+  isStale = false,
 }) => {
   const { t } = useTranslation();
+  const staleValue = isStale ? "opacity-60" : "";
 
   return (
     <div className="grid grid-cols-3 gap-2 md:gap-3">
       <div className="bg-[var(--surface)] rounded-xl p-3 border border-[var(--surface-light)]">
-        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] uppercase tracking-wide truncate">
-          {t("budget.budgetHealth")}
+        <p className="text-[10px] sm:text-xs text-[var(--text-muted)] uppercase tracking-wide truncate flex items-center gap-1">
+          <span className="truncate">{t("budget.budgetHealth")}</span>
+          {isStale && (
+            <Clock
+              size={11}
+              className="shrink-0 text-amber-400"
+              aria-label={t("budget.freshness.provisional")}
+            />
+          )}
         </p>
-        <div className="flex items-baseline gap-1 mt-1 flex-wrap">
+        <div className={`flex items-baseline gap-1 mt-1 flex-wrap ${staleValue}`}>
           <span className="text-lg md:text-xl font-bold text-emerald-400">
             {onTrackCount}
           </span>
@@ -55,16 +71,16 @@ export const BudgetSummaryStrip: React.FC<BudgetSummaryStripProps> = ({
           {t("budget.biggestOverspend")}
         </p>
         {biggestOverspend ? (
-          <>
+          <div className={staleValue}>
             <p className="text-sm md:text-base font-bold mt-1 text-rose-400 truncate" dir="auto">
               {biggestOverspend.name}
             </p>
             <p className="text-[10px] sm:text-xs text-[var(--text-muted)]" dir="ltr">
               {Math.round(biggestOverspend.percentage * 100)}%
             </p>
-          </>
+          </div>
         ) : (
-          <p className="text-sm md:text-base font-bold mt-1 text-emerald-400">
+          <p className={`text-sm md:text-base font-bold mt-1 text-emerald-400 ${staleValue}`}>
             {t("budget.allGood")}
           </p>
         )}

--- a/frontend/src/components/budget/DataFreshnessBadge.tsx
+++ b/frontend/src/components/budget/DataFreshnessBadge.tsx
@@ -17,6 +17,9 @@ interface DataFreshnessBadgeProps {
   oldestSyncDate: string | null;
   staleAccounts: StaleAccount[];
   isSyncing: boolean;
+  /** Viewed month — missing ranges are clamped to it. */
+  year: number;
+  month: number;
 }
 
 interface TierStyle {
@@ -37,6 +40,8 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
   oldestSyncDate,
   staleAccounts,
   isSyncing,
+  year,
+  month,
 }) => {
   const { t } = useTranslation();
   const [showDetails, setShowDetails] = useState(false);
@@ -100,13 +105,23 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
   ) : (
     <>
       <span>{t("budget.freshness.missingLabel")}</span>
-      {oldestSyncDate && <span dir="ltr">{formatMissingRange(oldestSyncDate)}</span>}
+      {oldestSyncDate && (
+        <span dir="ltr">{formatMissingRange(oldestSyncDate, year, month)}</span>
+      )}
     </>
+  );
+
+  // Accounts that are actually missing data within the viewed month (never
+  // synced, or with a non-empty clamped range for this month).
+  const monthStaleAccounts = staleAccounts.filter(
+    (acc) =>
+      acc.lastScrapeDate === null ||
+      formatMissingRange(acc.lastScrapeDate, year, month) !== null,
   );
 
   // Popover only carries weight when there are accounts to act on and we're
   // not mid-sync.
-  const hasDetails = !isSyncing && staleAccounts.length > 0;
+  const hasDetails = !isSyncing && monthStaleAccounts.length > 0;
 
   const chip = (
     <span
@@ -155,7 +170,7 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
               {t("budget.freshness.staleTitle")}
             </p>
             <ul className="space-y-1.5 mb-3">
-              {staleAccounts.map((acc) => (
+              {monthStaleAccounts.map((acc) => (
                 <li
                   key={`${acc.provider}_${acc.accountName}`}
                   className="flex items-center justify-between gap-2 text-xs"
@@ -170,7 +185,7 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
                     dir={acc.lastScrapeDate ? "ltr" : "auto"}
                   >
                     {acc.lastScrapeDate
-                      ? formatMissingRange(acc.lastScrapeDate)
+                      ? formatMissingRange(acc.lastScrapeDate, year, month)
                       : t("budget.freshness.neverSynced")}
                   </span>
                 </li>

--- a/frontend/src/components/budget/DataFreshnessBadge.tsx
+++ b/frontend/src/components/budget/DataFreshnessBadge.tsx
@@ -9,6 +9,7 @@ import {
   ArrowRight,
 } from "lucide-react";
 import type { FreshnessTier, StaleAccount } from "../../hooks/useBudgetFreshness";
+import { groupStaleAccountsByMonth } from "../../hooks/useBudgetFreshness";
 import { formatMissingRange } from "../../utils/dateFormatting";
 import { humanizeProvider } from "../../utils/textFormatting";
 
@@ -111,17 +112,12 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
     </>
   );
 
-  // Accounts that are actually missing data within the viewed month (never
-  // synced, or with a non-empty clamped range for this month).
-  const monthStaleAccounts = staleAccounts.filter(
-    (acc) =>
-      acc.lastScrapeDate === null ||
-      formatMissingRange(acc.lastScrapeDate, year, month) !== null,
-  );
+  // Accounts missing data within the viewed month, grouped by shared window.
+  const groups = groupStaleAccountsByMonth(staleAccounts, year, month);
 
   // Popover only carries weight when there are accounts to act on and we're
   // not mid-sync.
-  const hasDetails = !isSyncing && monthStaleAccounts.length > 0;
+  const hasDetails = !isSyncing && groups.length > 0;
 
   const chip = (
     <span
@@ -169,25 +165,20 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
             <p className="text-xs font-semibold text-[var(--text-default)] mb-2">
               {t("budget.freshness.staleTitle")}
             </p>
-            <ul className="space-y-1.5 mb-3">
-              {monthStaleAccounts.map((acc) => (
-                <li
-                  key={`${acc.provider}_${acc.accountName}`}
-                  className="flex items-center justify-between gap-2 text-xs"
-                >
-                  <span className="truncate text-[var(--text-default)]" dir="auto">
-                    {humanizeProvider(acc.provider)}
-                    <span className="text-[var(--text-muted)]"> · </span>
-                    <span dir="auto">{acc.accountName}</span>
-                  </span>
-                  <span
-                    className="shrink-0 text-[10px] text-[var(--text-muted)]"
-                    dir={acc.lastScrapeDate ? "ltr" : "auto"}
+            <ul className="space-y-2 mb-3">
+              {groups.map((group) => (
+                <li key={group.range ?? "__never__"} className="text-xs">
+                  <p
+                    className="font-medium text-[var(--text-default)]"
+                    dir={group.range ? "ltr" : "auto"}
                   >
-                    {acc.lastScrapeDate
-                      ? formatMissingRange(acc.lastScrapeDate, year, month)
-                      : t("budget.freshness.neverSynced")}
-                  </span>
+                    {group.range ?? t("budget.freshness.neverSynced")}
+                  </p>
+                  <p className="text-[10px] text-[var(--text-muted)]" dir="auto">
+                    {group.accounts
+                      .map((acc) => `${humanizeProvider(acc.provider)} · ${acc.accountName}`)
+                      .join(", ")}
+                  </p>
                 </li>
               ))}
             </ul>

--- a/frontend/src/components/budget/DataFreshnessBadge.tsx
+++ b/frontend/src/components/budget/DataFreshnessBadge.tsx
@@ -1,0 +1,178 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import {
+  CheckCircle2,
+  Clock,
+  AlertTriangle,
+  RefreshCw,
+  ArrowRight,
+} from "lucide-react";
+import type { FreshnessTier, StaleAccount } from "../../hooks/useBudgetFreshness";
+import { formatRelativeDate } from "../../utils/dateFormatting";
+import { humanizeProvider } from "../../utils/textFormatting";
+
+interface DataFreshnessBadgeProps {
+  tier: FreshnessTier;
+  oldestSyncDate: string | null;
+  staleAccounts: StaleAccount[];
+  isSyncing: boolean;
+}
+
+interface TierStyle {
+  icon: React.ReactNode;
+  chip: string;
+  text: string;
+}
+
+/**
+ * Compact "last synced" chip for the budget month view. Quiet when data is
+ * fresh; escalates color + iconography as the weakest-link sync ages, and
+ * exposes a tap/hover popover that names the stale accounts and links to
+ * Data Sources for a re-sync. Pure presentation — freshness is computed by
+ * `useBudgetFreshness`.
+ */
+export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
+  tier,
+  oldestSyncDate,
+  staleAccounts,
+  isSyncing,
+}) => {
+  const { t } = useTranslation();
+  const [showDetails, setShowDetails] = useState(false);
+
+  const styles: Record<FreshnessTier | "syncing", TierStyle> = {
+    syncing: {
+      icon: <RefreshCw size={13} className="animate-spin shrink-0" />,
+      chip: "bg-blue-500/10 border-blue-500/20 text-blue-400",
+      text: "text-blue-400",
+    },
+    fresh: {
+      icon: <CheckCircle2 size={13} className="shrink-0" />,
+      chip: "bg-emerald-500/10 border-emerald-500/20 text-emerald-400",
+      text: "text-emerald-400",
+    },
+    aging: {
+      icon: <Clock size={13} className="shrink-0" />,
+      chip: "bg-[var(--surface-light)]/40 border-[var(--surface-light)] text-[var(--text-muted)]",
+      text: "text-[var(--text-muted)]",
+    },
+    stale: {
+      icon: <Clock size={13} className="shrink-0" />,
+      chip: "bg-amber-500/10 border-amber-500/20 text-amber-400",
+      text: "text-amber-400",
+    },
+    veryStale: {
+      icon: <AlertTriangle size={13} className="shrink-0" />,
+      chip: "bg-rose-500/10 border-rose-500/20 text-rose-400",
+      text: "text-rose-400",
+    },
+    never: {
+      icon: <AlertTriangle size={13} className="shrink-0" />,
+      chip: "bg-rose-500/10 border-rose-500/20 text-rose-400",
+      text: "text-rose-400",
+    },
+    none: {
+      icon: null,
+      chip: "",
+      text: "",
+    },
+  };
+
+  if (tier === "none") return null;
+
+  const effectiveTier = isSyncing ? "syncing" : tier;
+  const style = styles[effectiveTier];
+
+  const label = (() => {
+    if (isSyncing) return t("budget.freshness.syncing");
+    if (tier === "fresh") return t("budget.freshness.upToDate");
+    if (tier === "never") return t("budget.freshness.neverSynced");
+    return t("budget.freshness.updated", {
+      time: oldestSyncDate ? formatRelativeDate(oldestSyncDate) : "",
+    });
+  })();
+
+  // Popover only carries weight when there are accounts to act on and we're
+  // not mid-sync.
+  const hasDetails = !isSyncing && staleAccounts.length > 0;
+
+  const chip = (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium ${style.chip} ${
+        hasDetails ? "cursor-pointer" : ""
+      }`}
+      onClick={hasDetails ? () => setShowDetails((v) => !v) : undefined}
+      role={hasDetails ? "button" : undefined}
+      tabIndex={hasDetails ? 0 : undefined}
+      onKeyDown={
+        hasDetails
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                setShowDetails((v) => !v);
+              }
+            }
+          : undefined
+      }
+      aria-label={hasDetails ? t("budget.freshness.showDetails") : undefined}
+    >
+      {style.icon}
+      <span dir="auto">{label}</span>
+    </span>
+  );
+
+  if (!hasDetails) {
+    return <div className="flex items-center">{chip}</div>;
+  }
+
+  return (
+    <div className="relative flex items-center">
+      {chip}
+      {showDetails && (
+        <>
+          {/* Click-away backdrop (works for touch + mouse). */}
+          <div
+            className="fixed inset-0 z-[19]"
+            onClick={() => setShowDetails(false)}
+          />
+          <div
+            className="absolute top-full mt-2 inset-inline-start-0 z-20 w-full max-w-[calc(100vw-2rem)] sm:w-72 rounded-xl border border-[var(--surface-light)] bg-[var(--surface)] p-3 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="text-xs font-semibold text-[var(--text-default)] mb-2">
+              {t("budget.freshness.staleTitle")}
+            </p>
+            <ul className="space-y-1.5 mb-3">
+              {staleAccounts.map((acc) => (
+                <li
+                  key={`${acc.provider}_${acc.accountName}`}
+                  className="flex items-center justify-between gap-2 text-xs"
+                >
+                  <span className="truncate text-[var(--text-default)]" dir="auto">
+                    {humanizeProvider(acc.provider)}
+                    <span className="text-[var(--text-muted)]"> · </span>
+                    <span dir="auto">{acc.accountName}</span>
+                  </span>
+                  <span className="shrink-0 text-[10px] text-[var(--text-muted)]" dir="auto">
+                    {acc.lastScrapeDate
+                      ? formatRelativeDate(acc.lastScrapeDate)
+                      : t("dataSources.neverSynced")}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <Link
+              to="/data-sources"
+              onClick={() => setShowDetails(false)}
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-[var(--primary)] hover:underline"
+            >
+              {t("budget.freshness.syncNow")}
+              <ArrowRight size={13} className="shrink-0 rtl:rotate-180" />
+            </Link>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/budget/DataFreshnessBadge.tsx
+++ b/frontend/src/components/budget/DataFreshnessBadge.tsx
@@ -81,6 +81,11 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
 
   if (tier === "none") return null;
 
+  // Very-stale / never escalate to the banner, which carries the full account
+  // list and the call to action. Don't also render a redundant chip — except
+  // while syncing, when the chip shows live progress and the banner is hidden.
+  if (!isSyncing && (tier === "veryStale" || tier === "never")) return null;
+
   const effectiveTier = isSyncing ? "syncing" : tier;
   const style = styles[effectiveTier];
 

--- a/frontend/src/components/budget/DataFreshnessBadge.tsx
+++ b/frontend/src/components/budget/DataFreshnessBadge.tsx
@@ -9,7 +9,7 @@ import {
   ArrowRight,
 } from "lucide-react";
 import type { FreshnessTier, StaleAccount } from "../../hooks/useBudgetFreshness";
-import { formatRelativeDate } from "../../utils/dateFormatting";
+import { formatMissingRange } from "../../utils/dateFormatting";
 import { humanizeProvider } from "../../utils/textFormatting";
 
 interface DataFreshnessBadgeProps {
@@ -89,14 +89,20 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
   const effectiveTier = isSyncing ? "syncing" : tier;
   const style = styles[effectiveTier];
 
-  const label = (() => {
-    if (isSyncing) return t("budget.freshness.syncing");
-    if (tier === "fresh") return t("budget.freshness.upToDate");
-    if (tier === "never") return t("budget.freshness.neverSynced");
-    return t("budget.freshness.updated", {
-      time: oldestSyncDate ? formatRelativeDate(oldestSyncDate) : "",
-    });
-  })();
+  // The range is LTR date content; keep it isolated from any surrounding RTL
+  // label so the month/day order survives in Hebrew.
+  const labelNode = isSyncing ? (
+    <span>{t("budget.freshness.syncing")}</span>
+  ) : tier === "fresh" ? (
+    <span>{t("budget.freshness.upToDate")}</span>
+  ) : tier === "never" ? (
+    <span>{t("budget.freshness.neverSynced")}</span>
+  ) : (
+    <>
+      <span>{t("budget.freshness.missingLabel")}</span>
+      {oldestSyncDate && <span dir="ltr">{formatMissingRange(oldestSyncDate)}</span>}
+    </>
+  );
 
   // Popover only carries weight when there are accounts to act on and we're
   // not mid-sync.
@@ -123,7 +129,7 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
       aria-label={hasDetails ? t("budget.freshness.showDetails") : undefined}
     >
       {style.icon}
-      <span dir="auto">{label}</span>
+      {labelNode}
     </span>
   );
 
@@ -159,10 +165,13 @@ export const DataFreshnessBadge: React.FC<DataFreshnessBadgeProps> = ({
                     <span className="text-[var(--text-muted)]"> · </span>
                     <span dir="auto">{acc.accountName}</span>
                   </span>
-                  <span className="shrink-0 text-[10px] text-[var(--text-muted)]" dir="auto">
+                  <span
+                    className="shrink-0 text-[10px] text-[var(--text-muted)]"
+                    dir={acc.lastScrapeDate ? "ltr" : "auto"}
+                  >
                     {acc.lastScrapeDate
-                      ? formatRelativeDate(acc.lastScrapeDate)
-                      : t("dataSources.neverSynced")}
+                      ? formatMissingRange(acc.lastScrapeDate)
+                      : t("budget.freshness.neverSynced")}
                   </span>
                 </li>
               ))}

--- a/frontend/src/components/budget/MonthHeader.tsx
+++ b/frontend/src/components/budget/MonthHeader.tsx
@@ -10,6 +10,8 @@ interface MonthHeaderProps {
   onNext: () => void;
   onToday: () => void;
   onAddRule: () => void;
+  /** Optional data-freshness chip rendered inline beside the month controls. */
+  freshnessBadge?: React.ReactNode;
 }
 
 /** Month navigation + add-rule control. */
@@ -20,6 +22,7 @@ export const MonthHeader: React.FC<MonthHeaderProps> = ({
   onNext,
   onToday,
   onAddRule,
+  freshnessBadge,
 }) => {
   const { t } = useTranslation();
   const isRtl = i18n.language === "he";
@@ -50,6 +53,7 @@ export const MonthHeader: React.FC<MonthHeaderProps> = ({
             {t("common.today")}
           </button>
         )}
+        {freshnessBadge && <div className="min-w-0">{freshnessBadge}</div>}
       </div>
 
       <button

--- a/frontend/src/components/budget/MonthlyBudgetView.tsx
+++ b/frontend/src/components/budget/MonthlyBudgetView.tsx
@@ -296,6 +296,8 @@ export const MonthlyBudgetView: React.FC<MonthlyBudgetViewProps> = ({
               oldestSyncDate={freshness.oldestSyncDate}
               staleAccounts={freshness.staleAccounts}
               isSyncing={isAnyScraping}
+              year={year}
+              month={month}
             />
           ) : undefined
         }
@@ -305,6 +307,8 @@ export const MonthlyBudgetView: React.FC<MonthlyBudgetViewProps> = ({
         freshness={freshness}
         isSyncing={isAnyScraping}
         show={showFreshness}
+        year={year}
+        month={month}
       />
 
       {copiedFromForThisMonth && (

--- a/frontend/src/components/budget/MonthlyBudgetView.tsx
+++ b/frontend/src/components/budget/MonthlyBudgetView.tsx
@@ -206,8 +206,20 @@ export const MonthlyBudgetView: React.FC<MonthlyBudgetViewProps> = ({
   const isCurrentMonth =
     year === today.getFullYear() && month === today.getMonth() + 1;
 
-  // Freshness only matters for the live month; historical months are settled.
-  const showFreshness = isCurrentMonth && freshness.hasScrapableAccounts;
+  // Freshness applies to the current month and any earlier month whose data
+  // could still be missing transactions — i.e. months ending on/after the
+  // oldest sync. Fully-settled history (before the last sync) stays clean.
+  // Future months and never-synced accounts only flag the live month.
+  const viewedIndex = year * 12 + (month - 1);
+  const currentIndex = today.getFullYear() * 12 + today.getMonth();
+  const monthEnd = new Date(year, month, 0, 23, 59, 59, 999).getTime();
+  const monthCouldBeIncomplete =
+    viewedIndex <= currentIndex &&
+    (isCurrentMonth ||
+      (freshness.oldestSyncDate !== null &&
+        monthEnd >= new Date(freshness.oldestSyncDate).getTime()));
+  const showFreshness =
+    freshness.hasScrapableAccounts && monthCouldBeIncomplete;
   const isBudgetStale =
     showFreshness &&
     !isAnyScraping &&
@@ -277,18 +289,17 @@ export const MonthlyBudgetView: React.FC<MonthlyBudgetViewProps> = ({
         onNext={handleNextMonth}
         onToday={handleCurrentMonth}
         onAddRule={openAddModal}
+        freshnessBadge={
+          showFreshness ? (
+            <DataFreshnessBadge
+              tier={freshness.tier}
+              oldestSyncDate={freshness.oldestSyncDate}
+              staleAccounts={freshness.staleAccounts}
+              isSyncing={isAnyScraping}
+            />
+          ) : undefined
+        }
       />
-
-      {showFreshness && (
-        <div className="flex justify-end -mt-1">
-          <DataFreshnessBadge
-            tier={freshness.tier}
-            oldestSyncDate={freshness.oldestSyncDate}
-            staleAccounts={freshness.staleAccounts}
-            isSyncing={isAnyScraping}
-          />
-        </div>
-      )}
 
       <BudgetFreshnessBanner
         freshness={freshness}

--- a/frontend/src/components/budget/MonthlyBudgetView.tsx
+++ b/frontend/src/components/budget/MonthlyBudgetView.tsx
@@ -16,6 +16,10 @@ import { useConfirm } from "../../context/DialogContext";
 import { MonthHeader } from "./MonthHeader";
 import { BudgetAlertsBanner } from "./BudgetAlertsBanner";
 import { BudgetSummaryStrip } from "./BudgetSummaryStrip";
+import { DataFreshnessBadge } from "./DataFreshnessBadge";
+import { BudgetFreshnessBanner } from "./BudgetFreshnessBanner";
+import { useBudgetFreshness } from "../../hooks/useBudgetFreshness";
+import { useScraping } from "../../hooks/useScraping";
 import { BudgetTrendChart } from "./BudgetTrendChart";
 import { BudgetRuleRow } from "./BudgetRuleRow";
 import { ProjectsThisMonthSummary } from "./ProjectsThisMonthSummary";
@@ -65,6 +69,8 @@ export const MonthlyBudgetView: React.FC<MonthlyBudgetViewProps> = ({
   );
 
   const queryClient = useQueryClient();
+  const freshness = useBudgetFreshness();
+  const { isAnyScraping } = useScraping();
 
   const { data: analysis, isLoading } = useQuery({
     queryKey: ["budgetAnalysis", year, month, includeSplitParents],
@@ -200,6 +206,15 @@ export const MonthlyBudgetView: React.FC<MonthlyBudgetViewProps> = ({
   const isCurrentMonth =
     year === today.getFullYear() && month === today.getMonth() + 1;
 
+  // Freshness only matters for the live month; historical months are settled.
+  const showFreshness = isCurrentMonth && freshness.hasScrapableAccounts;
+  const isBudgetStale =
+    showFreshness &&
+    !isAnyScraping &&
+    (freshness.tier === "stale" ||
+      freshness.tier === "veryStale" ||
+      freshness.tier === "never");
+
   if (isLoading)
     return (
       <div className="space-y-4 md:space-y-6">
@@ -264,6 +279,23 @@ export const MonthlyBudgetView: React.FC<MonthlyBudgetViewProps> = ({
         onAddRule={openAddModal}
       />
 
+      {showFreshness && (
+        <div className="flex justify-end -mt-1">
+          <DataFreshnessBadge
+            tier={freshness.tier}
+            oldestSyncDate={freshness.oldestSyncDate}
+            staleAccounts={freshness.staleAccounts}
+            isSyncing={isAnyScraping}
+          />
+        </div>
+      )}
+
+      <BudgetFreshnessBanner
+        freshness={freshness}
+        isSyncing={isAnyScraping}
+        show={showFreshness}
+      />
+
       {copiedFromForThisMonth && (
         <div className="flex items-start justify-between gap-3 bg-blue-500/10 border border-blue-500/20 text-blue-400 px-4 py-3 rounded-xl text-sm font-medium">
           <span>{t("budget.rulesCopiedFrom", { month: copiedFromForThisMonth })}</span>
@@ -289,6 +321,7 @@ export const MonthlyBudgetView: React.FC<MonthlyBudgetViewProps> = ({
             biggestOverspend={biggestOverspend}
             daysLeft={daysLeft}
             monthLabel={monthShortLabel}
+            isStale={isBudgetStale}
           />
           <BudgetTrendChart
             year={year}

--- a/frontend/src/hooks/useBudgetFreshness.ts
+++ b/frontend/src/hooks/useBudgetFreshness.ts
@@ -1,0 +1,122 @@
+import { useQuery } from "@tanstack/react-query";
+import { scrapingApi } from "../services/api";
+import { useDemoMode } from "../context/DemoModeContext";
+import { daysSince } from "../utils/dateFormatting";
+
+/**
+ * Freshness tiers, ordered worst-to-best in severity. Drives the budget
+ * data-freshness badge, the stale-KPI treatment, and the sync banner.
+ *
+ * - `none`      — no scrapable accounts exist (cash/manual-only user); hide UI
+ * - `fresh`     — newest weakest-link sync ≤ 1 day old
+ * - `aging`     — 2–3 days old
+ * - `stale`     — 4–6 days old
+ * - `veryStale` — ≥ 7 days old
+ * - `never`     — at least one account has never been synced
+ */
+export type FreshnessTier =
+  | "none"
+  | "fresh"
+  | "aging"
+  | "stale"
+  | "veryStale"
+  | "never";
+
+export interface StaleAccount {
+  service: string;
+  provider: string;
+  accountName: string;
+  /** ISO date of last successful scrape, or null if never synced. */
+  lastScrapeDate: string | null;
+}
+
+export interface BudgetFreshness {
+  tier: FreshnessTier;
+  /** ISO date of the oldest (weakest-link) sync; null when an account never synced. */
+  oldestSyncDate: string | null;
+  /** Accounts that are stale (≥ 4 days) or never synced — for the popover + banner. */
+  staleAccounts: StaleAccount[];
+  /** True when at least one scrapable account exists (badge should render). */
+  hasScrapableAccounts: boolean;
+  isLoading: boolean;
+}
+
+const STALE_THRESHOLD_DAYS = 4;
+const VERY_STALE_THRESHOLD_DAYS = 7;
+const AGING_THRESHOLD_DAYS = 2;
+
+/**
+ * Computes how current the budget's underlying transaction data is, based on
+ * the *oldest* successful scrape across all scrapable accounts (the weakest
+ * link). A single account that hasn't synced in a week makes the whole budget
+ * provisional, so we surface that rather than the most-recent sync.
+ *
+ * Demo mode short-circuits to `none` — scrape recency is meaningless there.
+ */
+export function useBudgetFreshness(): BudgetFreshness {
+  const { isDemoMode } = useDemoMode();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["last-scrapes", isDemoMode],
+    queryFn: () => scrapingApi.getLastScrapes().then((res) => res.data),
+    enabled: !isDemoMode,
+  });
+
+  if (isDemoMode || !data || data.length === 0) {
+    return {
+      tier: "none",
+      oldestSyncDate: null,
+      staleAccounts: [],
+      hasScrapableAccounts: false,
+      isLoading: isDemoMode ? false : isLoading,
+    };
+  }
+
+  const accounts: StaleAccount[] = data.map((s) => ({
+    service: s.service,
+    provider: s.provider,
+    accountName: s.account_name,
+    lastScrapeDate: s.last_scrape_date,
+  }));
+
+  const neverSynced = accounts.filter((a) => a.lastScrapeDate === null);
+  const synced = accounts.filter(
+    (a): a is StaleAccount & { lastScrapeDate: string } =>
+      a.lastScrapeDate !== null,
+  );
+
+  // Weakest link: the largest day-gap drives the tier. Never-synced accounts
+  // are infinitely stale and dominate.
+  let tier: FreshnessTier;
+  let oldestSyncDate: string | null;
+
+  if (neverSynced.length > 0) {
+    tier = "never";
+    oldestSyncDate = null;
+  } else {
+    // synced is guaranteed non-empty here (accounts.length > 0, none null).
+    const oldest = synced.reduce((acc, a) =>
+      daysSince(a.lastScrapeDate) > daysSince(acc.lastScrapeDate) ? a : acc,
+    );
+    oldestSyncDate = oldest.lastScrapeDate;
+    const worstDays = daysSince(oldest.lastScrapeDate);
+    if (worstDays >= VERY_STALE_THRESHOLD_DAYS) tier = "veryStale";
+    else if (worstDays >= STALE_THRESHOLD_DAYS) tier = "stale";
+    else if (worstDays >= AGING_THRESHOLD_DAYS) tier = "aging";
+    else tier = "fresh";
+  }
+
+  const staleAccounts = accounts.filter(
+    (a) =>
+      a.lastScrapeDate === null ||
+      daysSince(a.lastScrapeDate) >= STALE_THRESHOLD_DAYS,
+  );
+
+  return {
+    tier,
+    oldestSyncDate,
+    staleAccounts,
+    hasScrapableAccounts: true,
+    isLoading,
+  };
+}

--- a/frontend/src/hooks/useBudgetFreshness.ts
+++ b/frontend/src/hooks/useBudgetFreshness.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { scrapingApi } from "../services/api";
 import { useDemoMode } from "../context/DemoModeContext";
-import { daysSince } from "../utils/dateFormatting";
+import { daysSince, formatMissingRange } from "../utils/dateFormatting";
 
 /**
  * Freshness tiers, ordered worst-to-best in severity. Drives the budget
@@ -39,6 +39,43 @@ export interface BudgetFreshness {
   /** True when at least one scrapable account exists (badge should render). */
   hasScrapableAccounts: boolean;
   isLoading: boolean;
+}
+
+export interface StaleAccountGroup {
+  /** Localized missing-window label, or null for never-synced accounts. */
+  range: string | null;
+  accounts: StaleAccount[];
+}
+
+/**
+ * Collapse stale accounts that share the same missing window (clamped to the
+ * viewed month) into one group, so the banner/popover shows each window once
+ * instead of repeating it per account. Accounts fully covered for the month
+ * are dropped. Never-synced accounts group together (range null) and sort
+ * first as the most severe.
+ */
+export function groupStaleAccountsByMonth(
+  accounts: StaleAccount[],
+  year: number,
+  month: number,
+): StaleAccountGroup[] {
+  const groups = new Map<string, StaleAccountGroup>();
+  for (const acc of accounts) {
+    const range = acc.lastScrapeDate
+      ? formatMissingRange(acc.lastScrapeDate, year, month)
+      : null;
+    if (acc.lastScrapeDate !== null && range === null) continue; // covered this month
+    const key = range ?? "__never__";
+    const existing = groups.get(key);
+    if (existing) existing.accounts.push(acc);
+    else groups.set(key, { range, accounts: [acc] });
+  }
+  // Never-synced first; otherwise stable insertion order.
+  return [...groups.values()].sort((a, b) => {
+    if (a.range === null) return -1;
+    if (b.range === null) return 1;
+    return 0;
+  });
 }
 
 const STALE_THRESHOLD_DAYS = 4;

--- a/frontend/src/hooks/useBudgetFreshness.ts
+++ b/frontend/src/hooks/useBudgetFreshness.ts
@@ -62,7 +62,11 @@ export function useBudgetFreshness(): BudgetFreshness {
     enabled: !isDemoMode,
   });
 
-  if (isDemoMode || !data || data.length === 0) {
+  // Insurance is scraped but never produces budget transactions, so a stale
+  // insurance sync says nothing about the budget's completeness — exclude it.
+  const budgetRelevant = (data ?? []).filter((s) => s.service !== "insurances");
+
+  if (isDemoMode || budgetRelevant.length === 0) {
     return {
       tier: "none",
       oldestSyncDate: null,
@@ -72,7 +76,7 @@ export function useBudgetFreshness(): BudgetFreshness {
     };
   }
 
-  const accounts: StaleAccount[] = data.map((s) => ({
+  const accounts: StaleAccount[] = budgetRelevant.map((s) => ({
     service: s.service,
     provider: s.provider,
     accountName: s.account_name,

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -451,7 +451,7 @@
     "inMonth": "in {{month}}",
     "freshness": {
       "upToDate": "Up to date",
-      "updated": "Updated {{time}}",
+      "missingLabel": "Missing",
       "neverSynced": "Never synced",
       "syncing": "Syncing…",
       "provisional": "Provisional — based on stale data",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -458,8 +458,7 @@
       "showDetails": "Show sync details",
       "staleTitle": "Out-of-date sources",
       "syncNow": "Sync now",
-      "bannerStale": "Budget may be incomplete — {{account}} last synced {{time}}.",
-      "bannerNeverSynced": "Budget may be incomplete — {{account}} has never synced."
+      "bannerTitle": "Budget may be incomplete — these sources are behind:"
     },
     "confirmDeleteRule": "Are you sure you want to delete this budget rule?",
     "projectSpending": "Project Spending",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -449,6 +449,18 @@
     "allGood": "All good!",
     "daysLeft": "Days Left",
     "inMonth": "in {{month}}",
+    "freshness": {
+      "upToDate": "Up to date",
+      "updated": "Updated {{time}}",
+      "neverSynced": "Never synced",
+      "syncing": "Syncing…",
+      "provisional": "Provisional — based on stale data",
+      "showDetails": "Show sync details",
+      "staleTitle": "Out-of-date sources",
+      "syncNow": "Sync now",
+      "bannerStale": "Budget may be incomplete — {{account}} last synced {{time}}.",
+      "bannerNeverSynced": "Budget may be incomplete — {{account}} has never synced."
+    },
     "confirmDeleteRule": "Are you sure you want to delete this budget rule?",
     "projectSpending": "Project Spending",
     "project": "Project",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -449,6 +449,18 @@
     "allGood": "הכל בסדר!",
     "daysLeft": "ימים נותרו",
     "inMonth": "ב{{month}}",
+    "freshness": {
+      "upToDate": "מעודכן",
+      "updated": "עודכן {{time}}",
+      "neverSynced": "מעולם לא סונכרן",
+      "syncing": "מסנכרן…",
+      "provisional": "זמני — מבוסס על נתונים לא מעודכנים",
+      "showDetails": "הצג פרטי סנכרון",
+      "staleTitle": "מקורות לא מעודכנים",
+      "syncNow": "סנכרן עכשיו",
+      "bannerStale": "ייתכן שהתקציב חלקי — {{account}} סונכרן לאחרונה {{time}}.",
+      "bannerNeverSynced": "ייתכן שהתקציב חלקי — {{account}} מעולם לא סונכרן."
+    },
     "confirmDeleteRule": "האם אתה בטוח שברצונך למחוק כלל תקציב זה?",
     "projectSpending": "הוצאות פרויקט",
     "project": "פרויקט",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -458,8 +458,7 @@
       "showDetails": "הצג פרטי סנכרון",
       "staleTitle": "מקורות לא מעודכנים",
       "syncNow": "סנכרן עכשיו",
-      "bannerStale": "ייתכן שהתקציב חלקי — {{account}} סונכרן לאחרונה {{time}}.",
-      "bannerNeverSynced": "ייתכן שהתקציב חלקי — {{account}} מעולם לא סונכרן."
+      "bannerTitle": "ייתכן שהתקציב חלקי — המקורות הבאים אינם מעודכנים:"
     },
     "confirmDeleteRule": "האם אתה בטוח שברצונך למחוק כלל תקציב זה?",
     "projectSpending": "הוצאות פרויקט",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -451,7 +451,7 @@
     "inMonth": "ב{{month}}",
     "freshness": {
       "upToDate": "מעודכן",
-      "updated": "עודכן {{time}}",
+      "missingLabel": "חסר",
       "neverSynced": "מעולם לא סונכרן",
       "syncing": "מסנכרן…",
       "provisional": "זמני — מבוסס על נתונים לא מעודכנים",

--- a/frontend/src/pages/DataSources.tsx
+++ b/frontend/src/pages/DataSources.tsx
@@ -40,21 +40,9 @@ import { useScraping } from "../hooks/useScraping";
 import { ProviderLogo } from "../components/common/ProviderLogo";
 import { Skeleton } from "../components/common/Skeleton";
 import { humanizeAccountType, humanizeProvider } from "../utils/textFormatting";
-import { formatShortDate } from "../utils/dateFormatting";
+import { formatRelativeDate } from "../utils/dateFormatting";
 import { formatCurrency } from "../utils/numberFormatting";
 import i18n from "../i18n";
-
-function formatRelativeDate(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) return i18n.t("common.today");
-  if (diffDays === 1) return i18n.t("common.yesterday");
-  if (diffDays < 7) return `${diffDays} ${i18n.t("common.daysAgo")}`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)} ${i18n.t("common.weeksAgo")}`;
-  return formatShortDate(date);
-}
 
 const SCRAPING_PERIODS = [
   { key: "auto", days: null },

--- a/frontend/src/utils/dateFormatting.ts
+++ b/frontend/src/utils/dateFormatting.ts
@@ -68,3 +68,37 @@ export function formatRelativeDate(date: string | Date): string {
   if (diffDays < 30) return `${Math.floor(diffDays / 7)} ${i18n.t("common.weeksAgo")}`;
   return formatShortDate(date);
 }
+
+/**
+ * The un-scraped date window: from the day after the last successful scrape
+ * through today. Renders compactly — "26–30 May" within a month, "26 May – 6
+ * Jun" across months, "26 Dec 2025 – 6 Jan 2026" across years. Always LTR
+ * content; wrap the output in `dir="ltr"` when embedding in translated text.
+ * @param lastScrapeDate - Last successful scrape date (ISO string or Date)
+ * @returns Localized missing-range label
+ */
+export function formatMissingRange(lastScrapeDate: string | Date): string {
+  const start =
+    typeof lastScrapeDate === "string"
+      ? new Date(lastScrapeDate)
+      : new Date(lastScrapeDate.getTime());
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() + 1); // data through the scrape date is covered
+  const end = new Date();
+  end.setHours(0, 0, 0, 0);
+
+  // Synced today/yesterday: only today is potentially missing.
+  if (start.getTime() >= end.getTime()) {
+    return format(end, "d MMM", getLocale());
+  }
+
+  const sameYear = start.getFullYear() === end.getFullYear();
+  const sameMonth = sameYear && start.getMonth() === end.getMonth();
+  if (sameMonth) {
+    return `${format(start, "d", getLocale())}–${format(end, "d MMM", getLocale())}`;
+  }
+  if (sameYear) {
+    return `${format(start, "d MMM", getLocale())} – ${format(end, "d MMM", getLocale())}`;
+  }
+  return `${format(start, "d MMM yyyy", getLocale())} – ${format(end, "d MMM yyyy", getLocale())}`;
+}

--- a/frontend/src/utils/dateFormatting.ts
+++ b/frontend/src/utils/dateFormatting.ts
@@ -41,3 +41,30 @@ export function formatMonthYear(date: string | Date): string {
   const dateObj = typeof date === "string" ? new Date(date) : date;
   return format(dateObj, "MMMM yyyy", getLocale());
 }
+
+/**
+ * Whole calendar-agnostic days elapsed between `date` and now.
+ * @param date - Date string (ISO format) or Date object
+ * @returns Number of full days since the given date (0 = today)
+ */
+export function daysSince(date: string | Date): number {
+  const dateObj = typeof date === "string" ? new Date(date) : date;
+  const diffMs = Date.now() - dateObj.getTime();
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Human, localized relative date: "Today", "Yesterday", "3 d ago",
+ * "2 w ago", or an absolute short date once older than a month.
+ * Shared by the Data Sources sync badges and the budget freshness badge.
+ * @param date - Date string (ISO format) or Date object
+ * @returns Localized relative-time label
+ */
+export function formatRelativeDate(date: string | Date): string {
+  const diffDays = daysSince(date);
+  if (diffDays <= 0) return i18n.t("common.today");
+  if (diffDays === 1) return i18n.t("common.yesterday");
+  if (diffDays < 7) return `${diffDays} ${i18n.t("common.daysAgo")}`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} ${i18n.t("common.weeksAgo")}`;
+  return formatShortDate(date);
+}

--- a/frontend/src/utils/dateFormatting.ts
+++ b/frontend/src/utils/dateFormatting.ts
@@ -69,29 +69,10 @@ export function formatRelativeDate(date: string | Date): string {
   return formatShortDate(date);
 }
 
-/**
- * The un-scraped date window: from the day after the last successful scrape
- * through today. Renders compactly — "26–30 May" within a month, "26 May – 6
- * Jun" across months, "26 Dec 2025 – 6 Jan 2026" across years. Always LTR
- * content; wrap the output in `dir="ltr"` when embedding in translated text.
- * @param lastScrapeDate - Last successful scrape date (ISO string or Date)
- * @returns Localized missing-range label
- */
-export function formatMissingRange(lastScrapeDate: string | Date): string {
-  const start =
-    typeof lastScrapeDate === "string"
-      ? new Date(lastScrapeDate)
-      : new Date(lastScrapeDate.getTime());
-  start.setHours(0, 0, 0, 0);
-  start.setDate(start.getDate() + 1); // data through the scrape date is covered
-  const end = new Date();
-  end.setHours(0, 0, 0, 0);
-
-  // Synced today/yesterday: only today is potentially missing.
-  if (start.getTime() >= end.getTime()) {
+function formatDayRange(start: Date, end: Date): string {
+  if (start.getTime() === end.getTime()) {
     return format(end, "d MMM", getLocale());
   }
-
   const sameYear = start.getFullYear() === end.getFullYear();
   const sameMonth = sameYear && start.getMonth() === end.getMonth();
   if (sameMonth) {
@@ -101,4 +82,43 @@ export function formatMissingRange(lastScrapeDate: string | Date): string {
     return `${format(start, "d MMM", getLocale())} – ${format(end, "d MMM", getLocale())}`;
   }
   return `${format(start, "d MMM yyyy", getLocale())} – ${format(end, "d MMM yyyy", getLocale())}`;
+}
+
+/**
+ * The un-scraped date window for a *specific* month: the gap from the day
+ * after the last successful scrape through today, clamped to that month's
+ * boundaries. Viewing May never bleeds into June. Renders compactly —
+ * "24–31 May" within a month, "24 May – 6 Jun" across months (current view),
+ * with the year added across years. Returns `null` when the month is fully
+ * covered (last scrape lands on/after the month's end). Always LTR content;
+ * wrap output in `dir="ltr"` when embedding in translated text.
+ *
+ * @param lastScrapeDate - Last successful scrape date (ISO string or Date)
+ * @param year - Viewed year
+ * @param month - Viewed month (1-based)
+ * @returns Localized missing-range label, or null if nothing is missing
+ */
+export function formatMissingRange(
+  lastScrapeDate: string | Date,
+  year: number,
+  month: number,
+): string | null {
+  const monthStart = new Date(year, month - 1, 1);
+  monthStart.setHours(0, 0, 0, 0);
+  const monthEnd = new Date(year, month, 0); // day 0 of next month = last day
+  monthEnd.setHours(0, 0, 0, 0);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const firstMissing =
+    typeof lastScrapeDate === "string"
+      ? new Date(lastScrapeDate)
+      : new Date(lastScrapeDate.getTime());
+  firstMissing.setHours(0, 0, 0, 0);
+  firstMissing.setDate(firstMissing.getDate() + 1); // scrape date itself is covered
+
+  const start = firstMissing > monthStart ? firstMissing : monthStart;
+  const end = today < monthEnd ? today : monthEnd;
+  if (start.getTime() > end.getTime()) return null;
+  return formatDayRange(start, end);
 }


### PR DESCRIPTION
## Summary

Adds comprehensive data freshness UX to the budget view, surfacing how current the underlying transaction data is based on the *oldest* (weakest-link) successful scrape across all scrapable accounts. When data is stale or never synced, the budget figures are flagged as provisional and a dismissible amber banner nudges the user to re-sync.

## Key Changes

- **`useBudgetFreshness` hook** — Computes freshness tier (`fresh`, `aging`, `stale`, `veryStale`, `never`, `none`) based on the oldest sync date across accounts. Suppressed in Demo Mode (scrape recency is meaningless there).

- **`DataFreshnessBadge` component** — Compact "last synced" chip in the budget month view. Quiet when data is fresh; escalates color + iconography as staleness increases. Tap/hover popover names stale accounts and links to Data Sources for re-sync.

- **`BudgetFreshnessBanner` component** — Amber nudge shown when the weakest-link sync is very stale (≥ 7 days) or an account has never synced. Dismissible for the session; re-appears if staleness state changes.

- **Stale-KPI treatment** — When data is stale, the Budget Health tile is dimmed (opacity-60) and flagged with a clock icon to signal the figures are provisional, not authoritative.

- **Date formatting utilities** — Extracted `formatRelativeDate()` and `daysSince()` from DataSources into `dateFormatting.ts` for reuse across the app. Produces localized relative labels ("Today", "Yesterday", "3 d ago", "2 w ago", or absolute short date).

- **Freshness only for current month** — Historical months are settled; freshness UI only renders for the live month.

- **Internationalization** — Added freshness strings to both `en.json` and `he.json` (Hebrew translations included).

- **E2E tests** — `budget-freshness.spec.ts` covers very-stale badge + banner, popover with stale accounts, fresh sync hiding the banner, and dismissal persistence.

## Implementation Details

- Freshness tiers are ordered worst-to-best: `none` (no scrapable accounts) → `fresh` (≤ 1 day) → `aging` (2–3 days) → `stale` (4–6 days) → `veryStale` (≥ 7 days) → `never` (at least one account never synced).
- The "weakest link" approach ensures a single stale account doesn't hide the staleness from the user — the entire budget is only as fresh as the oldest sync.
- Badge popover is keyboard-accessible (Enter/Space to toggle) and includes click-away backdrop for touch + mouse.
- Banner dismissal is keyed by `tier:oldestSyncDate` so it re-appears if the staleness state changes (e.g., after a successful sync).
- RTL support via Tailwind logical properties and `dir="auto"` on text nodes.

https://claude.ai/code/session_01AmDYwQBuHEs9HYyZFxBptL