### PR TITLE
fix(scraper): sync discount, leumi, visa-cal, yahav with upstream

### DIFF
--- a/.claude/skills/sync-upstream-scraper/SKILL.md
+++ b/.claude/skills/sync-upstream-scraper/SKILL.md
@@ -16,6 +16,26 @@ When invoked, immediately execute the workflow below. Do not just display refere
 - `<provider>` -- sync a specific provider (e.g., `hapoalim`, `max`, `visa-cal`)
 - `--base` -- check base classes and framework files only
 
+## Sync State Manifest
+
+`scraper/upstream_sync.json` records the single **upstream commit our ports
+were last checked against**:
+
+```json
+{
+  "repo": "eshaham/israeli-bank-scrapers",
+  "last_checked_commit": "<upstream HEAD sha at last sync pass>",
+  "last_checked_date": "YYYY-MM-DD"
+}
+```
+
+This is the source of truth for "when did we last sync". The scan diffs
+`last_checked_commit` against upstream HEAD via the GitHub compare API, which
+returns exactly the `src/scrapers/*` files that changed in between -- no
+guessing from our own git history. **Bump `last_checked_commit` to the current
+upstream HEAD after each sync pass** (see Step 8). The manifest is committed
+alongside the code so the checked-state travels with the ports.
+
 ## Provider Name Mapping
 
 | Upstream TS file | Local Python file |
@@ -48,14 +68,19 @@ When invoked, immediately execute the workflow below. Do not just display refere
 
 ## Execution: Scan All Providers (no args)
 
-**Step 1:** Run the bulk scan to get last commit date per upstream provider:
+**Step 1:** Diff our last-checked commit against upstream HEAD. The compare API
+returns exactly the `src/scrapers/*` files that changed in between -- those are
+the providers that need attention:
 
 ```bash
-for f in hapoalim leumi discount mercantile mizrahi otsar-hahayal union-bank beinleumi massad yahav pagi one-zero max visa-cal isracard amex beyahad-bishvilha behatsdaa base-scraper base-scraper-with-browser interface; do
-  date=$(gh api "repos/eshaham/israeli-bank-scrapers/commits?path=src/scrapers/${f}.ts&per_page=1" --jq '.[0].commit.committer.date[:10]' 2>/dev/null)
-  echo "$date  $f"
-done | sort -r
+LAST=$(jq -r '.last_checked_commit' scraper/upstream_sync.json)
+gh api "repos/eshaham/israeli-bank-scrapers/compare/${LAST}...master" \
+  --jq '.files[].filename' | grep '^src/scrapers/' | grep -vE '\.test\.ts$'
 ```
+
+If the output is empty, nothing changed upstream since the last check -- you're
+done. Otherwise, map each changed file to its local port (see the mapping
+table) and proceed to the single-provider flow for each.
 
 **Step 2:** Also check for new upstream providers not yet ported:
 
@@ -66,12 +91,13 @@ gh api "repos/eshaham/israeli-bank-scrapers/git/trees/master?recursive=1" \
 
 Compare against the mapping table. Flag any files that don't have a local counterpart.
 
-**Step 3:** Present a summary table to the user:
+**Step 3:** Present a summary table to the user of the providers that changed
+since `last_checked_commit`:
 
-| Provider | Last Upstream Change | Status |
+| Provider | Changed Files | Notes |
 |---|---|---|
-| hapoalim | 2026-02-15 | May need update |
-| max | 2026-01-03 | Likely current |
+| yahav | src/scrapers/yahav.ts | datepicker + multi-portfolio |
+| discount | src/scrapers/discount.ts | new login URLs |
 | ... | ... | ... |
 
 Ask the user which provider(s) to sync. Then proceed to the single-provider flow below.
@@ -130,4 +156,18 @@ Always prefer framework utilities over raw Playwright:
 
 **Step 7 - Verify:** Run `poetry run pytest tests/backend/unit/test_scraper/ -v` to check nothing broke.
 
