### PR TITLE
feat(dashboard): dynamic card sizing + spending calendar two-month view

### DIFF
--- a/frontend/e2e/dashboard-block-sizes.spec.ts
+++ b/frontend/e2e/dashboard-block-sizes.spec.ts
@@ -46,25 +46,48 @@ test.describe("Dashboard half-width blocks", () => {
     expect(charts.width).toBeGreaterThan(budget.width * 1.8);
   });
 
-  test("every block is one fixed height with internal scroll (>=lg)", async ({ page }) => {
+  test("blocks are capped and scroll overflow; paired cards share a row height (>=lg)", async ({
+    page,
+  }) => {
+    // 39rem at the default 16px root font size — the max card height.
+    const CAP = 624;
     await page.setViewportSize({ width: 1440, height: 1000 });
     await page.goto("/");
 
     const ids = ["budget", "recent", "heatmap", "income_by_source", "charts"];
-    const heights: number[] = [];
-    for (const id of ids) heights.push((await boxOf(page, id)).height);
+    const boxes: Record<string, { height: number }> = {};
+    for (const id of ids) boxes[id] = await boxOf(page, id);
 
-    // All blocks (half and full alike) are the same fixed height.
-    expect(Math.max(...heights) - Math.min(...heights)).toBeLessThan(2);
+    // No block grows past the cap — taller content scrolls inside instead.
+    for (const id of ids) {
+      expect(boxes[id].height, `${id} should not exceed the cap`).toBeLessThanOrEqual(CAP + 2);
+    }
 
-    // Every block fills its cell and enables internal scrolling, so content
-    // that exceeds the fixed height scrolls within the block instead of
-    // stretching the row.
-    const overflowYs = await page
+    // Two half cards sharing a row are the same height (the taller of the two).
+    expect(Math.abs(boxes.budget.height - boxes.recent.height)).toBeLessThan(2);
+    expect(Math.abs(boxes.heatmap.height - boxes.income_by_source.height)).toBeLessThan(2);
+
+    // Every block enables internal scrolling and is height-capped, so content
+    // taller than the cap scrolls within the block instead of stretching the
+    // row.
+    const childStyles = await page
       .locator("[data-card-id] > *")
-      .evaluateAll((els) => els.map((el) => getComputedStyle(el).overflowY));
-    expect(overflowYs.length).toBeGreaterThan(0);
-    expect(overflowYs.every((o) => o === "auto")).toBe(true);
+      .evaluateAll((els) =>
+        els.map((el) => {
+          const cs = getComputedStyle(el);
+          return { overflowY: cs.overflowY, maxHeight: cs.maxHeight };
+        }),
+      );
+    expect(childStyles.length).toBeGreaterThan(0);
+    expect(childStyles.every((s) => s.overflowY === "auto")).toBe(true);
+    expect(childStyles.every((s) => s.maxHeight === `${CAP}px`)).toBe(true);
+
+    // At least one demo card has more content than the cap and actually scrolls
+    // — proving the cap engages rather than every card just being short.
+    const anyScrolls = await page
+      .locator("[data-card-id] > *")
+      .evaluateAll((els) => els.some((el) => el.scrollHeight > el.clientHeight + 1));
+    expect(anyScrolls).toBe(true);
   });
 
   test("fill order flips under RTL (Hebrew)", async ({ page }) => {

--- a/frontend/e2e/dashboard-block-sizes.spec.ts
+++ b/frontend/e2e/dashboard-block-sizes.spec.ts
@@ -67,20 +67,27 @@ test.describe("Dashboard half-width blocks", () => {
     expect(Math.abs(boxes.budget.height - boxes.recent.height)).toBeLessThan(2);
     expect(Math.abs(boxes.heatmap.height - boxes.income_by_source.height)).toBeLessThan(2);
 
-    // Every block enables internal scrolling and is height-capped, so content
-    // taller than the cap scrolls within the block instead of stretching the
-    // row.
-    const childStyles = await page
+    // Every block enables internal scrolling.
+    const allOverflows = await page
       .locator("[data-card-id] > *")
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).overflowY));
+    expect(allOverflows.length).toBeGreaterThan(0);
+    expect(allOverflows.every((o) => o === "auto")).toBe(true);
+
+    // All cards except `recent` are height-capped. `recent` is intentionally
+    // uncapped so it can show more transactions than the cap allows.
+    const cappedStyles = await page
+      .locator("[data-card-id]:not([data-card-id='recent']) > *")
       .evaluateAll((els) =>
-        els.map((el) => {
-          const cs = getComputedStyle(el);
-          return { overflowY: cs.overflowY, maxHeight: cs.maxHeight };
-        }),
+        els.map((el) => getComputedStyle(el).maxHeight),
       );
-    expect(childStyles.length).toBeGreaterThan(0);
-    expect(childStyles.every((s) => s.overflowY === "auto")).toBe(true);
-    expect(childStyles.every((s) => s.maxHeight === `${CAP}px`)).toBe(true);
+    expect(cappedStyles.length).toBeGreaterThan(0);
+    expect(cappedStyles.every((h) => h === `${CAP}px`)).toBe(true);
+
+    const recentMaxH = await page
+      .locator("[data-card-id='recent'] > *")
+      .evaluateAll((els) => els.map((el) => getComputedStyle(el).maxHeight));
+    expect(recentMaxH.every((h) => h === "none")).toBe(true);
 
     // At least one demo card has more content than the cap and actually scrolls
     // — proving the cap engages rather than every card just being short.

--- a/frontend/e2e/dashboard-insights-strip.spec.ts
+++ b/frontend/e2e/dashboard-insights-strip.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, type Page } from "@playwright/test";
+import { enableDemoMode, disableDemoMode } from "./helpers";
+
+/**
+ * The dashboard grid sizes cards to their content on >=lg, capped at
+ * `--dash-card-h` (39rem): a card alone on a row is exactly as tall as it needs
+ * to be, and taller content scrolls inside the cap instead of growing the row.
+ *
+ * `forecast` (the "This Month" hero) and `insights` are short full-width cards
+ * — a heading plus a couple of rows of tiles — so they collapse well under the
+ * cap with no tall empty gap below them. A content-heavy card (e.g. `budget`
+ * paired with the transaction-rich `recent` feed) instead sits at the cap.
+ *
+ * forecast/insights ship beta/hidden by default, so each test seeds a layout
+ * that puts them first, ahead of the half-width `budget` card.
+ */
+test.describe("Dashboard strip cards", () => {
+  const CAP = 624; // --dash-card-h: 39rem at the default 16px root font size.
+  const STRIP_CARDS = ["forecast", "insights"] as const;
+
+  const LAYOUT = {
+    order: ["forecast", "insights", "budget", "recent", "heatmap", "income_by_source", "charts"],
+    hidden: ["recurring", "goals"],
+    v: 2,
+  };
+
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await enableDemoMode(page);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await disableDemoMode(page);
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((layout) => {
+      window.localStorage.setItem("fa.dashboard.layout", JSON.stringify(layout));
+    }, LAYOUT);
+  });
+
+  async function boxOf(page: Page, id: string) {
+    const el = page.locator(`[data-card-id="${id}"]`);
+    await expect(el).toBeVisible({ timeout: 45_000 });
+    const box = await el.boundingBox();
+    if (!box) throw new Error(`no box for ${id}`);
+    return box;
+  }
+
+  test("strip cards collapse to content well under the cap (>=lg)", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto("/");
+
+    // The content-heavy `budget` card stays within the cap (taller content
+    // scrolls inside instead of growing the row).
+    const budget = await boxOf(page, "budget");
+    expect(budget.height, "budget should not exceed the cap").toBeLessThanOrEqual(CAP + 2);
+
+    // Each strip is much shorter than the cap — it sized to its content instead
+    // of being stretched to a fixed row height.
+    for (const id of STRIP_CARDS) {
+      const strip = await boxOf(page, id);
+      expect(strip.height, `${id} should collapse to content`).toBeLessThan(CAP * 0.8);
+    }
+  });
+
+  test("the card after a strip follows immediately, with no tall empty gap (>=lg)", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto("/");
+
+    // forecast -> insights and insights -> budget are both strip->next pairs.
+    const pairs: [string, string][] = [
+      ["forecast", "insights"],
+      ["insights", "budget"],
+    ];
+    for (const [stripId, nextId] of pairs) {
+      const strip = await boxOf(page, stripId);
+      const next = await boxOf(page, nextId);
+      const gap = next.y - (strip.y + strip.height);
+      // Only the grid gap (md:gap-8 = 32px) — never the ~350px the fixed
+      // height used to leave below a short strip. Allow generous slack.
+      expect(gap, `gap below ${stripId}`).toBeGreaterThanOrEqual(0);
+      expect(gap, `gap below ${stripId}`).toBeLessThan(64);
+    }
+  });
+
+  test("below lg the strips stack full-width above the next card", async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 1000 });
+    await page.goto("/");
+
+    const forecast = await boxOf(page, "forecast");
+    const insights = await boxOf(page, "insights");
+    const budget = await boxOf(page, "budget");
+
+    expect(insights.y).toBeGreaterThan(forecast.y + forecast.height - 4);
+    expect(budget.y).toBeGreaterThan(insights.y + insights.height - 4);
+    expect(Math.abs(insights.width - budget.width)).toBeLessThan(8);
+  });
+});

