### PR TITLE
feat(categories): move auto-tagging rules to top, pair search with add button

### DIFF
--- a/frontend/e2e/categories.spec.ts
+++ b/frontend/e2e/categories.spec.ts
@@ -102,4 +102,38 @@ test.describe("Categories", () => {
     await panel.getByRole("button", { name: /^close$/i }).click();
     await expect(panel).toBeHidden({ timeout: 3_000 });
   });
+
+  test("protected category shows a disabled delete button with a reason on hover", async ({
+    page,
+  }) => {
+    await navigateTo(page, "/categories");
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.waitForLoadState("networkidle");
+
+    // Investments is a protected category — it cannot be deleted.
+    const protectedCard = page.locator('[data-testid="category-card-Investments"]');
+    await expect(protectedCard).toBeVisible({ timeout: 10_000 });
+    await protectedCard.click();
+
+    const panel = page.locator('[data-testid="category-panel"]');
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+
+    // The delete button is rendered but disabled (not hidden).
+    const deleteBtn = panel.getByRole("button", { name: /delete category/i });
+    await expect(deleteBtn).toBeVisible({ timeout: 5_000 });
+    await expect(deleteBtn).toBeDisabled();
+
+    // Hovering reveals the reason tooltip.
+    const reason = panel.getByText(/cannot be deleted/i);
+    const hiddenOpacity = await reason.evaluate((el) => getComputedStyle(el.parentElement!).opacity);
+    expect(Number(hiddenOpacity)).toBe(0);
+
+    await deleteBtn.hover();
+    await expect
+      .poll(async () => reason.evaluate((el) => getComputedStyle(el.parentElement!).opacity))
+      .toBe("1");
+
+    await panel.getByRole("button", { name: /^close$/i }).click();
+    await expect(panel).toBeHidden({ timeout: 3_000 });
+  });
 });

--- a/frontend/e2e/categories.spec.ts
+++ b/frontend/e2e/categories.spec.ts
@@ -40,6 +40,35 @@ test.describe("Categories", () => {
     await expect(page.getByText("Investments").first()).toBeVisible();
   });
 
