### PR TITLE
feat(transactions): default transactions table to 100 rows per page

### DIFF
--- a/frontend/src/pages/Transactions.tsx
+++ b/frontend/src/pages/Transactions.tsx
@@ -405,7 +405,7 @@ export function Transactions() {
                 showSplitParentsFilter
                 includeSplitParents={includeSplitParents}
                 onIncludeSplitParentsChange={setIncludeSplitParents}
-                rowsPerPage={10}
+                rowsPerPage={100}
                 rowsPerPageOptions={[10, 50, 100, 500, 1000]}
                 onTransactionUpdated={refreshAll}
                 pendingRefundsMap={pendingRefundsMap}


### PR DESCRIPTION
## What

Changes the default page size of the transactions table on the **Transactions** page from **10** to **100** rows.

## Why

Requested change — most of the time the user wants to see far more than 10 transactions at once without paging.

## Details

- Single-line change in `frontend/src/pages/Transactions.tsx`: `rowsPerPage={10}` → `rowsPerPage={100}`.
- `100` was already present in `rowsPerPageOptions={[10, 50, 100, 500, 1000]}`, so the dropdown is unchanged — only the initial default moves.

## Note

Per the repo's branch workflow, feature PRs normally target `dev`. This PR targets `main` directly per explicit request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)