### PR TITLE
test(e2e): stop onezero force-2FA spec from leaking dummy data into prod DB

### DIFF
--- a/frontend/e2e/onezero-force-2fa.spec.ts
+++ b/frontend/e2e/onezero-force-2fa.spec.ts
@@ -69,15 +69,27 @@ test.describe("OneZero force-2FA (Re-authenticate)", () => {
     await expect(reauth).toBeVisible();
 
     // Clicking it must POST /api/scraping/start with the force_2fa flag set
-    // for the OneZero provider. Intercept the request and assert the JSON
-    // body — this is the wire contract the button exists to satisfy.
-    const startReq = page.waitForRequest(
-      (req) =>
-        req.url().includes("/api/scraping/start") && req.method() === "POST",
-    );
+    // for the OneZero provider — that wire contract is the whole point of
+    // this test. We MUST NOT let the request reach the backend, though:
+    // Demo Mode is a process-global flag (backend/config.py), the scrape
+    // runs as an async background task, and `afterAll`'s disableDemoMode()
+    // races it back to the production DB. A real dummy scrape here once
+    // leaked 6 fake transactions into the user's real data.db. So intercept
+    // the request, assert its body, and fulfill it with a stub — the scrape
+    // never actually starts. Do NOT "simplify" this back to waitForRequest +
+    // a live click; that reopens the leak.
+    let startBody: unknown;
+    await page.route("**/api/scraping/start", async (route) => {
+      startBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "started" }),
+      });
+    });
+
     await reauth.click();
-    const req = await startReq;
-    expect(req.postDataJSON()).toMatchObject({
+    await expect.poll(() => startBody).toMatchObject({
       provider: "onezero",
       force_2fa: true,
     });


### PR DESCRIPTION
## What

Harden `frontend/e2e/onezero-force-2fa.spec.ts` so it can no longer trigger a real scrape that writes to the production database.

## Why

While reviewing a suspicious `Restaurant -40.91 ₪ / E2E OneZero` row in the **production** transactions table, I traced it to this e2e test. The leak mechanism:

1. `beforeAll` enables Demo Mode (a **process-global** flag — `backend/config.py`) and seeds an `E2E OneZero` OneZero credential into the demo DB.
2. The test clicks **Re-authenticate**, which fires a real `POST /api/scraping/start`. The old test only *observed* the request (`waitForRequest`) and let it through, so an **async background dummy scrape** kicked off.
3. `afterAll` calls `disableDemoMode()`, flipping the global flag **back to production** — racing the still-running background scrape.
4. The dummy scraper's writes landed in the real `~/.finance-analysis/data.db`, leaking 6 fake rows (`Restaurant`, `Pharmacy`, `Gym`, `Cinema`, `Coffee Shop`).

## The fix

Intercept `/api/scraping/start` with `page.route`, assert the same wire contract (`{ provider: "onezero", force_2fa: true }`) **inside the handler**, and `fulfill` it with a stub. The scrape never starts, so there's nothing to leak — independent of teardown timing. A prominent comment documents the leak and warns against reverting to `waitForRequest` + a live click.

### Considered and rejected
An `afterAll` purge of leaked rows: `DELETE /api/transactions/{id}` is **manual-entries-only** (403s on scraped rows), so it would be a false safety net. Prevention at the source is the real guarantee.

### Audit
The only other spec touching scraping — `budget-freshness.spec.ts` — already stubs its endpoint safely. No other offenders.

## Verification

- ✅ Spec passes against live backend + frontend (3.4s).
- ✅ After a full run, **production** `data.db` has **0** `E2E OneZero` rows / credentials (real data untouched).
- ✅ The demo DB also has **0** dummy rows, confirming no scrape fired anywhere.

## Note for reviewer

The 6 already-leaked rows were cleaned out of the local `data.db` separately (with a timestamped backup) — that's live user data, not part of this repo, so it's not in this PR. The underlying architectural smell (Demo Mode being a global singleton with no per-request isolation) is real but out of scope here; this PR closes the leak at the test boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)