--- a/frontend/e2e/dashboard-spending-calendar.spec.ts
+++ b/frontend/e2e/dashboard-spending-calendar.spec.ts
@@ -32,8 +32,9 @@ test.describe("Dashboard spending calendar months", () => {
     const card = page.locator('[data-card-id="heatmap"]');
     await expect(card).toBeVisible({ timeout: 45_000 });
     // Each month renders a weekday header: a 7-column grid whose first cell is a
-    // single-letter weekday label.
-    return card.locator("div.grid.grid-cols-7.mb-1\\.5").count();
+    // single-letter weekday label. The header uses mb-1 (gap was mb-1.5 before
+    // the compact-cell refactor).
+    return card.locator("div.grid.grid-cols-7.mb-1").count();
   }
 
   test("shows two months at half-row width (>=lg)", async ({ page }) => {

--- a/frontend/e2e/dashboard-spending-calendar.spec.ts
+++ b/frontend/e2e/dashboard-spending-calendar.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect, type Page } from "@playwright/test";
+import { enableDemoMode, disableDemoMode } from "./helpers";
+
+/**
+ * The Spending Calendar (`heatmap`) card shows two months (previous + current)
+ * side by side when it sits at half-row width on wide (>=lg) screens, and a
+ * single current month when it's full-width or in the single-column mobile
+ * layout.
+ *
+ * The card ships visible by default (non-beta), so no custom layout seeding is
+ * needed — it renders at its configured half width.
+ */
+test.describe("Dashboard spending calendar months", () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await enableDemoMode(page);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await disableDemoMode(page);
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => window.localStorage.removeItem("fa.dashboard.layout"));
+  });
+
+  /** Count the 7-column weekday-header rows inside the heatmap card — one per month. */
+  async function monthGridCount(page: Page) {
+    const card = page.locator('[data-card-id="heatmap"]');
+    await expect(card).toBeVisible({ timeout: 45_000 });
+    // Each month renders a weekday header: a 7-column grid whose first cell is a
+    // single-letter weekday label.
+    return card.locator("div.grid.grid-cols-7.mb-1\\.5").count();
+  }
+
+  test("shows two months at half-row width (>=lg)", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto("/");
+
+    await expect.poll(() => monthGridCount(page), { timeout: 45_000 }).toBe(2);
+  });
+
+  test("shows a single month in the single-column mobile layout", async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 1000 });
+    await page.goto("/");
+
+    await expect.poll(() => monthGridCount(page), { timeout: 45_000 }).toBe(1);
+  });
+});

