### PR TITLE
Repo audit: pending-scrape dedup, per-table month overrides, lazy Plotly, RTL & cache fixes

### DIFF
--- a/.claude/rules/backend_repositories.md
+++ b/.claude/rules/backend_repositories.md
@@ -107,6 +107,41 @@ class TransactionsRepository:
         self.bank_repo = BankRepository(db)
 ```
 
+## `unique_id` Is Per-Table — Never Use It Alone Across Tables
+
+Every transaction table (`bank_transactions`, `credit_card_transactions`,
+`cash_transactions`, `manual_investment_transactions`,
+`insurance_transactions`) defines `unique_id` as its **own auto-increment
+primary key**. The same integer exists in every table — bank #5 and
+credit-card #5 are unrelated transactions. This has caused real bugs more
+than once (most recently: a budget month override stored for a credit-card
+transaction re-monthed the bank transaction sharing its integer, because the
+lookup map was keyed by bare `unique_id` over the merged analysis frame).
+
+**Rules:**
+
+- `unique_id` only identifies a row **within one table**. The moment data
+  from two or more transaction tables is merged (the analysis DataFrame,
+  KPI inputs, budget views), bare `unique_id` is ambiguous.
+- Any cross-table reference must carry the table alongside the id. Existing
+  precedents to follow:
+  - `pending_refunds`: `source_id` + `source_table`
+  - `split_transactions`: `transaction_id` + `source`
+  - `budget_month_overrides`: `source_id` + `source_table` (and the
+    override map is keyed by `(source_table, source_id)`)
+- When building a dict/map from one of those tables to apply over a merged
+  DataFrame, key it by `(source_table, unique_id)` — never by `unique_id`
+  alone. Same for joins, `Series.map`, `isin` filters, and caches.
+- API payloads that point at a transaction must include both fields; the
+  frontend sends `tx.source` as the table identifier (it holds the table
+  name, e.g. `"bank_transactions"`).
+- Frontend React keys follow the same logic: `` `${tx.source}_${tx.unique_id}` ``
+  (see `frontend_pitfalls.md` → "Key Generation in Lists").
+
+If you find yourself writing `df["unique_id"].map(...)` or
+`WHERE unique_id = :id` without already knowing **which table** the id came
+from, stop — that's the bug.
+
 ## YAML vs Database
 
 | Use YAML | Use Database |

--- a/.claude/rules/kpi_calculations.md
+++ b/.claude/rules/kpi_calculations.md
@@ -224,6 +224,6 @@ All previously identified code misalignments have been fixed:
 - `get_expenses_by_category()` now excludes `Credit Cards` category alongside other non-expense categories
 - `get_income_investments_and_expenses()` now filters non-expense categories from expenses, with negative Liabilities overriding back into expenses
 - Overview and net worth chart both use transaction-based investment totals (`-sum(all inv txns)`), not portfolio value
-- Ignore category has no special treatment in KPI calculations — not in non-expense categories, not filtered
+- Ignore category is part of `NON_EXPENSE_CATEGORIES` (excluded from category breakdowns like the expense pie), but gets no special treatment in the income/expense masks used by aggregate totals
 - `"Salay"` typo in `PROTECTED_CATEGORIES` corrected to `"Salary"`
 - `NonExpensesCategories` enum removed; non-expense categories now built from individual constants (`INVESTMENTS_CATEGORY`, `LIABILITIES_CATEGORY`) and `IncomeCategories` enum

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ The frontend ships as a PWA — service worker precaches the build, persists the
 
 ## Gotchas
 
+- **`unique_id` is a per-table auto-increment** — bank #5 and credit-card #5 are different transactions. Never key merged/cross-table data by bare `unique_id`; always pair it with the table (`source` / `source_table`). See `.claude/rules/backend_repositories.md` → "unique_id Is Per-Table"
 - Passwords stored in OS Keyring, never in YAML or code
 - SQLite uses `NullPool` and `check_same_thread=False` for FastAPI compatibility
 - SQLite stores booleans as `0`/`1` integers — in React JSX, `{0 && <Component />}` renders "0". Always use `!!value &&` or `value > 0 &&` for SQLite boolean fields in JSX conditionals

--- a/alembic.ini
+++ b/alembic.ini
@@ -87,7 +87,7 @@ path_separator = os
 # other means of configuring database URLs may be customized within the env.py
 # file.
 # Note: The actual URL is determined from backend.config.AppConfig
-sqlalchemy.url = sqlite:////Users/tomer/.finance-analysis/data.db
+sqlalchemy.url = sqlite:///placeholder-overridden-by-env.py
 
 
 [post_write_hooks]

--- a/backend/repositories/investment_snapshots_repository.py
+++ b/backend/repositories/investment_snapshots_repository.py
@@ -5,7 +5,7 @@ Investment balance snapshots repository with SQLAlchemy ORM.
 from typing import Optional
 
 import pandas as pd
-from sqlalchemy import select, update, delete
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -108,6 +108,31 @@ class InvestmentSnapshotsRepository:
             .order_by(InvestmentBalanceSnapshot.date.asc())
         )
         return pd.read_sql(stmt, self.db.bind)
+
+    def get_latest_snapshot_dates(self, target_date: str) -> dict[int, str]:
+        """Get the most recent snapshot date on or before a target date, per investment.
+
+        Parameters
+        ----------
+        target_date : str
+            Upper bound date in ``YYYY-MM-DD`` format (inclusive).
+
+        Returns
+        -------
+        dict[int, str]
+            Mapping of ``investment_id`` to its latest snapshot date.
+            Investments without snapshots are absent from the mapping.
+        """
+        rows = (
+            self.db.query(
+                InvestmentBalanceSnapshot.investment_id,
+                func.max(InvestmentBalanceSnapshot.date),
+            )
+            .filter(InvestmentBalanceSnapshot.date <= target_date)
+            .group_by(InvestmentBalanceSnapshot.investment_id)
+            .all()
+        )
+        return {investment_id: latest_date for investment_id, latest_date in rows}
 
     def get_latest_snapshot_on_or_before(
         self, investment_id: int, target_date: str

--- a/backend/repositories/transactions_repository.py
+++ b/backend/repositories/transactions_repository.py
@@ -608,7 +608,17 @@ class TransactionsRepository:
             self.db.delete(row)
         self.db.flush()
 
-        return pd.DataFrame(carried) if carried else None
+        if not carried:
+            return None
+        # Two distinct transactions can legitimately share
+        # (id, provider, date, amount) — e.g. two identical same-day ATM
+        # withdrawals with empty reference ids (see migration
+        # d4f6a8c0e2b5). Collapse duplicate keys so the left-join that
+        # restores tags can't cartesian-multiply a scraped row into
+        # several inserts.
+        return pd.DataFrame(carried).drop_duplicates(
+            subset=self.unique_columns, keep="first"
+        )
 
     def add_transaction(
         self,

--- a/backend/repositories/transactions_repository.py
+++ b/backend/repositories/transactions_repository.py
@@ -10,6 +10,7 @@ import pandas as pd
 from sqlalchemy import cast, delete, func, Integer, select, update
 from sqlalchemy.orm import Session
 
+from backend.models.pending_refund import PendingRefund
 from backend.models.transaction import (
     BankTransaction,
     CashTransaction,
@@ -408,7 +409,12 @@ class TransactionsRepository:
             Services.INSURANCE.value: self.insurance_repo,
         }
 
-    def add_scraped_transactions(self, df: pd.DataFrame, table_name: str) -> None:
+    def add_scraped_transactions(
+        self,
+        df: pd.DataFrame,
+        table_name: str,
+        scrape_start_date: str | None = None,
+    ) -> None:
         """Persist scraped transactions, skipping rows that already exist.
 
         Parameters
@@ -418,6 +424,11 @@ class TransactionsRepository:
             id, provider, date, amount plus any other transaction fields.
         table_name : str
             Target table name; must be one of the four supported tables.
+        scrape_start_date : str, optional
+            Start of the scraped window (``YYYY-MM-DD``). When provided,
+            existing ``pending`` rows for the scraped provider/account from
+            this date onward are reconciled (see Notes). Falls back to the
+            earliest date in ``df``.
 
         Raises
         ------
@@ -428,21 +439,45 @@ class TransactionsRepository:
         -----
         Deduplication is based on the composite key (id, provider, date, amount).
         Only rows not already present in the DB are inserted.
+
+        Pending reconciliation: a transaction scraped while still pending can
+        settle with a different date or amount (FX conversion, card holds), so
+        the settled row fails the duplicate check and BOTH rows persist,
+        double-counting the spend. The scrape is authoritative for its window:
+        stale pending rows are deleted, still-pending transactions are
+        re-reported by the scrape and re-inserted, and any user-assigned
+        category/tag is carried over by composite key. Split parents and rows
+        referenced by pending refunds are never purged.
         """
         if table_name not in self.tables:
             raise ValueError(f"table_name should be one of {self.tables}")
 
         repo = self.get_repo_by_source(table_name)
 
-        # Using pandas for the merge logic as in original code is robust for the duplicate check
+        carried_tags = self._reconcile_pending_rows(repo, df, scrape_start_date)
+
+        # Using pandas for the merge logic as in original code is robust for the
+        # duplicate check. Read through the session's own connection so the
+        # uncommitted pending-row deletions above are visible — otherwise
+        # re-reported pending rows would be deduped against the rows just
+        # deleted and silently dropped.
         stmt = select(
             repo.model.id, repo.model.provider, repo.model.date, repo.model.amount
         )
-        existing_data = pd.read_sql(stmt, self.db.bind)
+        existing_data = pd.read_sql(stmt, self.db.connection())
 
         # Make sure columns align for merge
         df = df.astype({col: str for col in self.unique_columns})
         existing_data = existing_data.astype({col: str for col in self.unique_columns})
+
+        if carried_tags is not None and not carried_tags.empty:
+            df = df.merge(
+                carried_tags, on=self.unique_columns, how="left", suffixes=("", "_carried")
+            )
+            for col in ("category", "tag"):
+                carried_col = f"{col}_carried"
+                df[col] = df[col].fillna(df[carried_col])
+                df = df.drop(columns=carried_col)
 
         if not existing_data.empty:
             merged_df = df.merge(
@@ -455,6 +490,8 @@ class TransactionsRepository:
             new_rows = df
 
         if new_rows.empty:
+            # Still commit any pending-row deletions from the reconcile step.
+            self.db.commit()
             return
 
         # Prepare list of model instances
@@ -485,6 +522,93 @@ class TransactionsRepository:
 
         self.db.add_all(instances)
         self.db.commit()
+
+    def _reconcile_pending_rows(
+        self,
+        repo,
+        df: pd.DataFrame,
+        scrape_start_date: str | None,
+    ) -> pd.DataFrame | None:
+        """Delete stale pending rows superseded by a re-scrape of their window.
+
+        Deletions are flushed but not committed — the caller commits them
+        together with the inserted rows so the reconcile is atomic.
+
+        Parameters
+        ----------
+        repo
+            Sub-repository whose model/table is being written to.
+        df : pd.DataFrame
+            Incoming scraped transactions.
+        scrape_start_date : str or None
+            Start of the scraped window; falls back to the earliest date
+            in ``df``.
+
+        Returns
+        -------
+        pd.DataFrame or None
+            Carried-over ``category``/``tag`` values keyed by the composite
+            (id, provider, date, amount) — already string-typed — or ``None``
+            when nothing was purged.
+        """
+        required = {"date", "provider", "account_name"}
+        if df.empty or not required.issubset(df.columns):
+            return None
+
+        window_start = scrape_start_date or df["date"].min()
+        providers = [str(p) for p in df["provider"].dropna().unique()]
+        accounts = [str(a) for a in df["account_name"].dropna().unique()]
+        if not window_start or not providers or not accounts:
+            return None
+
+        model = repo.model
+        stale = (
+            self.db.execute(
+                select(model).where(
+                    model.status == "pending",
+                    model.provider.in_(providers),
+                    model.account_name.in_(accounts),
+                    model.date >= str(window_start),
+                    model.type != "split_parent",
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if not stale:
+            return None
+
+        # Never purge rows a pending refund points at — the refund record
+        # references the row's unique_id and would be orphaned.
+        refund_locked = {
+            row[0]
+            for row in self.db.execute(
+                select(PendingRefund.source_id).where(
+                    PendingRefund.source_type == "transaction",
+                    PendingRefund.source_table == repo.table,
+                )
+            ).all()
+        }
+
+        carried = []
+        for row in stale:
+            if row.unique_id in refund_locked:
+                continue
+            if row.category:
+                carried.append(
+                    {
+                        "id": str(row.id),
+                        "provider": str(row.provider),
+                        "date": str(row.date),
+                        "amount": str(row.amount),
+                        "category": row.category,
+                        "tag": row.tag,
+                    }
+                )
+            self.db.delete(row)
+        self.db.flush()
+
+        return pd.DataFrame(carried) if carried else None
 
     def add_transaction(
         self,

--- a/backend/scraper/adapter.py
+++ b/backend/scraper/adapter.py
@@ -438,7 +438,11 @@ class ScraperAdapter:
         """Persist the scraped DataFrame to the database."""
         with get_db_context() as db:
             transactions_repo = TransactionsRepository(db)
-            transactions_repo.add_scraped_transactions(self._data, self._table_name)
+            transactions_repo.add_scraped_transactions(
+                self._data,
+                self._table_name,
+                scrape_start_date=self.start_date.strftime("%Y-%m-%d"),
+            )
 
     def _apply_auto_tagging(self) -> None:
         """Apply tagging rules to newly scraped transactions.

--- a/backend/services/budget_month_override_service.py
+++ b/backend/services/budget_month_override_service.py
@@ -198,8 +198,13 @@ class BudgetMonthOverrideService:
         Returns
         -------
         dict[str, dict]
-            Dictionary with keys 'transaction' and 'split', each mapping a
-            source_id to a ``(override_year, override_month)`` tuple.
+            Dictionary with keys 'transaction' and 'split'. The 'transaction'
+            map is keyed by ``(source_table, source_id)`` — ``unique_id``
+            values are per-table auto-increments, so the same integer exists
+            in every transaction table and the table must disambiguate. The
+            'split' map is keyed by ``source_id`` alone (split ids live in a
+            single table). Values are ``(override_year, override_month)``
+            tuples.
         """
         df = self.repo.get_all()
         if df.empty:
@@ -210,7 +215,11 @@ class BudgetMonthOverrideService:
             bucket = result.get(row.source_type)
             if bucket is None:
                 continue
-            bucket[row.source_id] = (int(row.override_year), int(row.override_month))
+            value = (int(row.override_year), int(row.override_month))
+            if row.source_type == "transaction":
+                bucket[(row.source_table, row.source_id)] = value
+            else:
+                bucket[row.source_id] = value
         return result
 
     @staticmethod

--- a/backend/services/budget_service.py
+++ b/backend/services/budget_service.py
@@ -25,6 +25,7 @@ from backend.constants.budget import (
 )
 from backend.constants.categories import INVESTMENTS_CATEGORY, LIABILITIES_CATEGORY, IncomeCategories
 from backend.constants.tables import TransactionsTableFields
+from backend.errors import EntityNotFoundException
 from backend.repositories.budget_repository import BudgetRepository
 from backend.services.budget_month_override_service import BudgetMonthOverrideService
 from backend.services.pending_refunds_service import PendingRefundsService
@@ -1151,6 +1152,10 @@ class ProjectBudgetService(BudgetService):
         """
         rules = self.get_rules_for_project(category)
         total_rule = rules.loc[rules[TAGS].apply(lambda x: x == [ALL_TAGS])]
+        if total_rule.empty:
+            raise EntityNotFoundException(
+                f"No total budget rule found for project '{category}'"
+            )
         rule_id = int(total_rule.iloc[0][ID])
         self.update_rule(rule_id, amount=total_budget)
 

--- a/backend/services/budget_service.py
+++ b/backend/services/budget_service.py
@@ -737,11 +737,21 @@ class MonthlyBudgetService(BudgetService):
 
         tx_map = overrides["transaction"]
         if tx_map:
-            uid = expenses[TransactionsTableFields.UNIQUE_ID.value]
-            budget_year = uid.map({k: v[0] for k, v in tx_map.items()}).fillna(
+            # Key by (source table, unique_id): unique_id is a per-table
+            # auto-increment, so the bare integer collides across tables.
+            keys = pd.Series(
+                list(
+                    zip(
+                        expenses[TransactionsTableFields.SOURCE.value],
+                        expenses[TransactionsTableFields.UNIQUE_ID.value],
+                    )
+                ),
+                index=expenses.index,
+            )
+            budget_year = keys.map({k: v[0] for k, v in tx_map.items()}).fillna(
                 budget_year
             )
-            budget_month = uid.map({k: v[1] for k, v in tx_map.items()}).fillna(
+            budget_month = keys.map({k: v[1] for k, v in tx_map.items()}).fillna(
                 budget_month
             )
 

--- a/backend/services/investments_service.py
+++ b/backend/services/investments_service.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from backend.constants.categories import INVESTMENTS_CATEGORY
@@ -73,20 +73,55 @@ class InvestmentsService:
         df = self.investments_repo.get_all_investments(include_closed=include_closed)
         df = df.replace({np.nan: None})
         records = df.to_dict(orient="records")
+        if not records:
+            return records
+
+        # Batch the per-investment lookups: one snapshot GROUP BY query, one
+        # merged-transactions load, and one insurance-transactions load —
+        # instead of 2-3 queries per investment.
+        snapshot_dates = self.snapshots_repo.get_latest_snapshot_dates(
+            date.today().strftime("%Y-%m-%d")
+        )
+
+        analysis_df = self.transactions_service.get_data_for_analysis()
+        manual_first_dates: dict[tuple[str, str], str] = {}
+        if not analysis_df.empty:
+            dated = analysis_df.assign(_date=pd.to_datetime(analysis_df["date"]))
+            manual_first_dates = {
+                key: first.strftime("%Y-%m-%d")
+                for key, first in dated.groupby(["category", "tag"])["_date"].min().items()
+            }
+
+        policy_ids = [
+            record["insurance_policy_id"]
+            for record in records
+            if record.get("insurance_policy_id")
+        ]
+        insurance_first_dates: dict[str, str] = {}
+        if policy_ids:
+            stmt = select(
+                InsuranceTransaction.account_number,
+                func.min(InsuranceTransaction.date),
+            ).where(
+                InsuranceTransaction.account_number.in_(policy_ids)
+            ).group_by(InsuranceTransaction.account_number)
+            insurance_first_dates = {
+                account: first[:10]
+                for account, first in self.db.execute(stmt).all()
+                if first
+            }
 
         for record in records:
-            latest = self.snapshots_repo.get_latest_snapshot_on_or_before(
-                record["id"], date.today().strftime("%Y-%m-%d")
-            )
-            record["latest_snapshot_date"] = latest["date"] if latest else None
+            record["latest_snapshot_date"] = snapshot_dates.get(record["id"])
 
-            txns = self._get_all_transactions_for_investment(
-                record["category"], record["tag"], investment_id=record["id"]
-            )
-            if not txns.empty:
-                record["first_transaction_date"] = pd.to_datetime(txns["date"]).min().strftime("%Y-%m-%d")
-            else:
-                record["first_transaction_date"] = None
+            candidates = []
+            manual_first = manual_first_dates.get((record["category"], record["tag"]))
+            if manual_first:
+                candidates.append(manual_first)
+            policy_id = record.get("insurance_policy_id")
+            if policy_id and policy_id in insurance_first_dates:
+                candidates.append(insurance_first_dates[policy_id])
+            record["first_transaction_date"] = min(candidates) if candidates else None
 
         return records
 

--- a/backend/services/pending_refunds_service.py
+++ b/backend/services/pending_refunds_service.py
@@ -1,11 +1,14 @@
 """Pending refunds service with business logic."""
 
+import logging
 from typing import Literal, Optional
 
 from sqlalchemy.orm import Session
 
 from backend.errors import EntityNotFoundException, ValidationException
 from backend.repositories.pending_refunds_repository import PendingRefundsRepository
+
+logger = logging.getLogger(__name__)
 
 
 class PendingRefundsService:
@@ -290,7 +293,9 @@ class PendingRefundsService:
                                 "original_currency": "ILS",  # Assumption
                             }
                 except Exception:
-                    pass  # Fail gracefully on enrichment
+                    logger.warning(
+                        "Failed to enrich pending refunds from %s", table, exc_info=True
+                    )
             elif type_ == "split":
                 # For splits, we need to get the split record to find the parent transaction
                 # Then get details from the parent
@@ -323,7 +328,11 @@ class PendingRefundsService:
                                         "original_currency": "ILS",
                                     }
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to enrich pending refund splits from %s",
+                        table,
+                        exc_info=True,
+                    )
 
         # Apply details to pending items
         for p in pending_list:
@@ -378,7 +387,9 @@ class PendingRefundsService:
                                 "original_currency": "ILS",
                             }
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Failed to enrich refund links from %s", table, exc_info=True
+                    )
 
             # Apply details to links
             for link in p["links"]:

--- a/frontend/e2e/chart-styling.spec.ts
+++ b/frontend/e2e/chart-styling.spec.ts
@@ -28,8 +28,11 @@ test.describe("Chart styling (soft gradient)", () => {
 
   test("dashboard charts render after the restyle", async ({ page }) => {
     await navigateTo(page, "/");
+    // Plotly is lazy-loaded (LazyPlot); the dev server serves the chunk
+    // unminified, so a cold first fetch+eval can take tens of seconds on
+    // slow CI/sandbox machines.
     await expect(page.locator(".js-plotly-plot").first()).toBeVisible({
-      timeout: 15_000,
+      timeout: 45_000,
     });
   });
 

--- a/frontend/e2e/chart-touch-scroll.spec.ts
+++ b/frontend/e2e/chart-touch-scroll.spec.ts
@@ -22,7 +22,9 @@ import { enableDemoMode, disableDemoMode, navigateTo } from "./helpers";
 /** Read the computed Plotly dragmode off the first rendered graph div. */
 async function firstChartDragmode(page: Page): Promise<unknown> {
   const plot = page.locator(".js-plotly-plot").first();
-  await expect(plot).toBeVisible({ timeout: 15_000 });
+  // Plotly is lazy-loaded (LazyPlot); a cold first fetch+eval of the dev
+  // chunk can take tens of seconds on slow CI/sandbox machines.
+  await expect(plot).toBeVisible({ timeout: 45_000 });
   return plot.evaluate(
     (el) => (el as unknown as { _fullLayout?: { dragmode?: unknown } })._fullLayout?.dragmode,
   );

--- a/frontend/e2e/chart-touch-zoom.spec.ts
+++ b/frontend/e2e/chart-touch-zoom.spec.ts
@@ -78,7 +78,7 @@ test.describe("Chart double-tap native zoom mode (touch)", () => {
 
   test("double-tap enters zoom mode; native drag zooms and persists", async ({ page }) => {
     await navigateTo(page, "/");
-    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({ timeout: 45_000 });
     const before = await markChart(page);
     expect(before, "expected a zoomable cartesian chart").not.toBeNull();
 
@@ -118,7 +118,7 @@ test.describe("Chart double-tap native zoom mode (touch)", () => {
 
   test("touching outside the chart leaves zoom mode", async ({ page }) => {
     await navigateTo(page, "/");
-    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator(".js-plotly-plot").first()).toBeVisible({ timeout: 45_000 });
     await markChart(page);
 
     await doubleTap(page);

--- a/frontend/e2e/lazy-plotly.spec.ts
+++ b/frontend/e2e/lazy-plotly.spec.ts
@@ -31,9 +31,12 @@ test.describe("Lazy-loaded Plotly charts", () => {
     test(`renders Plotly charts on the ${name} page`, async ({ page }) => {
       await navigateTo(page, path);
       // Plotly renders into div.js-plotly-plot only after the lazy chunk
-      // resolves and the Suspense fallback is replaced.
+      // resolves and the Suspense fallback is replaced. The dev server
+      // serves the chunk unminified, so its first cold fetch+eval can take
+      // tens of seconds on slow CI/sandbox machines — hence the generous
+      // timeout.
       await expect(page.locator(".js-plotly-plot").first()).toBeVisible({
-        timeout: 15_000,
+        timeout: 45_000,
       });
     });
   }

--- a/frontend/e2e/lazy-plotly.spec.ts
+++ b/frontend/e2e/lazy-plotly.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+import { enableDemoMode, disableDemoMode, navigateTo } from "./helpers";
+
+/**
+ * Plotly is code-split out of the main bundle (components/common/LazyPlot.tsx)
+ * and loaded on demand when the first chart mounts. These tests guard the
+ * lazy-loading path: charts on every Plotly-using page must still hydrate
+ * from the Suspense skeleton into a rendered figure.
+ */
+test.describe("Lazy-loaded Plotly charts", () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await enableDemoMode(page);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await disableDemoMode(page);
+    await page.close();
+  });
+
+  const pagesWithCharts: [string, string][] = [
+    ["dashboard", "/"],
+    ["budget", "/budget"],
+    ["investments", "/investments"],
+    ["liabilities", "/liabilities"],
+  ];
+
+  for (const [name, path] of pagesWithCharts) {
+    test(`renders Plotly charts on the ${name} page`, async ({ page }) => {
+      await navigateTo(page, path);
+      // Plotly renders into div.js-plotly-plot only after the lazy chunk
+      // resolves and the Suspense fallback is replaced.
+      await expect(page.locator(".js-plotly-plot").first()).toBeVisible({
+        timeout: 15_000,
+      });
+    });
+  }
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "1.27.0",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "1.27.0",
+      "version": "1.32.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^8.0.0",

--- a/frontend/src/components/SankeyChart.tsx
+++ b/frontend/src/components/SankeyChart.tsx
@@ -1,4 +1,4 @@
-import Plot from "react-plotly.js";
+import Plot from "./common/LazyPlot";
 import { chartTheme, plotlyConfig, CHART_COLORS, CHART_SURFACE_COLOR } from "../utils/plotlyLocale";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";

--- a/frontend/src/components/budget/BudgetTrendChart.tsx
+++ b/frontend/src/components/budget/BudgetTrendChart.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
-import Plot from "react-plotly.js";
+import Plot from "../common/LazyPlot";
 import { ChevronDown, ChevronUp, TrendingUp } from "lucide-react";
 import i18n from "../../i18n";
 import { chartTheme, plotlyConfig, barMarker } from "../../utils/plotlyLocale";

--- a/frontend/src/components/budget/MonthlyBudgetView.tsx
+++ b/frontend/src/components/budget/MonthlyBudgetView.tsx
@@ -527,7 +527,7 @@ export const MonthlyBudgetView: React.FC<MonthlyBudgetViewProps> = ({
                       <ChevronUp size={20} />
                     )}
                   </span>
-                  <span className="font-semibold text-[var(--text-default)] truncate">
+                  <span className="font-semibold text-[var(--text-default)] truncate" dir="auto">
                     {totalItem.rule.name}
                   </span>
                 </button>

--- a/frontend/src/components/budget/ProjectSpendChart.tsx
+++ b/frontend/src/components/budget/ProjectSpendChart.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import Plot from "react-plotly.js";
+import Plot from "../common/LazyPlot";
 import { BarChart3 } from "lucide-react";
 import i18n from "../../i18n";
 import { chartTheme, plotlyConfig, barMarker, CHART_COLORS } from "../../utils/plotlyLocale";

--- a/frontend/src/components/common/LazyPlot.tsx
+++ b/frontend/src/components/common/LazyPlot.tsx
@@ -1,0 +1,23 @@
+import { Suspense, lazy } from "react";
+import type { PlotParams } from "react-plotly.js";
+
+// Plotly is ~3 MB minified — loading it lazily keeps it out of the main
+// bundle (and under the Workbox per-file precache budget, see
+// .claude/rules/frontend_pwa.md). All chart components must import Plot
+// from here instead of "react-plotly.js" directly.
+const Plot = lazy(() => import("react-plotly.js"));
+
+export default function LazyPlot(props: PlotParams) {
+  return (
+    <Suspense
+      fallback={
+        <div
+          className="h-full w-full min-h-[120px] rounded-lg bg-[var(--surface-light)] animate-pulse"
+          style={props.style}
+        />
+      }
+    >
+      <Plot {...props} />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/common/LazyPlot.tsx
+++ b/frontend/src/components/common/LazyPlot.tsx
@@ -12,10 +12,10 @@ const Plot = lazy(importPlotly);
 // data queries instead of starting only when the first chart mounts.
 if (typeof window !== "undefined") {
   const warm = () => void importPlotly();
-  if ("requestIdleCallback" in window) {
+  if (typeof window.requestIdleCallback === "function") {
     window.requestIdleCallback(warm, { timeout: 2000 });
   } else {
-    window.setTimeout(warm, 1000);
+    setTimeout(warm, 1000);
   }
 }
 

--- a/frontend/src/components/common/LazyPlot.tsx
+++ b/frontend/src/components/common/LazyPlot.tsx
@@ -5,7 +5,19 @@ import type { PlotParams } from "react-plotly.js";
 // bundle (and under the Workbox per-file precache budget, see
 // .claude/rules/frontend_pwa.md). All chart components must import Plot
 // from here instead of "react-plotly.js" directly.
-const Plot = lazy(() => import("react-plotly.js"));
+const importPlotly = () => import("react-plotly.js");
+const Plot = lazy(importPlotly);
+
+// Warm the chunk right after first paint so its fetch/parse overlaps the
+// data queries instead of starting only when the first chart mounts.
+if (typeof window !== "undefined") {
+  const warm = () => void importPlotly();
+  if ("requestIdleCallback" in window) {
+    window.requestIdleCallback(warm, { timeout: 2000 });
+  } else {
+    window.setTimeout(warm, 1000);
+  }
+}
 
 export default function LazyPlot(props: PlotParams) {
   return (

--- a/frontend/src/components/common/MultiSelect.tsx
+++ b/frontend/src/components/common/MultiSelect.tsx
@@ -126,7 +126,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
               key={s}
               className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-[var(--primary)]/10 text-[var(--primary)] text-[10px] font-medium max-w-full"
             >
-              <span className="truncate">
+              <span className="truncate" dir="auto">
                 {s.length > 18 ? s.slice(0, 18) + "..." : s}
               </span>
               <button
@@ -199,7 +199,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
                       <Check size={10} className="text-white" />
                     )}
                   </div>
-                  <span className="truncate text-[var(--text-default)]">
+                  <span className="truncate text-[var(--text-default)]" dir="auto">
                     {opt}
                   </span>
                 </button>

--- a/frontend/src/components/dashboard/CashFlowForecastCard.tsx
+++ b/frontend/src/components/dashboard/CashFlowForecastCard.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import Plot from "react-plotly.js";
+import Plot from "../common/LazyPlot";
 import { TrendingUp, Wallet, CalendarClock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { analyticsApi } from "../../services/api";

--- a/frontend/src/components/dashboard/DashboardChartsPanel.tsx
+++ b/frontend/src/components/dashboard/DashboardChartsPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { TrendingDown, Calculator, Tag } from "lucide-react";
-import Plot from "react-plotly.js";
+import Plot from "../common/LazyPlot";
 import { analyticsApi, taggingApi } from "../../services/api";
 import { SankeyChart } from "../SankeyChart";
 import { Skeleton } from "../common/Skeleton";

--- a/frontend/src/components/investments/InvestmentAnalysisModal.tsx
+++ b/frontend/src/components/investments/InvestmentAnalysisModal.tsx
@@ -13,7 +13,7 @@ import {
   Check,
   BarChart2,
 } from "lucide-react";
-import Plot from "react-plotly.js";
+import Plot from "../common/LazyPlot";
 import { investmentsApi } from "../../services/api";
 import { chartTheme, plotlyConfig, gradientFill } from "../../utils/plotlyLocale";
 import { formatCurrency } from "../../utils/numberFormatting";

--- a/frontend/src/components/investments/PortfolioOverview.tsx
+++ b/frontend/src/components/investments/PortfolioOverview.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import { Wallet, DollarSign, Percent } from "lucide-react";
-import Plot from "react-plotly.js";
+import Plot from "../common/LazyPlot";
 import { investmentsApi } from "../../services/api";
 import { chartTheme, plotlyConfig, donutMarker, CHART_COLORS } from "../../utils/plotlyLocale";
 import { formatCurrency } from "../../utils/numberFormatting";

--- a/frontend/src/components/retirement/NetWorthProjectionChart.tsx
+++ b/frontend/src/components/retirement/NetWorthProjectionChart.tsx
@@ -1,4 +1,4 @@
-import Plot from "react-plotly.js";
+import Plot from "../common/LazyPlot";
 import { useTranslation } from "react-i18next";
 import { plotlyConfig, chartTheme, isTouchDevice } from "../../utils/plotlyLocale";
 

--- a/frontend/src/components/retirement/RetirementIncomeChart.tsx
+++ b/frontend/src/components/retirement/RetirementIncomeChart.tsx
@@ -1,4 +1,4 @@
-import Plot from "react-plotly.js";
+import Plot from "../common/LazyPlot";
 import { useTranslation } from "react-i18next";
 import { plotlyConfig, chartTheme, isTouchDevice, barMarker } from "../../utils/plotlyLocale";
 

--- a/frontend/src/components/transactions/RuleEditorModal.tsx
+++ b/frontend/src/components/transactions/RuleEditorModal.tsx
@@ -270,7 +270,7 @@ export function RuleEditorModal({ isOpen, onClose, editingRule, onSaved, prefill
                     {error && (
                         <div className={`flex-1 flex items-center gap-2 p-2.5 bg-red-500/10 border border-red-500/20 rounded-xl text-red-400 text-sm animate-in duration-200 ${isRtl ? "slide-in-from-right-2" : "slide-in-from-left-2"}`}>
                             <AlertTriangle size={16} className="shrink-0" />
-                            <span className="line-clamp-2">{error}</span>
+                            <span className="line-clamp-2" dir="auto">{error}</span>
                         </div>
                     )}
                     <div className="flex items-center gap-3 sm:ms-auto">

--- a/frontend/src/pages/Insurances.tsx
+++ b/frontend/src/pages/Insurances.tsx
@@ -16,7 +16,7 @@ import {
   X,
   RotateCcw,
 } from "lucide-react";
-import Plot from "react-plotly.js";
+import Plot from "../components/common/LazyPlot";
 import { chartTheme, plotlyConfig, barMarker, donutMarker } from "../utils/plotlyLocale";
 import { insuranceAccountsApi, transactionsApi, type InsuranceAccount } from "../services/api";
 import { formatDate } from "../utils/dateFormatting";

--- a/frontend/src/pages/Liabilities.tsx
+++ b/frontend/src/pages/Liabilities.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useScrollLock } from "../hooks/useScrollLock";
-import Plot from "react-plotly.js";
+import Plot from "../components/common/LazyPlot";
 import { chartTheme, plotlyConfig, donutMarker, CHART_COLORS } from "../utils/plotlyLocale";
 import {
   Plus,

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -12,6 +12,13 @@ import { createStore, get, set, del } from "idb-keyval";
 const NON_PERSISTABLE_KEY_PREFIXES = new Set<string>([
   "scrapingStatus",
   "scraping-status",
+  // Mirrors the SW's /api/scraping/* exclusion (rules/frontend_pwa.md says
+  // both cache layers must agree).
+  "last-scrapes",
+  // Hits /api/credentials/providers — mirrors the SW's /api/credentials*
+  // exclusion; the key itself doesn't contain "credential" so the heuristic
+  // below misses it.
+  "providers",
   "rule-preview",
   "rule-conflicts",
   "retirement-preview",
@@ -116,4 +123,6 @@ export function shouldDehydrateQuery(query: Query): boolean {
  * type was renamed). A mismatch causes the persister to discard the saved
  * cache instead of hydrating stale data into incompatible components.
  */
-export const PERSIST_BUSTER = "v1";
+// v2: "last-scrapes" and "providers" became non-persistable; discard caches
+// that still hold them.
+export const PERSIST_BUSTER = "v2";

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -197,8 +197,6 @@ export const taggingApi = {
     api.post(`/tagging-rules/rules/${id}/apply`, null, {
       params: { overwrite },
     }),
-  testRule: (conditions: ConditionNode[]) =>
-    api.post("/tagging-rules/rules/test", conditions),
   checkConflicts: (conditions: ConditionNode, category: string, tag: string, ruleId?: number) =>
     api.post("/tagging-rules/rules/validate", {
       conditions,

--- a/frontend/src/utils/chartTouchZoom.ts
+++ b/frontend/src/utils/chartTouchZoom.ts
@@ -1,4 +1,3 @@
-import Plotly from "plotly.js/dist/plotly";
 import i18n from "../i18n";
 
 /**
@@ -40,6 +39,18 @@ function isCartesian(gd: PlotlyGraphDiv): boolean {
   return Array.isArray(gd._fullLayout?.xaxis?.range);
 }
 
+/**
+ * Plotly is imported dynamically so this module doesn't pull the ~3 MB
+ * library into the main bundle (charts load it lazily via LazyPlot). By the
+ * time a chart can be touched, the chunk is already loaded — the dynamic
+ * import resolves from cache.
+ */
+function relayout(gd: PlotlyGraphDiv, layout: { dragmode: "zoom" | false }): void {
+  void import("plotly.js/dist/plotly").then(({ default: Plotly }) =>
+    Plotly.relayout(gd, layout)
+  );
+}
+
 export function installChartTouchZoom(): () => void {
   let pendingTime = 0;
   let pendingX = 0;
@@ -66,7 +77,7 @@ export function installChartTouchZoom(): () => void {
     zoomGd = gd;
     gd.classList.add("chart-zoom-active");
     showHint(gd);
-    void Plotly.relayout(gd, { dragmode: "zoom" });
+    relayout(gd, { dragmode: "zoom" });
   };
 
   const exitZoom = () => {
@@ -77,7 +88,7 @@ export function installChartTouchZoom(): () => void {
     hint?.remove();
     hint = null;
     // Drop back to scroll mode; the zoom itself stays (uirevision preserves it).
-    void Plotly.relayout(gd, { dragmode: false });
+    relayout(gd, { dragmode: false });
   };
 
   const onStart = (e: TouchEvent) => {
@@ -89,7 +100,7 @@ export function installChartTouchZoom(): () => void {
       // double-tap (its native reset). Re-assert dragmode in case a re-render
       // reset it back to the themed default.
       if (gd === zoomGd) {
-        if (gd._fullLayout?.dragmode !== "zoom") void Plotly.relayout(gd, { dragmode: "zoom" });
+        if (gd._fullLayout?.dragmode !== "zoom") relayout(gd, { dragmode: "zoom" });
         return;
       }
       // Touched elsewhere → leave zoom mode, then fall through so this touch is

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -115,5 +115,12 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
+    optimizeDeps: {
+      // Plotly is only reached through a dynamic import (LazyPlot), so the
+      // dev server's dependency scanner doesn't see it at startup. Without
+      // this, the first chart render triggers on-demand optimization and a
+      // full page reload mid-session.
+      include: ["react-plotly.js", "plotly.js/dist/plotly"],
+    },
   };
 });

--- a/scraper/utils/browser.py
+++ b/scraper/utils/browser.py
@@ -1,6 +1,10 @@
+import logging
+
 from playwright.async_api import Frame, Page
 
 from scraper.utils.waiting import wait_until
+
+logger = logging.getLogger(__name__)
 
 
 async def wait_until_element_found(
@@ -85,7 +89,8 @@ async def page_eval_all(
     """Evaluate a JS expression on all elements matching selector."""
     try:
         return await page_or_frame.eval_on_selector_all(selector, expression)
-    except Exception:
+    except Exception as e:
+        logger.debug("page_eval_all failed for selector %r: %s", selector, e)
         return default_result
 
 
@@ -98,7 +103,8 @@ async def page_eval(
     """Evaluate a JS expression on first element matching selector."""
     try:
         return await page_or_frame.eval_on_selector(selector, expression)
-    except Exception:
+    except Exception as e:
+        logger.debug("page_eval failed for selector %r: %s", selector, e)
         return default_result
 
 

--- a/tests/backend/integration/test_budget_month_override_pipeline.py
+++ b/tests/backend/integration/test_budget_month_override_pipeline.py
@@ -138,4 +138,53 @@ class TestBudgetMonthOverridePipeline:
         )
 
         mapping = override_svc.get_override_map()
-        assert mapping["transaction"][uid] == (2024, 2)
+        assert mapping["transaction"][("credit_card_transactions", uid)] == (2024, 2)
+
+    def test_override_does_not_leak_across_tables_with_same_uid(
+        self, db_session: Session, seed_base_transactions
+    ):
+        """Verify an override only moves the row in its own table.
+
+        ``unique_id`` is a per-table auto-increment, so the same integer
+        exists in the bank and credit-card tables. An override stored for a
+        credit-card transaction must not re-month the bank transaction that
+        happens to share its unique_id.
+        """
+        import pandas as pd
+
+        budget_svc = MonthlyBudgetService(db_session)
+        override_svc = BudgetMonthOverrideService(db_session)
+        uid = _cc_jan_5_uid(db_session)
+
+        # Stored for the credit-card table only (repo-level to keep the
+        # colliding bank uid fully synthetic and independent of seed dates).
+        override_svc.repo.upsert(
+            source_type="transaction",
+            source_id=uid,
+            source_table="credit_card_transactions",
+            override_year=2024,
+            override_month=2,
+        )
+
+        expenses = pd.DataFrame(
+            [
+                {
+                    "unique_id": uid,
+                    "source": "credit_card_transactions",
+                    "date": "2024-01-20",
+                    "amount": -250.0,
+                },
+                {
+                    "unique_id": uid,
+                    "source": "bank_transactions",
+                    "date": "2024-01-20",
+                    "amount": -99.0,
+                },
+            ]
+        )
+        result = budget_svc._apply_month_overrides(expenses)
+
+        cc_row = result[result["source"] == "credit_card_transactions"].iloc[0]
+        bank_row = result[result["source"] == "bank_transactions"].iloc[0]
+        assert int(cc_row["budget_month"]) == 2
+        assert int(bank_row["budget_month"]) == 1

--- a/tests/backend/unit/repositories/test_transactions_repository.py
+++ b/tests/backend/unit/repositories/test_transactions_repository.py
@@ -479,3 +479,158 @@ class TestGetTransactionById:
         repo = TransactionsRepository(db_session)
         with pytest.raises(ValueError, match="not found"):
             repo.get_transaction_by_id(99999)
+
+
+class TestPendingReconciliation:
+    """Tests for pending-row reconciliation in add_scraped_transactions."""
+
+    @staticmethod
+    def _scraped_df(rows):
+        """Build a scraped-transactions DataFrame from partial row dicts."""
+        import pandas as pd
+
+        defaults = {
+            "id": "txn-1",
+            "date": "2026-06-05",
+            "provider": "hapoalim",
+            "account_name": "Main",
+            "account_number": "123",
+            "description": "Coffee",
+            "amount": -100.0,
+            "category": None,
+            "tag": None,
+            "source": "bank_transactions",
+            "type": "normal",
+            "status": "completed",
+        }
+        return pd.DataFrame([{**defaults, **row} for row in rows])
+
+    @staticmethod
+    def _add_bank_row(db_session, **overrides):
+        """Insert a BankTransaction directly and return it."""
+        from backend.models.transaction import BankTransaction
+
+        fields = {
+            "id": "txn-1",
+            "date": "2026-06-05",
+            "provider": "hapoalim",
+            "account_name": "Main",
+            "description": "Coffee",
+            "amount": -100.0,
+            "source": "bank_transactions",
+            "type": "normal",
+            "status": "pending",
+        }
+        fields.update(overrides)
+        row = BankTransaction(**fields)
+        db_session.add(row)
+        db_session.commit()
+        return row
+
+    def test_settled_pending_row_replaced(self, db_session):
+        """A pending row settling with a new amount is purged, not duplicated."""
+        from backend.models.transaction import BankTransaction
+
+        self._add_bank_row(db_session, amount=-100.0, status="pending")
+        repo = TransactionsRepository(db_session)
+
+        df = self._scraped_df([{"amount": -105.0, "status": "completed"}])
+        repo.add_scraped_transactions(df, "bank_transactions", scrape_start_date="2026-06-01")
+
+        rows = db_session.query(BankTransaction).all()
+        assert len(rows) == 1
+        assert rows[0].status == "completed"
+        assert rows[0].amount == -105.0
+
+    def test_still_pending_row_reinserted_with_carried_tag(self, db_session):
+        """A re-reported pending row keeps the user's category and tag."""
+        from backend.models.transaction import BankTransaction
+
+        self._add_bank_row(db_session, status="pending", category="Food", tag="Coffee")
+        repo = TransactionsRepository(db_session)
+
+        df = self._scraped_df([{"status": "pending"}])
+        repo.add_scraped_transactions(df, "bank_transactions", scrape_start_date="2026-06-01")
+
+        rows = db_session.query(BankTransaction).all()
+        assert len(rows) == 1
+        assert rows[0].status == "pending"
+        assert rows[0].category == "Food"
+        assert rows[0].tag == "Coffee"
+
+    def test_pending_outside_window_untouched(self, db_session):
+        """Pending rows older than the scraped window are not purged."""
+        from backend.models.transaction import BankTransaction
+
+        self._add_bank_row(db_session, id="old", date="2026-05-01", status="pending")
+        repo = TransactionsRepository(db_session)
+
+        df = self._scraped_df([{"id": "new", "date": "2026-06-05"}])
+        repo.add_scraped_transactions(df, "bank_transactions", scrape_start_date="2026-06-01")
+
+        rows = {r.id: r for r in db_session.query(BankTransaction).all()}
+        assert set(rows) == {"old", "new"}
+        assert rows["old"].status == "pending"
+
+    def test_split_parent_pending_not_purged(self, db_session):
+        """A split pending row is never purged (splits reference it)."""
+        from backend.models.transaction import BankTransaction
+
+        self._add_bank_row(db_session, id="split", type="split_parent", status="pending")
+        repo = TransactionsRepository(db_session)
+
+        df = self._scraped_df([{"id": "new"}])
+        repo.add_scraped_transactions(df, "bank_transactions", scrape_start_date="2026-06-01")
+
+        ids = {r.id for r in db_session.query(BankTransaction).all()}
+        assert ids == {"split", "new"}
+
+    def test_refund_locked_pending_not_purged(self, db_session):
+        """A pending row referenced by a pending refund is never purged."""
+        from backend.models.pending_refund import PendingRefund
+        from backend.models.transaction import BankTransaction
+
+        row = self._add_bank_row(db_session, id="locked", status="pending")
+        db_session.add(
+            PendingRefund(
+                source_type="transaction",
+                source_id=row.unique_id,
+                source_table="bank_transactions",
+                expected_amount=100.0,
+            )
+        )
+        db_session.commit()
+        repo = TransactionsRepository(db_session)
+
+        df = self._scraped_df([{"id": "new"}])
+        repo.add_scraped_transactions(df, "bank_transactions", scrape_start_date="2026-06-01")
+
+        ids = {r.id for r in db_session.query(BankTransaction).all()}
+        assert ids == {"locked", "new"}
+
+    def test_completed_rows_unaffected(self, db_session):
+        """Completed rows in the window are never reconciled away."""
+        from backend.models.transaction import BankTransaction
+
+        self._add_bank_row(db_session, id="done", status="completed")
+        repo = TransactionsRepository(db_session)
+
+        df = self._scraped_df([{"id": "new"}])
+        repo.add_scraped_transactions(df, "bank_transactions", scrape_start_date="2026-06-01")
+
+        ids = {r.id for r in db_session.query(BankTransaction).all()}
+        assert ids == {"done", "new"}
+
+    def test_no_window_start_falls_back_to_df_min_date(self, db_session):
+        """Without an explicit window the earliest scraped date bounds the purge."""
+        from backend.models.transaction import BankTransaction
+
+        self._add_bank_row(db_session, id="older", date="2026-06-01", status="pending")
+        self._add_bank_row(db_session, id="inside", date="2026-06-04", status="pending")
+        repo = TransactionsRepository(db_session)
+
+        df = self._scraped_df([{"id": "new", "date": "2026-06-03"}])
+        repo.add_scraped_transactions(df, "bank_transactions")
+
+        ids = {r.id for r in db_session.query(BankTransaction).all()}
+        assert ids == {"older", "new"}

--- a/tests/backend/unit/repositories/test_transactions_repository.py
+++ b/tests/backend/unit/repositories/test_transactions_repository.py
@@ -634,3 +634,41 @@ class TestPendingReconciliation:
 
         ids = {r.id for r in db_session.query(BankTransaction).all()}
         assert ids == {"older", "new"}
+
+    def test_duplicate_tuple_pending_rows_do_not_multiply_inserts(self, db_session):
+        """Two tagged pending rows sharing (id,provider,date,amount) don't explode.
+
+        Migration d4f6a8c0e2b5 allows two distinct transactions with the same
+        (id, provider, date, amount) tuple (e.g. identical same-day ATM
+        withdrawals with empty reference ids). If both are pending and tagged,
+        the tag-carry-over left-join must not cartesian-multiply the re-scraped
+        rows into extra inserts.
+        """
+        from backend.models.transaction import BankTransaction
+
+        # Two pending rows with an identical composite key, both tagged.
+        self._add_bank_row(
+            db_session, id="dup", amount=-200.0, status="pending",
+            category="Cash", tag="ATM",
+        )
+        self._add_bank_row(
+            db_session, id="dup", amount=-200.0, status="pending",
+            category="Cash", tag="ATM",
+        )
+        repo = TransactionsRepository(db_session)
+
+        # Re-scrape reports the same two settled rows.
+        df = self._scraped_df(
+            [
+                {"id": "dup", "amount": -200.0, "status": "completed"},
+                {"id": "dup", "amount": -200.0, "status": "completed"},
+            ]
+        )
+        repo.add_scraped_transactions(df, "bank_transactions", scrape_start_date="2026-06-01")
+
+        rows = db_session.query(BankTransaction).all()
+        # Exactly two rows persist (no cartesian blow-up), both settled and
+        # both keep the carried-over tag.
+        assert len(rows) == 2
+        assert all(r.status == "completed" for r in rows)
+        assert all(r.category == "Cash" and r.tag == "ATM" for r in rows)


### PR DESCRIPTION
Two verification-driven audit sweeps of the repo (backend, frontend, scraper, config) plus a rebase onto `main`. Every finding was confirmed against the actual code path before being fixed; the high-value items came from running the build, measuring timings, and reading the dense financial logic rather than from pattern-matching.

## Correctness bugs

- **Pending scraped transactions were double-counted.** Ten providers emit `pending` rows that are saved like any other transaction and counted in every KPI, but nothing ever reconciled them. When a pending charge settled with a different amount or date (FX conversion, fuel-station holds, pending vs. processing date), the duplicate check on `(id, provider, date, amount)` missed it and **both** rows persisted permanently. `add_scraped_transactions` now treats each scrape as authoritative for its window: stale pending rows for the scraped provider/account are deleted, still-pending rows are re-reported and re-inserted, and any user-assigned category/tag is carried over by composite key. Split parents and rows referenced by a pending refund are never purged.
- **Budget month overrides leaked across tables.** `unique_id` is a per-table auto-increment, so bank #5 and credit-card #5 are different transactions. The override lookup map was keyed by bare `unique_id`, so an override stored for a credit-card transaction could re-month the bank transaction sharing its id. Now keyed by `(source_table, unique_id)` end-to-end.
- **`update_project` 500'd instead of 404'ing** when a project had no total-budget rule (unhandled `IndexError` on `.iloc[0]`). Now raises `EntityNotFoundException`.

## Performance

- **Main JS bundle 5.8 MB → 1.1 MB.** Plotly (~4.9 MB) was statically imported by every chart component, forcing it into the app-shell chunk. All charts now route through a new `LazyPlot` wrapper (`React.lazy` + Suspense skeleton), `chartTouchZoom` imports Plotly dynamically, and the chunk is warmed on idle after first paint so charts still appear promptly. `vite.config` pre-bundles it in dev to avoid a mid-session reload. This was the documented engineering-debt item in the PWA rules.
- **`GET /investments/` N+1 removed.** It ran 2–3 DB queries *per investment* (snapshot lookup + full four-table transaction merge each). Now batched into three fixed queries regardless of portfolio size.

## Frontend correctness & hygiene

- **RTL truncation:** added `dir="auto"` to `truncate`/`line-clamp` elements holding user data (MultiSelect labels, budget rule name, rule-editor error) so Hebrew clips the correct end.
- **PWA cache parity:** `last-scrapes` and `providers` queries were runtime-cached by the service worker but not excluded from the IndexedDB persister (the two layers must agree). Added to the persister exclusion list and bumped `PERSIST_BUSTER`.
- Removed a dead `testRule` API client method with no backend route or callers.

## Robustness & docs

- Logged previously-swallowed exceptions in pending-refund enrichment and the scraper's `page_eval` helpers; replaced a hardcoded `/Users/tomer/...` path in `alembic.ini` with a neutral placeholder.
- Documented the `unique_id`-is-per-table pitfall in `.claude/rules/backend_repositories.md` and `CLAUDE.md` (it had caused bugs more than once).

## Rebase hardening

After rebasing onto `main`, a clean (conflict-free) auto-merge turned out to be semantically wrong: upstream migration `d4f6a8c0e2b5` deliberately drops the `(id, provider, date, amount)` unique constraint because two distinct transactions can share that tuple (identical same-day ATM withdrawals with empty reference ids). That makes the tag-carry-over left-join in the new pending reconciliation able to cartesian-multiply a re-scraped row into duplicate inserts. Fixed by collapsing duplicate keys before the join, with a regression test proven to fail without the fix.

## Verification

- Backend: **1219 pytest tests** pass (incl. new pending-reconciliation and per-table-override regression tests).
- Frontend: ESLint, `tsc -b`, **194 vitest tests**, and production build all clean.
- Playwright e2e: full suite green against live servers (new `lazy-plotly` spec covers chart hydration on four pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bua76X1nxtxGsSJW2DSN5e