-**Step 8 - Commit:** `git commit -m "fix(scraper): update <provider> to match upstream changes"`
+**Step 8 - Update the sync manifest:** Once you've reconciled every changed
+provider in this pass (ported or confirmed equivalent), bump
+`last_checked_commit` to the current upstream HEAD so the next scan diffs from
+here. Only advance the pointer when **all** files surfaced by the Step 1 diff
+have been handled -- otherwise the unhandled ones silently drop off the radar.
+
+```bash
+read head_sha head_date < <(gh api repos/eshaham/israeli-bank-scrapers/commits/master --jq '"\(.sha) \(.commit.committer.date[:10])"')
+jq --arg c "$head_sha" --arg d "$(date +%F)" \
+  '.last_checked_commit = $c | .last_checked_date = $d' \
+  scraper/upstream_sync.json > scraper/upstream_sync.json.tmp && mv scraper/upstream_sync.json.tmp scraper/upstream_sync.json
+```
+
+**Step 9 - Commit:** Stage the provider file(s) **and** the manifest together:
+`git commit -m "fix(scraper): update <provider> to match upstream changes"`

--- a/scraper/providers/banks/discount.py
+++ b/scraper/providers/banks/discount.py
@@ -205,6 +205,8 @@ def _get_possible_login_results() -> dict[LoginResult, list]:
             f"{BASE_URL}/apollo/retail/#/MY_ACCOUNT_HOMEPAGE",
             f"{BASE_URL}/apollo/retail2/#/MY_ACCOUNT_HOMEPAGE",
             f"{BASE_URL}/apollo/retail2/",
+            f"{BASE_URL}/apollo/retail3/#/MY_ACCOUNT_HOMEPAGE",
+            f"{BASE_URL}/apollo/retail3/",
         ],
         LoginResult.INVALID_PASSWORD: [
             f"{BASE_URL}/apollo/core/templates/lobby/masterPage.html#/LOGIN_PAGE",

--- a/scraper/providers/banks/leumi.py
+++ b/scraper/providers/banks/leumi.py
@@ -44,6 +44,11 @@ INVALID_PASSWORD_MSG = (
 
 SHEKEL_CURRENCY = "ILS"
 
+# Leumi redesigned its forced-password-change flow (upstream 2026-05-31,
+# commit ddec311). The old URL/`form[action="/changepassword"]` markers no
+# longer match; the modal is now detected by the new-password input field.
+CHANGE_PASSWORD_MODAL_SELECTOR = 'form input[name="newPwd"]'
+
 
 def _remove_special_characters(s: str) -> str:
     """Remove non-numeric characters except dash and slash."""
@@ -151,7 +156,7 @@ async def _wait_for_post_login(page) -> None:
             ),
             asyncio.create_task(
                 wait_until_element_found(
-                    page, 'form[action="/changepassword"]', only_visible=True, timeout=60000
+                    page, CHANGE_PASSWORD_MODAL_SELECTOR, only_visible=True, timeout=60000
                 )
             ),
         ],
@@ -191,11 +196,15 @@ def _get_possible_login_results(page) -> dict[LoginResult, list]:
         )
         return bool(error_message and error_message.startswith(ACCOUNT_BLOCKED_MSG))
 
+    async def is_change_password(**kwargs):
+        target = kwargs.get("page", page)
+        return bool(await target.query_selector(CHANGE_PASSWORD_MODAL_SELECTOR))
+
     return {
         LoginResult.SUCCESS: [re.compile(r"ebanking/SO/SPA\.aspx", re.IGNORECASE)],
         LoginResult.INVALID_PASSWORD: [is_invalid_password],
         LoginResult.ACCOUNT_BLOCKED: [is_account_blocked],
-        LoginResult.CHANGE_PASSWORD: ["https://hb2.bankleumi.co.il/authenticate"],
+        LoginResult.CHANGE_PASSWORD: [is_change_password],
     }
 
 

--- a/scraper/providers/banks/yahav.py
+++ b/scraper/providers/banks/yahav.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from datetime import date, datetime, timedelta
+
+from dateutil.relativedelta import relativedelta
 
 from scraper.base import BrowserScraper, LoginOptions
 from scraper.models.account import AccountResult