--- a/frontend/src/components/dashboard/SpendingHeatmap.tsx
+++ b/frontend/src/components/dashboard/SpendingHeatmap.tsx
@@ -3,61 +3,156 @@ import { useTranslation } from "react-i18next";
 import { CalendarDays } from "lucide-react";
 import type { Transaction } from "../../types/transaction";
 import { formatCurrency } from "../../utils/numberFormatting";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
+import type { DashboardCardSize } from "../../hooks/useDashboardLayout";
 
 // Categories that are not discretionary spending.
 const NON_EXPENSE = new Set([
   "Ignore", "Salary", "Other Income", "Investments", "Liabilities", "Credit Cards",
 ]);
 
+type Cell = { day: number; spend: number } | null;
+
+interface MonthData {
+  year: number;
+  month: number; // 0-11
+  weeks: Cell[][];
+  total: number;
+}
+
+/** Build the calendar grid + spending total for a single month. */
+function buildMonth(transactions: Transaction[] | undefined, year: number, month: number): MonthData {
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const firstWeekday = new Date(year, month, 1).getDay(); // 0 = Sunday
+
+  const perDay: Record<number, number> = {};
+  for (const tx of transactions ?? []) {
+    const amount = tx.amount ?? 0;
+    if (amount >= 0) continue;
+    if (tx.category && NON_EXPENSE.has(tx.category)) continue;
+    const d = new Date(tx.date ?? "");
+    if (d.getFullYear() !== year || d.getMonth() !== month) continue;
+    perDay[d.getDate()] = (perDay[d.getDate()] ?? 0) + Math.abs(amount);
+  }
+
+  const cells: Cell[] = [];
+  for (let i = 0; i < firstWeekday; i++) cells.push(null);
+  for (let day = 1; day <= daysInMonth; day++) cells.push({ day, spend: perDay[day] ?? 0 });
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const weeks: Cell[][] = [];
+  for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
+
+  return {
+    year,
+    month,
+    weeks,
+    total: Object.values(perDay).reduce((s, v) => s + v, 0),
+  };
+}
+
 /**
- * Current-month spending heatmap — a calendar grid where each day's cell is
- * shaded by how much was spent that day. Reuses the dashboard's already-fetched
- * transactions, so no extra request.
+ * Spending heatmap — a calendar grid where each day's cell is shaded by how much
+ * was spent that day. Reuses the dashboard's already-fetched transactions, so no
+ * extra request.
+ *
+ * When the card sits at half-row width on wide screens it shows the previous and
+ * current month stacked vertically (shared colour scale so the shading is comparable).
+ * A full-width card, or any narrow (mobile) render, shows the current month only.
+ *
+ * Cells use a fixed h-8 height (not aspect-square) so both one and two month views
+ * stay within the dashboard card's 39rem height cap.
  */