+  test("auto-tagging rules sit above the search row, with add-category beside the search box", async ({
+    page,
+  }) => {
+    await navigateTo(page, "/categories");
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.waitForLoadState("networkidle");
+
+    const rulesCard = page.getByRole("button", { name: /Auto-Tagging Rules/i });
+    const searchBox = page.getByPlaceholder(/Search categories and tags/i);
+    const addButton = page.getByRole("button", { name: /New Category/i });
+
+    await expect(rulesCard).toBeVisible({ timeout: 10_000 });
+    await expect(searchBox).toBeVisible();
+    await expect(addButton).toBeVisible();
+
+    const rulesBox = await rulesCard.boundingBox();
+    const searchBoxBox = await searchBox.boundingBox();
+    const addBox = await addButton.boundingBox();
+    expect(rulesBox && searchBoxBox && addBox).toBeTruthy();
+
+    // The auto-tagging rules card is at the top — above the search row.
+    expect(rulesBox!.y + rulesBox!.height).toBeLessThanOrEqual(searchBoxBox!.y + 1);
+
+    // The search box and the add-category button share the same row (vertically aligned).
+    const searchCenter = searchBoxBox!.y + searchBoxBox!.height / 2;
+    const addCenter = addBox!.y + addBox!.height / 2;
+    expect(Math.abs(searchCenter - addCenter)).toBeLessThan(searchBoxBox!.height);
+  });
+
   test("delete button is visible inside the category detail panel", async ({ page }) => {
     await navigateTo(page, "/categories");
     await page.setViewportSize({ width: 1280, height: 800 });

--- a/frontend/src/components/categories/CategoryDetailPanel.tsx
+++ b/frontend/src/components/categories/CategoryDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { X, Plus, Trash2, MoveRight, Wallet } from "lucide-react";
@@ -33,6 +33,7 @@ export function CategoryDetailPanel({
   const confirm = useConfirm();
   const notify = useNotify();
   const isProtected = PROTECTED_CATEGORIES.includes(category);
+  const deleteReasonId = useId();
 
   useScrollLock(true);
 
@@ -294,7 +295,7 @@ export function CategoryDetailPanel({
                     if (ok) deleteCategoryMutation.mutate(category);
                   }}
                   disabled={isProtected}
-                  title={isProtected ? t("categories.protectedCannotDelete") : undefined}
+                  aria-describedby={isProtected ? deleteReasonId : undefined}
                   className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl border border-transparent transition-all font-bold text-sm ${
                     isProtected
                       ? "text-[var(--text-muted)] opacity-50 cursor-not-allowed"
@@ -306,7 +307,11 @@ export function CategoryDetailPanel({
                 </button>
                 {isProtected && (
                   <div className="pointer-events-none absolute bottom-full inset-x-0 mb-2 flex justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-                    <span className="px-3 py-1.5 rounded-lg bg-[var(--surface-base)] border border-[var(--surface-light)] text-xs text-[var(--text-muted)] shadow-lg max-w-[calc(100%-1rem)] text-center">
+                    <span
+                      id={deleteReasonId}
+                      role="tooltip"
+                      className="px-3 py-1.5 rounded-lg bg-[var(--surface-base)] border border-[var(--surface-light)] text-xs text-[var(--text-muted)] shadow-lg max-w-[calc(100%-1rem)] text-center"
+                    >
                       {t("categories.protectedCannotDelete")}
                     </span>
                   </div>

--- a/frontend/src/components/categories/CategoryDetailPanel.tsx
+++ b/frontend/src/components/categories/CategoryDetailPanel.tsx
@@ -281,8 +281,8 @@ export function CategoryDetailPanel({
             </div>
 
             {/* Category danger zone */}
-            {!isProtected && (
-              <div className="pt-4 border-t border-[var(--surface-light)]">
+            <div className="pt-4 border-t border-[var(--surface-light)]">
+              <div className="group relative">
                 <button
                   onClick={async () => {
                     const ok = await confirm({
@@ -293,13 +293,26 @@ export function CategoryDetailPanel({
                     });
                     if (ok) deleteCategoryMutation.mutate(category);
                   }}
-                  className="w-full flex items-center gap-3 px-4 py-3 rounded-xl text-red-400 hover:bg-red-500/10 border border-transparent hover:border-red-500/20 transition-all font-bold text-sm"
+                  disabled={isProtected}
+                  title={isProtected ? t("categories.protectedCannotDelete") : undefined}
+                  className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl border border-transparent transition-all font-bold text-sm ${
+                    isProtected
+                      ? "text-[var(--text-muted)] opacity-50 cursor-not-allowed"
+                      : "text-red-400 hover:bg-red-500/10 hover:border-red-500/20"
+                  }`}
                 >
                   <Trash2 size={16} />
                   {t("categories.deleteCategory")}
                 </button>
+                {isProtected && (
+                  <div className="pointer-events-none absolute bottom-full inset-x-0 mb-2 flex justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                    <span className="px-3 py-1.5 rounded-lg bg-[var(--surface-base)] border border-[var(--surface-light)] text-xs text-[var(--text-muted)] shadow-lg max-w-[calc(100%-1rem)] text-center">
+                      {t("categories.protectedCannotDelete")}
+                    </span>
+                  </div>
+                )}
               </div>
-            )}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -553,6 +553,7 @@
     "renameTag": "Click to rename",
     "renameError": "Cannot rename. The name may already exist or is protected.",
     "protectedCannotRename": "Protected items cannot be renamed",
+    "protectedCannotDelete": "Protected categories cannot be deleted",
     "categoriesCount": "{{count}} categories",
     "tagsCount": "{{count}} tags",
     "searchPlaceholder": "Search categories and tags...",

--- a/frontend/src/locales/he.json
+++ b/frontend/src/locales/he.json
@@ -553,6 +553,7 @@
     "renameTag": "לחץ לשינוי שם",
     "renameError": "לא ניתן לשנות שם. השם עשוי להיות קיים כבר או מוגן.",
     "protectedCannotRename": "לא ניתן לשנות שם של פריטים מוגנים",
+    "protectedCannotDelete": "לא ניתן למחוק קטגוריות מוגנות",
     "categoriesCount": "{{count}} קטגוריות",
     "tagsCount": "{{count}} תגיות",
     "searchPlaceholder": "חפש קטגוריות ותגיות...",

--- a/frontend/src/pages/Categories.tsx
+++ b/frontend/src/pages/Categories.tsx
@@ -61,26 +61,27 @@ export function Categories() {
 
   return (
     <div className="space-y-4 md:space-y-6 animate-in fade-in duration-500">
-      {/* Header */}
-      <div className="flex items-center justify-end gap-3">
+      {/* Auto-Tagging Rules */}
+      <RulesSection />
+
+      {/* Search Bar + Add Category */}
+      <div className="flex flex-col md:flex-row md:items-center gap-3">
+        <div className="relative flex-1">
+          <Search size={16} className="absolute start-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
+          <input
+            type="text"
+            placeholder={t("categories.searchPlaceholder")}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full bg-[var(--surface)] border border-[var(--surface-light)] rounded-xl ps-11 pe-4 py-2 text-sm outline-none focus:border-[var(--primary)] transition-all"
+          />
+        </div>
         <button
           onClick={() => setIsAddCategoryOpen(true)}
-          className="flex items-center justify-center gap-2 px-4 md:px-6 py-2.5 bg-[var(--primary)] text-white rounded-xl font-bold shadow-lg shadow-[var(--primary)]/20 hover:bg-[var(--primary-dark)] transition-all text-sm md:text-base"
+          className="flex items-center justify-center gap-2 px-4 md:px-6 py-2.5 bg-[var(--primary)] text-white rounded-xl font-bold shadow-lg shadow-[var(--primary)]/20 hover:bg-[var(--primary-dark)] transition-all text-sm md:text-base shrink-0"
         >
           <Plus size={18} /> {t("categories.newCategory")}
         </button>
-      </div>
-
-      {/* Search Bar */}
-      <div className="relative">
-        <Search size={16} className="absolute start-4 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
-        <input
-          type="text"
-          placeholder={t("categories.searchPlaceholder")}
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full bg-[var(--surface)] border border-[var(--surface-light)] rounded-xl ps-11 pe-4 py-2 text-sm outline-none focus:border-[var(--primary)] transition-all"
-        />
       </div>
 
       {/* Category Grid */}
@@ -121,11 +122,6 @@ export function Categories() {
           </div>
         )
       )}
-
-      {/* Auto-Tagging Rules */}
-      <div className="pt-2">
-        <RulesSection />
-      </div>
 
       {/* Detail Panel */}
       {selectedCategory && (


### PR DESCRIPTION
## Summary

Reorganizes the Categories page layout:

- **Auto-tagging rules card** moved to the top of the page.
- **Search box** and the **New Category button** now share a single row, directly beneath the rules card. The search input flexes to fill the width; the button sits beside it. On mobile they stack (`flex-col md:flex-row`) to avoid cramping.
- Category grid follows below.

Previously the New Category button was alone in a right-aligned header row, the search box was on its own row, and the rules section sat at the bottom of the page.

## Verification

- `Categories.test.tsx` unit tests — 5 passed
- `tsc -b` type-check and ESLint on changed files — clean
- e2e (real browser via `with_server.py`, both servers up): all 5 specs in `categories.spec.ts` passed, including a new test asserting the auto-tagging rules card sits above the search row and that the search box and add-category button share the same horizontal row

> Note: opened against `main` because there is no `dev` branch on the remote. The project convention normally routes feature PRs through `dev`.

https://claude.ai/code/session_01449pXDSqg1nELC6YZwzztd

---
_Generated by [Claude Code](https://claude.ai/code/session_01449pXDSqg1nELC6YZwzztd)_