@@ -11,6 +14,7 @@ from scraper.models.transaction import Transaction, TransactionStatus, Transacti
 from scraper.utils import (
     click_button,
     element_present_on_page,
+    page_eval,
     page_eval_all,
     wait_for_navigation,
     wait_until_element_disappear,
@@ -27,11 +31,22 @@ INVALID_DETAILS_SELECTOR = ".ui-dialog-buttons"
 CHANGE_PASSWORD_OLD_PASS = "input#ef_req_parameter_old_credential"
 BASE_WELCOME_URL = f"{BASE_URL}main/home"
 
-ACCOUNT_ID_SELECTOR = (
-    'span.portfolio-value[ng-if="mainController.data.portfolioList.length === 1"]'
+# Portfolio selectors (upstream 2026-06-12, commit 4521667). Multi-portfolio
+# accounts render an <inline-drop-down> inside form[name="formPortfolioSelect"]
+# with the current portfolio at .selected-item-top and the others as <li>s;
+# single-portfolio accounts render only the single value span.
+PORTFOLIO_FORM = 'form[name="formPortfolioSelect"]'
+ACCOUNT_ID_SELECTOR_SINGLE = "span.portfolio-value"
+ACCOUNT_ID_SELECTOR_MULTI = f"{PORTFOLIO_FORM} .selected-item-top"
+PORTFOLIO_OPTION_SELECTOR = (
+    f"{PORTFOLIO_FORM} .drop-down-item-list li.drop-down-item"
 )
 ACCOUNT_DETAILS_SELECTOR = ".account-details"
 DATE_FORMAT = "%d/%m/%Y"
+
+# All datepicker selectors are scoped to the "from date" control to avoid
+# ambiguity with the "to date" picker.
+FROM_PICKER = 'date-picker-access[btn-label="from"]'
 
 USER_ELEM = "#username"
 PASSWD_ELEM = "#password"
@@ -177,8 +192,6 @@ async def _redirect_or_dialog(page) -> None:
     page : Page
         Playwright page instance.
     """
-    import asyncio
-
     await wait_for_navigation(page)
     await wait_until_element_disappear(page, ".loading-bar-spinner")
 
@@ -209,8 +222,12 @@ async def _redirect_or_dialog(page) -> None:
     await wait_until_element_disappear(page, ".loading-bar-spinner")
 
 
-async def _get_account_id(page) -> str:
-    """Extract the account ID from the page.
+async def _get_portfolio_ids(page) -> list[str]:
+    """Snapshot the list of portfolio IDs available on the home page.
+
+    The dropdown only lists *unselected* portfolios, so the IDs are captured
+    up front (selected-first) before any portfolio switch loses the ones not
+    yet scraped. Single-portfolio accounts render only the single value span.
 
     Parameters
     ----------
@@ -219,27 +236,73 @@ async def _get_account_id(page) -> str:
 
     Returns
     -------
-    str
-        The account ID text.
+    list[str]
+        Portfolio IDs, selected portfolio first. Empty if none found.
     """
-    try:
-        element = await page.query_selector(ACCOUNT_ID_SELECTOR)
-        if element:
-            text = await element.text_content()
-            return text or ""
-    except Exception as e:
-        raise Exception(
-            f"Failed to retrieve account ID. "
-            f"Possible outdated selector '{ACCOUNT_ID_SELECTOR}': {e}"
-        )
-    raise Exception(
-        f"Failed to retrieve account ID. "
-        f"Possible outdated selector '{ACCOUNT_ID_SELECTOR}'"
+    done, pending = await asyncio.wait(
+        [
+            asyncio.create_task(
+                page.wait_for_selector(ACCOUNT_ID_SELECTOR_MULTI, timeout=10000)
+            ),
+            asyncio.create_task(
+                page.wait_for_selector(ACCOUNT_ID_SELECTOR_SINGLE, timeout=10000)
+            ),
+        ],
+        return_when=asyncio.FIRST_COMPLETED,
     )
+    for task in pending:
+        task.cancel()
+    for task in done:
+        task.exception()  # consume any exception so it isn't logged as unretrieved
+
+    selected_el = await page.query_selector(ACCOUNT_ID_SELECTOR_MULTI)
+    if selected_el:
+        selected = ((await selected_el.text_content()) or "").strip()
+        if selected:
+            option_els = await page.query_selector_all(PORTFOLIO_OPTION_SELECTOR)
+            others = [
+                ((await el.text_content()) or "").strip() for el in option_els
+            ]
+            return [pid for pid in [selected, *others] if pid]
+
+    single_el = await page.query_selector(ACCOUNT_ID_SELECTOR_SINGLE)
+    if single_el:
+        single = ((await single_el.text_content()) or "").strip()
+        return [single] if single else []
+    return []
+
+
+async def _select_portfolio(page, target_id: str) -> None:
+    """Select a portfolio by its ID from the dropdown.
+
+    Angular's listItemAction navigates the page back to /main/home with the
+    new portfolio selected, so the caller must re-enter the statements flow
+    after this returns.
+
+    Parameters
+    ----------
+    page : Page
+        Playwright page instance.
+    target_id : str
+        The portfolio ID (trimmed text) to select.
+    """
+    option_els = await page.query_selector_all(PORTFOLIO_OPTION_SELECTOR)
+    for el in option_els:
+        text = ((await el.text_content()) or "").strip()
+        if text == target_id:
+            await el.click()
+            await wait_until_element_disappear(page, ".loading-bar-spinner")
+            return
+    raise Exception(f"Portfolio option not found for ID: {target_id}")
 
 
 async def _search_by_dates(page, start_date: date) -> None:
-    """Manipulate the calendar dropdown to set the start date.
+    """Set the "from" date by stepping the datepicker calendar back.
+
+    Opens the "from" picker, reads its current input value (always
+    ``DD/MM/YYYY``) to learn which month it opened on, steps back the required
+    number of months, then clicks the target day. Reading the input value
+    avoids parsing the header text, which renders in the account's locale.
 
     Parameters
     ----------
@@ -248,64 +311,36 @@ async def _search_by_dates(page, start_date: date) -> None:
     start_date : date
         The start date for the transaction search.
     """
-    start_day = str(start_date.day)
-    start_month = str(start_date.month)
-    start_year = str(start_date.year)
-
-    # Open the calendar date picker
-    date_from_pick = (
-        "div.date-options-cell:nth-child(7) > date-picker:nth-child(1) "
-        "> div:nth-child(1) > span:nth-child(2)"
-    )
-    await wait_until_element_found(page, date_from_pick, only_visible=True)
-    await click_button(page, date_from_pick)
-
-    # Wait for days to appear
+    open_button = f"{FROM_PICKER} a.datepicker-button"
+    await wait_until_element_found(page, open_button, only_visible=True)
+    await click_button(page, open_button)
     await wait_until_element_found(
-        page, ".pmu-days > div:nth-child(1)", only_visible=True
+        page, f"{FROM_PICKER} .datepicker-calendar", only_visible=True
     )
 
-    # Open months view
-    month_from_pick = ".pmu-month"
-    await wait_until_element_found(page, month_from_pick, only_visible=True)
-    await click_button(page, month_from_pick)
-    await wait_until_element_found(
-        page, ".pmu-months > div:nth-child(1)", only_visible=True
+    input_value = await page_eval(
+        page, f"{FROM_PICKER} .date-picker-input", "el => el.value", ""
     )
+    try:
+        displayed = datetime.strptime(input_value, "%d/%m/%Y").date()
+    except (ValueError, TypeError):
+        displayed = date.today()
 
-    # Open years view
-    await wait_until_element_found(page, month_from_pick, only_visible=True)
-    await click_button(page, month_from_pick)
-    await wait_until_element_found(
-        page, ".pmu-years > div:nth-child(1)", only_visible=True
+    months_to_go_back = (displayed.year - start_date.year) * 12 + (
+        displayed.month - start_date.month
     )
+    prev_month_selector = f"{FROM_PICKER} .datepicker-month-prev.enabled"
+    for _ in range(max(0, months_to_go_back)):
+        await wait_until_element_found(page, prev_month_selector, only_visible=True)
+        await click_button(page, prev_month_selector)
 
-    # Select year from the 12-year grid
-    for i in range(1, 13):
-        selector = f".pmu-years > div:nth-child({i})"
-        element = await page.query_selector(selector)
-        if element:
-            year_text = await element.inner_text()
-            if start_year == year_text:
-                await click_button(page, selector)
-                break
-
-    # Select month (1-indexed: January = 1)
-    await wait_until_element_found(
-        page, ".pmu-months > div:nth-child(1)", only_visible=True
+    # :not(.other-month) avoids adjacent-month cells sharing the same day number.
+    day_selector = (
+        f'{FROM_PICKER} .datepicker-calendar td.day.selectable:not(.other-month)'
+        f'[data-value="{start_date.day}"]'
     )
-    month_selector = f".pmu-months > div:nth-child({start_month})"
-    await click_button(page, month_selector)
-
-    # Select day from the calendar grid (up to 42 cells)
-    for i in range(1, 43):
-        selector = f".pmu-days > div:nth-child({i})"
-        element = await page.query_selector(selector)
-        if element:
-            day_text = await element.inner_text()
-            if start_day == day_text:
-                await click_button(page, selector)
-                break
+    await wait_until_element_found(page, day_selector, only_visible=True)
+    await click_button(page, day_selector)
 
 
 async def _get_account_transactions(page) -> list[Transaction]:
@@ -390,6 +425,50 @@ async def _fetch_account_data(
     )
 
 
+async def _fetch_accounts(page, start_date: date) -> list[AccountResult]:
+    """Iterate every portfolio, entering the statements flow for each.
+
+    Portfolio IDs are snapshotted up front (the dropdown only lists the
+    unselected portfolios, so after the first switch the rest would be lost).
+    For each portfolio the statements page is (re-)entered, since selecting a
+    portfolio navigates back to /main/home.
+
+    Parameters
+    ----------
+    page : Page
+        Playwright page instance.
+    start_date : date
+        Earliest transaction date.
+
+    Returns
+    -------
+    list[AccountResult]
+        One result per portfolio.
+    """
+    portfolio_ids = await _get_portfolio_ids(page)
+    if not portfolio_ids:
+        raise Exception(
+            "No portfolios found on /main/home — Yahav DOM likely changed"
+        )
+
+    accounts: list[AccountResult] = []
+    for i, portfolio_id in enumerate(portfolio_ids):
+        if i > 0:
+            await _select_portfolio(page, portfolio_id)
+        await wait_until_element_found(
+            page, ACCOUNT_DETAILS_SELECTOR, only_visible=True
+        )
+        await click_button(page, ACCOUNT_DETAILS_SELECTOR)
+        await wait_until_element_found(
+            page, ".statement-options .selected-item-top", only_visible=True
+        )
+        accounts.append(
+            await _fetch_account_data(page, start_date, portfolio_id)
+        )
+
+    return accounts
+
+
 class YahavScraper(BrowserScraper):
     """Scraper for Yahav Bank (https://www.yahav.co.il).
 
@@ -432,25 +511,18 @@ class YahavScraper(BrowserScraper):
         Returns
         -------
         list[AccountResult]
-            List of accounts with their transactions.
+            One result per portfolio, each with its transactions.
         """
-        # Navigate to account details / statements page
+        # Wait for the home page; the statements flow is (re-)entered per
+        # portfolio inside _fetch_accounts.
         await wait_until_element_found(
             self.page, ACCOUNT_DETAILS_SELECTOR, only_visible=True
         )
-        await click_button(self.page, ACCOUNT_DETAILS_SELECTOR)
-        await wait_until_element_found(
-            self.page, ".statement-options .selected-item-top", only_visible=True
-        )
 
-        default_start = date.today() - timedelta(days=90 - 1)
-        effective_start = max(
-            default_start, self.options.start_date or default_start
-        )
+        default_start = date.today() - relativedelta(months=3) + timedelta(days=1)
+        start = self.options.start_date or default_start
+        # Clamp to [default_start, today]: never earlier than the default
+        # window, never in the future.
+        effective_start = min(max(default_start, start), date.today())
 
-        account_id = await _get_account_id(self.page)
-        account = await _fetch_account_data(
-            self.page, effective_start, account_id
-        )
-
-        return [account]
+        return await _fetch_accounts(self.page, effective_start)

--- a/scraper/providers/credit_cards/visa_cal.py
+++ b/scraper/providers/credit_cards/visa_cal.py
@@ -67,6 +67,14 @@ INVALID_PASSWORD_MESSAGE = (
 
 X_SITE_ID = "09031987-273E-2311-906C-8AF85B17C8D9"
 
+# Forced-password-change detection. Upstream (2026-06-14, commit 809513e)
+# expanded this from a single subtitle check to four signals — the modal can
+# surface as a frame route, an Angular component, a title, or a subtitle — plus
+# the legacy ``.err-desc`` message.
+CHANGE_PASSWORD_URL = "/change-password"
+CHANGE_PASSWORD_SUBTITLE = "הגיע הזמן לסיסמה חדשה"
+CHANGE_PASSWORD_MESSAGE = "להחליף סיסמה"
+
 
 class TrnTypeCode(str, Enum):
     """Visa Cal transaction type codes."""
@@ -250,7 +258,14 @@ async def _has_invalid_password_error(page) -> bool:
 
 
 async def _has_change_password_form(page) -> bool:
-    """Check if change password form is displayed.
+    """Check if a forced password-change prompt is displayed.
+
+    Mirrors upstream's multi-signal detection: a frame navigated to the
+    change-password route, the ``change-password`` Angular component, a
+    ``.change-password-title``/``.change-password-subtitle`` element, or the
+    legacy ``.err-desc`` message. The login frame may already be gone by the
+    time this runs (it navigates to the change-password route), so the frame
+    URL scan happens first and the rest is guarded.
 
     Parameters
     ----------
@@ -260,10 +275,38 @@ async def _has_change_password_form(page) -> bool:
     Returns
     -------
     bool
-        True if change password form is present.
+        True if a change-password prompt is present.
     """
-    frame = await _get_login_frame(page)
-    return await element_present_on_page(frame, ".change-password-subtitle")
+    for frame in page.frames:
+        url = frame.url or ""
+        if "connect.cal-online.co.il" in url and CHANGE_PASSWORD_URL in url:
+            return True
+
+    try:
+        frame = await _get_login_frame(page)
+
+        if await element_present_on_page(frame, "change-password"):
+            return True
+
+        if await element_present_on_page(frame, ".change-password-title"):
+            return True
+
+        if await element_present_on_page(frame, ".change-password-subtitle"):
+            subtitle_text = await page_eval(
+                frame, ".change-password-subtitle", "el => el.innerText.trim()", ""
+            )
+            if CHANGE_PASSWORD_SUBTITLE in subtitle_text:
+                return True
+
+        if await element_present_on_page(frame, ".err-desc"):
+            err_text = await page_eval(
+                frame, ".err-desc", "el => el.innerText.trim()", ""
+            )
+            return CHANGE_PASSWORD_MESSAGE in err_text
+    except Exception as exc:
+        logger.debug("failed to check change password form in login frame: %s", exc)
+
+    return False
 
 
 def _get_possible_login_results(page) -> dict[LoginResult, list]:

--- a/scraper/upstream_sync.json
+++ b/scraper/upstream_sync.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Records the upstream eshaham/israeli-bank-scrapers commit our scraper ports were last checked against. The `sync-upstream-scraper` skill diffs this commit against upstream HEAD (via the compare API) to find which src/scrapers/* files changed since. Bump `last_checked_commit` to the current upstream HEAD after each sync pass.",
+  "repo": "eshaham/israeli-bank-scrapers",
+  "last_checked_commit": "d9d8f51b4dd9bc14ea1acc20e1a5dd73257b2cef",
+  "last_checked_date": "2026-06-20"
+}


### PR DESCRIPTION
## What & why

Synced our Python scraper port against the upstream `eshaham/israeli-bank-scrapers` TypeScript source (followed the `sync-upstream-scraper` workflow). Scanned all 22 upstream files; four had real functional drift and are ported here. The rest (incl. **hapoalim** and the base classes) are already functionally identical to current upstream — their recent upstream commits were just `uuid→crypto.randomUUID()` / ESLint chores.

## Changes

- **discount** — add the two `retail3` success-login URLs (upstream 2026-06-15). Users landing on the new lobby were being misclassified as login failures.
- **leumi** — detect the redesigned forced-password-change modal via `form input[name="newPwd"]` instead of the stale URL / `form[action="/changepassword"]` markers (upstream 2026-05-31). Updated both the post-login race and the login-result predicate.
- **visa-cal** — expand `_has_change_password_form` from a single subtitle check to upstream's 4 signals (frame route, Angular component, title, subtitle text) + the legacy `.err-desc` message, guarded so a vanished login frame doesn't throw (upstream 2026-06-14).
- **yahav** — adopt the `4521667` rewrite (upstream 2026-06-12):
  - new `form[name="formPortfolioSelect"]` account-id selectors (old `ng-if` selector was removed upstream),
  - step-back datepicker model replacing the dead `.pmu-*` calendar grid,
  - **multi-portfolio iteration** — previously only the first portfolio was ever scraped,
  - upper date clamp (start date never in the future).

## Reviewer notes

- **hapoalim is intentionally untouched** — it matches current upstream; the issue reported against it was diagnosed separately and is not upstream drift.
- Two pre-existing, project-wide gaps were left as-is (not introduced here): the optional `includeRawTransaction` passthrough isn't implemented anywhere in the Python port, and visa-cal uses the session-storage auth token rather than capturing the live SSO `Authorization` header.
- yahav's datepicker / multi-portfolio changes are live-DOM interactions that can't be exercised by unit tests — they're faithful translations of the upstream reference but warrant a live smoke test when convenient.

## Verification

- `pytest tests/backend/unit/test_scraper/` — 20 passed
- `ruff check` on all four files — clean
- providers import and load through the factory; new constants/symbols verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)