-export function SpendingHeatmap({ transactions }: { transactions: Transaction[] | undefined }) {
+export function SpendingHeatmap({
+  transactions,
+  size = "half",
+}: {
+  transactions: Transaction[] | undefined;
+  size?: DashboardCardSize;
+}) {
   const { t, i18n } = useTranslation();
+  // Two months only when the card occupies half a row (>=lg). A full-width card
+  // or the single-column mobile layout shows one month.
+  const isWide = useMediaQuery("(min-width: 1024px)");
+  const twoMonths = size === "half" && isWide;
 
-  const { weeks, maxSpend, total } = useMemo(() => {
+  const months = useMemo(() => {
     const now = new Date();
-    const year = now.getFullYear();
-    const month = now.getMonth();
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    const firstWeekday = new Date(year, month, 1).getDay(); // 0 = Sunday
-
-    const perDay: Record<number, number> = {};
-    for (const tx of transactions ?? []) {
-      const dateStr = tx.date ?? "";
-      const amount = tx.amount ?? 0;
-      if (amount >= 0) continue;
-      if (tx.category && NON_EXPENSE.has(tx.category)) continue;
-      const d = new Date(dateStr);
-      if (d.getFullYear() !== year || d.getMonth() !== month) continue;
-      perDay[d.getDate()] = (perDay[d.getDate()] ?? 0) + Math.abs(amount);
+    const list: MonthData[] = [];
+    if (twoMonths) {
+      const prev = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+      list.push(buildMonth(transactions, prev.getFullYear(), prev.getMonth()));
     }
+    list.push(buildMonth(transactions, now.getFullYear(), now.getMonth()));
+    return list;
+  }, [transactions, twoMonths]);
 
-    const cells: ({ day: number; spend: number } | null)[] = [];
-    for (let i = 0; i < firstWeekday; i++) cells.push(null);
-    for (let day = 1; day <= daysInMonth; day++) {
-      cells.push({ day, spend: perDay[day] ?? 0 });
-    }
-    while (cells.length % 7 !== 0) cells.push(null);
-
-    const grid: (typeof cells)[] = [];
-    for (let i = 0; i < cells.length; i += 7) grid.push(cells.slice(i, i + 7));
-
-    const spends = Object.values(perDay);
-    return {
-      weeks: grid,
-      maxSpend: spends.length ? Math.max(...spends) : 0,
-      total: spends.reduce((s, v) => s + v, 0),
-    };
-  }, [transactions]);
+  // Shared scale across the shown months so intensities are comparable.
+  const maxSpend = useMemo(() => {
+    let max = 0;
+    for (const mo of months)
+      for (const week of mo.weeks)
+        for (const cell of week) if (cell && cell.spend > max) max = cell.spend;
+    return max;
+  }, [months]);
 
   const weekdayLabels =
     i18n.language === "he"
       ? ["א", "ב", "ג", "ד", "ה", "ו", "ש"]
       : ["S", "M", "T", "W", "T", "F", "S"];
 
+  const monthLabel = (mo: MonthData) =>
+    new Date(mo.year, mo.month, 1).toLocaleDateString(
+      i18n.language === "he" ? "he-IL" : "en-US",
+      { month: "long" },
+    );
+
+  const current = months[months.length - 1];
+
+  return (
+    <div className={`bg-[var(--surface)] rounded-2xl border border-[var(--surface-light)] ${twoMonths ? "p-3 md:p-4" : "p-4 md:p-6"}`}>
+      <div className={`flex items-center justify-between gap-2 ${twoMonths ? "mb-2" : "mb-4"}`}>
+        <div className="flex items-center gap-2">
+          <div className="p-1.5 rounded-lg bg-[var(--primary)]/15 text-[var(--primary)]">
+            <CalendarDays size={16} />
+          </div>
+          <p className="text-sm md:text-base font-bold">{t("dashboard.heatmap.title")}</p>
+        </div>
+        {!twoMonths && (
+          <div className="text-end">
+            <p className="text-[10px] md:text-xs text-[var(--text-muted)]">{t("dashboard.heatmap.monthTotal")}</p>
+            <p dir="ltr" className="text-sm md:text-base font-bold text-start">{formatCurrency(current.total)}</p>
+          </div>
+        )}
+      </div>
+
+      <div className={twoMonths ? "space-y-3" : ""}>
+        {months.map((mo) => (
+          <MonthCalendar
+            key={`${mo.year}-${mo.month}`}
+            data={mo}
+            maxSpend={maxSpend}
+            weekdayLabels={weekdayLabels}
+            label={twoMonths ? monthLabel(mo) : undefined}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MonthCalendar({
+  data,
+  maxSpend,
+  weekdayLabels,
+  label,
+}: {
+  data: MonthData;
+  maxSpend: number;
+  weekdayLabels: string[];
+  /** When set, render a per-month header (name + total) above the grid. */
+  label?: string;
+}) {
   const cellColor = (spend: number): string => {
     if (spend <= 0) return "bg-[var(--surface-light)]";
     const intensity = maxSpend > 0 ? spend / maxSpend : 0;
@@ -68,36 +163,29 @@ export function SpendingHeatmap({ transactions }: { transactions: Transaction[] 
   };
 
   return (
-    <div className="bg-[var(--surface)] rounded-2xl border border-[var(--surface-light)] p-4 md:p-6">
-      <div className="flex items-center justify-between gap-2 mb-4">
-        <div className="flex items-center gap-2">
-          <div className="p-1.5 rounded-lg bg-[var(--primary)]/15 text-[var(--primary)]">
-            <CalendarDays size={16} />
-          </div>
-          <p className="text-sm md:text-base font-bold">{t("dashboard.heatmap.title")}</p>
+    <div className="min-w-0">
+      {label && (
+        <div className="flex items-center justify-between gap-2 mb-1">
+          <p className="text-[11px] md:text-xs font-semibold text-[var(--text-muted)]" dir="auto">{label}</p>
+          <p dir="ltr" className="text-[11px] md:text-xs font-bold">{formatCurrency(data.total)}</p>
         </div>
-        <div className="text-end">
-          <p className="text-[10px] md:text-xs text-[var(--text-muted)]">{t("dashboard.heatmap.monthTotal")}</p>
-          <p dir="ltr" className="text-sm md:text-base font-bold text-start">{formatCurrency(total)}</p>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-7 gap-1.5 mb-1.5">
-        {weekdayLabels.map((label, i) => (
-          <div key={i} className="text-center text-[9px] md:text-[10px] text-[var(--text-muted)] font-medium">{label}</div>
+      )}
+      <div className="grid grid-cols-7 gap-1 mb-1">
+        {weekdayLabels.map((l, i) => (
+          <div key={i} className="text-center text-[9px] md:text-[10px] text-[var(--text-muted)] font-medium">{l}</div>
         ))}
       </div>
-      <div className="space-y-1.5">
-        {weeks.map((week, wi) => (
-          <div key={wi} className="grid grid-cols-7 gap-1.5">
+      <div className="space-y-1">
+        {data.weeks.map((week, wi) => (
+          <div key={wi} className="grid grid-cols-7 gap-1">
             {week.map((cell, ci) =>
               cell === null ? (
-                <div key={ci} className="aspect-square" />
+                <div key={ci} className="h-8" />
               ) : (
                 <div
                   key={ci}
                   title={`${cell.day}: ${formatCurrency(cell.spend)}`}
-                  className={`aspect-square rounded-md flex items-center justify-center ${cellColor(cell.spend)}`}
+                  className={`h-8 rounded-md flex items-center justify-center ${cellColor(cell.spend)}`}
                 >
                   <span className="text-[8px] md:text-[10px] text-[var(--text-primary)]/70">{cell.day}</span>
                 </div>

--- a/frontend/src/hooks/useMediaQuery.ts
+++ b/frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Subscribe to a CSS media query and return whether it currently matches.
+ *
+ * Reads `matchMedia` synchronously on first render so there's no layout flash,
+ * then updates whenever the match state changes.
+ *
+ * @param query A media query string, e.g. `"(min-width: 1024px)"`.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -273,7 +273,7 @@ export function Dashboard() {
     ),
     recurring: () => <RecurringSection />,
     goals: () => <GoalsSection />,
-    heatmap: () => <SpendingHeatmap transactions={allTransactions} />,
+    heatmap: () => <SpendingHeatmap transactions={allTransactions} size={cardSize("heatmap")} />,
     income_by_source: () => <IncomeBySourceCard />,
     charts: () => <DashboardChartsPanel />,
   };
@@ -296,20 +296,24 @@ export function Dashboard() {
           neighbour before a full card leaves an empty gap, and the stored order
           is preserved exactly.
 
-          Every cell is a fixed height on >=lg (`lg:auto-rows-[var(--dash-card-h)]`)
-          so all blocks are the same size regardless of content. Each card fills
-          its cell (`[&>*]:h-full`) and scrolls its own overflow
-          (`[&>*]:overflow-y-auto`) instead of stretching the row. On mobile the
-          grid is a single column with natural heights. */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8 lg:auto-rows-[var(--dash-card-h)] [--dash-card-h:32rem]">
+          Rows size to their content on >=lg (`grid-auto-rows: auto`), so a card
+          alone on a row is exactly as tall as it needs to be — no empty gap
+          below short cards. The card height is capped at `--dash-card-h`
+          (`lg:[&>*]:max-h-[var(--dash-card-h)]`): content taller than the cap
+          scrolls inside the card (`[&>*]:overflow-y-auto`) instead of growing
+          the row. When two half cards share a row, the default
+          `align-items: stretch` plus `[&>*]:h-full` makes both as tall as the
+          taller card (still capped). On mobile the grid is a single column with
+          natural, uncapped heights. */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8 [--dash-card-h:39rem]">
         {layout.order.map((id) => (
           <div
             key={id}
             data-card-id={id}
             data-card-size={cardSize(id)}
             className={`min-w-0 [&>*]:h-full [&>*]:overflow-y-auto ${
-              cardSize(id) === "full" ? "lg:col-span-2" : ""
-            }`}
+              id !== "recent" ? "lg:[&>*]:max-h-[var(--dash-card-h)]" : ""
+            } ${cardSize(id) === "full" ? "lg:col-span-2" : ""}`}
           >
             {cardRenderers[id]()}
           </div>


### PR DESCRIPTION
## Summary

- **Content-driven row heights**: Replaced the fixed `auto-rows` grid track with `grid-auto-rows: auto` so short cards (Insights strip, This Month forecast) collapse to their content instead of leaving a tall empty gap below them.
- **Per-card height cap** (`--dash-card-h: 39rem` = 624px): Cards taller than the cap scroll internally; shorter cards size to their content. Two half-cards sharing a row stretch to the taller of the two via `align-items: stretch` (still capped).
- **Recent Transactions uncapped**: The `recent` card is exempt from `max-height` so it can grow freely when there are many transactions to show.
- **Spending Calendar — two-month view**: When the heatmap card occupies a half-row on `>=lg` screens, it shows the previous + current month stacked vertically with a shared colour scale. Single month on mobile/full-width.
- **Fixed-height calendar cells** (`h-8` instead of `aspect-square`): Both one and two month views fit within the cap without requiring internal scroll.
- **`useMediaQuery` hook**: New hook for responsive JS detection (used by SpendingHeatmap to switch between one/two month modes).

## Test plan

- [ ] Short cards (Insights, This Month) collapse to their content — no tall gap below them
- [ ] Content-heavy card (Budget) is capped at 39rem with internal scroll
- [ ] Two half-cards in the same row share height (budget ≈ recent height)
- [ ] Recent Transactions card grows past 39rem when data is tall enough
- [ ] Spending Calendar at `>=lg` half-width shows May + June stacked vertically, both fully visible
- [ ] Spending Calendar on mobile / full-width shows single current month
- [ ] Month totals and colour scale display correctly in two-month mode
- [ ] E2e: `dashboard-block-sizes.spec.ts`, `dashboard-insights-strip.spec.ts`, `dashboard-spending-calendar.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)