### PR TITLE
perf: speed up first dashboard load (concurrent API, faster net worth, lazy cards)

### DIFF
--- a/backend/routes/analytics.py
+++ b/backend/routes/analytics.py
@@ -19,7 +19,7 @@ router = APIRouter()
 
 
 @router.get("/overview")
-async def get_overview(
+def get_overview(
     db: Session = Depends(get_database),
 ):
     """Return an aggregate financial overview across all available data.
@@ -34,7 +34,7 @@ async def get_overview(
 
 
 @router.get("/net-balance-over-time")
-async def get_net_balance_over_time(
+def get_net_balance_over_time(
     db: Session = Depends(get_database),
 ):
     """Return the cumulative net balance trend over time.
@@ -49,7 +49,7 @@ async def get_net_balance_over_time(
 
 
 @router.get("/income-expenses-over-time")
-async def get_income_expenses_over_time(
+def get_income_expenses_over_time(
     db: Session = Depends(get_database),
     exclude_projects: bool = False,
     exclude_liabilities: bool = False,
@@ -80,7 +80,7 @@ async def get_income_expenses_over_time(
 
 
 @router.get("/debt-payments-over-time")
-async def get_debt_payments_over_time(
+def get_debt_payments_over_time(
     db: Session = Depends(get_database),
 ):
     """Return monthly debt payment totals over time."""
@@ -89,7 +89,7 @@ async def get_debt_payments_over_time(
 
 
 @router.get("/expenses-by-category-over-time")
-async def get_expenses_by_category_over_time(
+def get_expenses_by_category_over_time(
     db: Session = Depends(get_database),
 ):
     """Return monthly expenses broken down by category."""
@@ -98,7 +98,7 @@ async def get_expenses_by_category_over_time(
 
 
 @router.get("/by-category")
-async def get_expenses_by_category(
+def get_expenses_by_category(
     db: Session = Depends(get_database),
 ):
     """Return expenses aggregated by category.
@@ -114,7 +114,7 @@ async def get_expenses_by_category(
 
 
 @router.get("/sankey")
-async def get_sankey_data(
+def get_sankey_data(
     db: Session = Depends(get_database),
 ) -> dict:
     """Return Sankey chart data showing income-to-expense flow.
@@ -130,7 +130,7 @@ async def get_sankey_data(
 
 
 @router.get("/income-by-source-over-time")
-async def get_income_by_source_over_time(
+def get_income_by_source_over_time(
     db: Session = Depends(get_database),
 ):
     """Return monthly income broken down by source (category+tag).
@@ -146,7 +146,7 @@ async def get_income_by_source_over_time(
 
 
 @router.get("/income-by-source")
-async def get_income_by_source(
+def get_income_by_source(
     start: date | None = Query(None),
     end: date | None = Query(None),
     db: Session = Depends(get_database),
@@ -170,7 +170,7 @@ async def get_income_by_source(
 
 
 @router.get("/monthly-expenses")
-async def get_monthly_expenses(
+def get_monthly_expenses(
     exclude_pending_refunds: bool = Query(True),
     include_projects: bool = Query(False),
     db: Session = Depends(get_database),
@@ -201,7 +201,7 @@ async def get_monthly_expenses(
 
 
 @router.get("/recurring")
-async def get_recurring(
+def get_recurring(
     db: Session = Depends(get_database),
 ):
     """Return detected recurring charges (subscriptions, bills).
@@ -217,7 +217,7 @@ async def get_recurring(
 
 
 @router.get("/insights")
-async def get_insights(
+def get_insights(
     db: Session = Depends(get_database),
 ):
     """Return rule-based financial insight cards.
@@ -233,7 +233,7 @@ async def get_insights(
 
 
 @router.get("/cash-flow-forecast")
-async def get_cash_flow_forecast(
+def get_cash_flow_forecast(
     db: Session = Depends(get_database),
 ):
     """Return the current-month cash-flow forecast.
@@ -252,7 +252,7 @@ async def get_cash_flow_forecast(
 
 
 @router.get("/net-worth-over-time")
-async def get_net_worth_over_time(
+def get_net_worth_over_time(
     db: Session = Depends(get_database),
 ):
     """Return the net worth trend over time including investment balances.

--- a/backend/routes/bank_balances.py
+++ b/backend/routes/bank_balances.py
@@ -21,7 +21,7 @@ class SetBalanceRequest(BaseModel):
 
 
 @router.get("/")
-async def get_bank_balances(
+def get_bank_balances(
     db: Session = Depends(get_database),
 ) -> list[dict]:
     """Get all bank balance records."""
@@ -30,7 +30,7 @@ async def get_bank_balances(
 
 
 @router.post("/")
-async def set_bank_balance(
+def set_bank_balance(
     request: SetBalanceRequest,
     db: Session = Depends(get_database),
 ) -> dict:

--- a/backend/routes/budget.py
+++ b/backend/routes/budget.py
@@ -47,7 +47,7 @@ class ProjectUpdate(BaseModel):
 
 
 @router.get("/rules")
-async def get_budget_rules(
+def get_budget_rules(
     db: Session = Depends(get_database),
 ) -> list[dict]:
     """Get all budget rules."""
@@ -57,7 +57,7 @@ async def get_budget_rules(
 
 
 @router.get("/rules/{year}/{month}")
-async def get_budget_rules_by_month(
+def get_budget_rules_by_month(
     year: int, month: int, db: Session = Depends(get_database)
 ) -> list[dict]:
     """Get budget rules for a specific month."""
@@ -67,7 +67,7 @@ async def get_budget_rules_by_month(
 
 
 @router.post("/rules")
-async def create_budget_rule(
+def create_budget_rule(
     rule: BudgetRuleCreate, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Create a new budget rule."""
@@ -82,7 +82,7 @@ async def create_budget_rule(
 
 
 @router.put("/rules/{rule_id}")
-async def update_budget_rule(
+def update_budget_rule(
     rule_id: int, rule: BudgetRuleUpdate, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Update a budget rule."""
@@ -93,7 +93,7 @@ async def update_budget_rule(
 
 
 @router.delete("/rules/{rule_id}")
-async def delete_budget_rule(
+def delete_budget_rule(
     rule_id: int, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Delete a budget rule."""
@@ -103,7 +103,7 @@ async def delete_budget_rule(
 
 
 @router.post("/rules/{year}/{month}/copy")
-async def copy_previous_month_rules(
+def copy_previous_month_rules(
     year: int, month: int, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Copy budget rules from the previous calendar month into the given month.
@@ -139,7 +139,7 @@ async def copy_previous_month_rules(
 
 
 @router.get("/analysis/{year}/{month}")
-async def get_monthly_analysis(
+def get_monthly_analysis(
     year: int,
     month: int,
     include_split_parents: bool = Query(False),
@@ -171,7 +171,7 @@ async def get_monthly_analysis(
 
 
 @router.get("/alerts")
-async def get_current_month_alerts(
+def get_current_month_alerts(
     threshold: float = Query(0.8, ge=0.0, le=1.0),
     db: Session = Depends(get_database),
 ) -> dict[str, Any]:
@@ -197,7 +197,7 @@ async def get_current_month_alerts(
 
 
 @router.get("/alerts/{year}/{month}")
-async def get_month_alerts(
+def get_month_alerts(
     year: int,
     month: int,
     threshold: float = Query(0.8, ge=0.0, le=1.0),
@@ -228,7 +228,7 @@ async def get_month_alerts(
 
 
 @router.get("/projects")
-async def get_projects(
+def get_projects(
     db: Session = Depends(get_database),
 ) -> list[str]:
     """Get all project names."""
@@ -237,7 +237,7 @@ async def get_projects(
 
 
 @router.get("/projects/available")
-async def get_available_categories_for_new_project(
+def get_available_categories_for_new_project(
     db: Session = Depends(get_database),
 ) -> list[str]:
     """Get available categories for a new project."""
@@ -246,7 +246,7 @@ async def get_available_categories_for_new_project(
 
 
 @router.post("/projects")
-async def create_project(
+def create_project(
     project: ProjectCreate, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Create a new project."""
@@ -256,7 +256,7 @@ async def create_project(
 
 
 @router.put("/projects/{name}")
-async def update_project(
+def update_project(
     name: str, project: ProjectUpdate, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Update project total budget."""
@@ -266,7 +266,7 @@ async def update_project(
 
 
 @router.delete("/projects/{name}")
-async def delete_project(
+def delete_project(
     name: str, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Delete a project."""
@@ -276,7 +276,7 @@ async def delete_project(
 
 
 @router.get("/projects/{name}")
-async def get_project_details(
+def get_project_details(
     name: str,
     include_split_parents: bool = Query(False),
     db: Session = Depends(get_database),

--- a/backend/routes/budget_month_overrides.py
+++ b/backend/routes/budget_month_overrides.py
@@ -28,7 +28,7 @@ class SetMonthOverrideRequest(BaseModel):
 
 
 @router.post("/")
-async def set_month_override(
+def set_month_override(
     request: SetMonthOverrideRequest,
     db: Session = Depends(get_database),
 ):
@@ -44,14 +44,14 @@ async def set_month_override(
 
 
 @router.get("/")
-async def get_month_overrides(db: Session = Depends(get_database)):
+def get_month_overrides(db: Session = Depends(get_database)):
     """Get all budget month overrides."""
     service = BudgetMonthOverrideService(db)
     return service.get_all()
 
 
 @router.delete("/{override_id}")
-async def delete_month_override(
+def delete_month_override(
     override_id: int,
     db: Session = Depends(get_database),
 ):

--- a/backend/routes/cash_balances.py
+++ b/backend/routes/cash_balances.py
@@ -20,7 +20,7 @@ class SetBalanceRequest(BaseModel):
 
 
 @router.get("/")
-async def get_cash_balances(
+def get_cash_balances(
     db: Session = Depends(get_database),
 ) -> list[dict]:
     """Get all cash balance records."""
@@ -29,7 +29,7 @@ async def get_cash_balances(
 
 
 @router.post("/")
-async def set_cash_balance(
+def set_cash_balance(
     request: SetBalanceRequest,
     db: Session = Depends(get_database),
 ) -> dict:
@@ -45,7 +45,7 @@ async def set_cash_balance(
 
 
 @router.post("/migrate")
-async def migrate_cash_balances(
+def migrate_cash_balances(
     db: Session = Depends(get_database),
 ) -> list[dict]:
     """Migrate existing cash transactions to cash_balances table.
@@ -58,7 +58,7 @@ async def migrate_cash_balances(
 
 
 @router.delete("/{account_name}")
-async def delete_cash_balance(
+def delete_cash_balance(
     account_name: str,
     db: Session = Depends(get_database),
 ) -> dict:

--- a/backend/routes/credentials.py
+++ b/backend/routes/credentials.py
@@ -33,7 +33,7 @@ class ProviderFieldsResponse(BaseModel):
 
 
 @router.get("/")
-async def get_credentials(
+def get_credentials(
     db: Session = Depends(get_database),
 ) -> dict[str, dict[str, list[str]]]:
     """Return all stored credentials, omitting passwords.
@@ -49,7 +49,7 @@ async def get_credentials(
 
 
 @router.get("/accounts")
-async def get_accounts(
+def get_accounts(
     db: Session = Depends(get_database),
 ) -> list[dict[str, str]]:
     """Get a list of all configured accounts."""
@@ -58,7 +58,7 @@ async def get_accounts(
 
 
 @router.get("/{service}/{provider}/{account_name}")
-async def get_credential_details(
+def get_credential_details(
     service: str,
     provider: str,
     account_name: str,
@@ -73,13 +73,13 @@ async def get_credential_details(
 
 
 @router.get("/providers")
-async def get_providers() -> dict[str, list[str]]:
+def get_providers() -> dict[str, list[str]]:
     """Get all supported providers."""
     return CredentialsService.get_available_providers()
 
 
 @router.post("/", response_model=StatusResponse)
-async def create_credential(
+def create_credential(
     credential: CredentialCreate,
     db: Session = Depends(get_database),
 ) -> dict[str, str]:
@@ -96,14 +96,14 @@ async def create_credential(
 
 
 @router.get("/fields/{provider}", response_model=ProviderFieldsResponse)
-async def get_provider_fields(provider: str) -> dict[str, List[str]]:
+def get_provider_fields(provider: str) -> dict[str, List[str]]:
     """Get the required fields for a provider login."""
     fields = LoginFields.get_fields(provider)
     return {"fields": fields}
 
 
 @router.delete("/{service}/{provider}/{account_name}", response_model=StatusResponse)
-async def delete_credential(
+def delete_credential(
     service: str,
     provider: str,
     account_name: str,

--- a/backend/routes/insurance_accounts.py
+++ b/backend/routes/insurance_accounts.py
@@ -48,7 +48,7 @@ class InsuranceAccountRename(BaseModel):
 
 
 @router.get("/", response_model=list[InsuranceAccountResponse])
-async def get_insurance_accounts(
+def get_insurance_accounts(
     db: Session = Depends(get_database),
 ):
     """Get all insurance account metadata records.
@@ -63,7 +63,7 @@ async def get_insurance_accounts(
 
 
 @router.patch("/{policy_id}/rename", response_model=InsuranceAccountResponse)
-async def rename_insurance_account(
+def rename_insurance_account(
     policy_id: str,
     body: InsuranceAccountRename,
     db: Session = Depends(get_database),
@@ -86,7 +86,7 @@ async def rename_insurance_account(
 
 
 @router.post("/sync-investments")
-async def sync_hishtalmut_investments(
+def sync_hishtalmut_investments(
     db: Session = Depends(get_database),
 ) -> dict:
     """Backfill investments from existing hishtalmut insurance accounts.

--- a/backend/routes/investments.py
+++ b/backend/routes/investments.py
@@ -50,7 +50,7 @@ class BalanceSnapshotUpdate(BaseModel):
 
 
 @router.get("/")
-async def get_investments(
+def get_investments(
     include_closed: bool = False, db: Session = Depends(get_database)
 ) -> list[dict[str, Any]]:
     """Return all investment records.
@@ -66,7 +66,7 @@ async def get_investments(
 
 
 @router.get("/{investment_id}")
-async def get_investment(
+def get_investment(
     investment_id: int, db: Session = Depends(get_database)
 ) -> dict[str, Any]:
     """Get a specific investment by ID."""
@@ -75,7 +75,7 @@ async def get_investment(
 
 
 @router.get("/analysis/portfolio")
-async def get_portfolio_analysis(
+def get_portfolio_analysis(
     db: Session = Depends(get_database),
 ) -> dict[str, Any]:
     """Get portfolio-level analysis and metrics."""
@@ -84,7 +84,7 @@ async def get_portfolio_analysis(
 
 
 @router.get("/analysis/balance-history")
-async def get_portfolio_balance_history(
+def get_portfolio_balance_history(
     include_closed: bool = False,
     db: Session = Depends(get_database),
 ) -> dict[str, Any]:
@@ -94,7 +94,7 @@ async def get_portfolio_balance_history(
 
 
 @router.get("/{investment_id}/analysis")
-async def get_investment_analysis(
+def get_investment_analysis(
     investment_id: int,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
@@ -116,7 +116,7 @@ async def get_investment_analysis(
 
 
 @router.post("/")
-async def create_investment(
+def create_investment(
     investment: InvestmentCreate, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Create a new investment."""
@@ -139,7 +139,7 @@ async def create_investment(
 
 
 @router.put("/{investment_id}")
-async def update_investment(
+def update_investment(
     investment_id: int,
     investment: InvestmentUpdate,
     db: Session = Depends(get_database),
@@ -152,7 +152,7 @@ async def update_investment(
 
 
 @router.post("/{investment_id}/close")
-async def close_investment(
+def close_investment(
     investment_id: int, closed_date: str, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Mark an investment as closed.
@@ -170,7 +170,7 @@ async def close_investment(
 
 
 @router.post("/{investment_id}/reopen")
-async def reopen_investment(
+def reopen_investment(
     investment_id: int, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Reopen a closed investment."""
@@ -180,7 +180,7 @@ async def reopen_investment(
 
 
 @router.delete("/{investment_id}")
-async def delete_investment(
+def delete_investment(
     investment_id: int, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Delete an investment."""
@@ -193,7 +193,7 @@ async def delete_investment(
 
 
 @router.get("/{investment_id}/balances")
-async def get_balance_snapshots(
+def get_balance_snapshots(
     investment_id: int, db: Session = Depends(get_database)
 ) -> list[dict[str, Any]]:
     """Get all balance snapshots for an investment."""
@@ -202,7 +202,7 @@ async def get_balance_snapshots(
 
 
 @router.post("/{investment_id}/balances")
-async def create_balance_snapshot(
+def create_balance_snapshot(
     investment_id: int,
     snapshot: BalanceSnapshotCreate,
     db: Session = Depends(get_database),
@@ -214,7 +214,7 @@ async def create_balance_snapshot(
 
 
 @router.post("/{investment_id}/balances/calculate")
-async def calculate_fixed_rate_snapshots(
+def calculate_fixed_rate_snapshots(
     investment_id: int,
     end_date: Optional[str] = None,
     db: Session = Depends(get_database),
@@ -226,7 +226,7 @@ async def calculate_fixed_rate_snapshots(
 
 
 @router.put("/{investment_id}/balances/{snapshot_id}")
-async def update_balance_snapshot(
+def update_balance_snapshot(
     investment_id: int,
     snapshot_id: int,
     snapshot: BalanceSnapshotUpdate,
@@ -240,7 +240,7 @@ async def update_balance_snapshot(
 
 
 @router.delete("/{investment_id}/balances/{snapshot_id}")
-async def delete_balance_snapshot(
+def delete_balance_snapshot(
     investment_id: int,
     snapshot_id: int,
     db: Session = Depends(get_database),

--- a/backend/routes/liabilities.py
+++ b/backend/routes/liabilities.py
@@ -44,7 +44,7 @@ class LiabilityUpdate(BaseModel):
 
 
 @router.get("/")
-async def get_liabilities(
+def get_liabilities(
     include_paid_off: bool = False, db: Session = Depends(get_database)
 ) -> list[dict[str, Any]]:
     """Return all liability records.
@@ -60,7 +60,7 @@ async def get_liabilities(
 
 
 @router.get("/debt-over-time")
-async def get_debt_over_time(
+def get_debt_over_time(
     db: Session = Depends(get_database),
 ) -> dict[str, Any]:
     """Return debt-over-time data for all active liabilities using actual transactions."""
@@ -69,7 +69,7 @@ async def get_debt_over_time(
 
 
 @router.get("/detect-transactions")
-async def detect_tag_transactions(
+def detect_tag_transactions(
     tag: str, db: Session = Depends(get_database)
 ) -> dict[str, Any]:
     """Detect existing transactions for a liability tag.
@@ -82,7 +82,7 @@ async def detect_tag_transactions(
 
 
 @router.get("/{liability_id}/analysis")
-async def get_liability_analysis(
+def get_liability_analysis(
     liability_id: int, db: Session = Depends(get_database)
 ) -> dict[str, Any]:
     """Return detailed analysis for a specific liability."""
@@ -91,7 +91,7 @@ async def get_liability_analysis(
 
 
 @router.get("/{liability_id}/transactions")
-async def get_liability_transactions(
+def get_liability_transactions(
     liability_id: int, db: Session = Depends(get_database)
 ) -> list[dict[str, Any]]:
     """Return all transactions associated with a specific liability."""
@@ -100,7 +100,7 @@ async def get_liability_transactions(
 
 
 @router.get("/{liability_id}")
-async def get_liability(
+def get_liability(
     liability_id: int, db: Session = Depends(get_database)
 ) -> dict[str, Any]:
     """Get a specific liability by ID."""
@@ -109,7 +109,7 @@ async def get_liability(
 
 
 @router.post("/")
-async def create_liability(
+def create_liability(
     liability: LiabilityCreate, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Create a new liability."""
@@ -128,7 +128,7 @@ async def create_liability(
 
 
 @router.put("/{liability_id}")
-async def update_liability(
+def update_liability(
     liability_id: int,
     liability: LiabilityUpdate,
     db: Session = Depends(get_database),
@@ -145,7 +145,7 @@ class PayOffRequest(BaseModel):
 
 
 @router.post("/{liability_id}/pay-off")
-async def pay_off_liability(
+def pay_off_liability(
     liability_id: int, body: PayOffRequest, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Mark a liability as paid off.
@@ -163,7 +163,7 @@ async def pay_off_liability(
 
 
 @router.post("/{liability_id}/reopen")
-async def reopen_liability(
+def reopen_liability(
     liability_id: int, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Reopen a paid-off liability."""
@@ -173,7 +173,7 @@ async def reopen_liability(
 
 
 @router.post("/{liability_id}/generate-transactions")
-async def generate_missing_transactions(
+def generate_missing_transactions(
     liability_id: int, db: Session = Depends(get_database)
 ) -> dict[str, Any]:
     """Auto-generate missing payment transactions from amortization schedule."""
@@ -183,7 +183,7 @@ async def generate_missing_transactions(
 
 
 @router.delete("/{liability_id}")
-async def delete_liability(
+def delete_liability(
     liability_id: int, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Delete a liability."""

--- a/backend/routes/onboarding.py
+++ b/backend/routes/onboarding.py
@@ -33,7 +33,7 @@ class OnboardingStatus(BaseModel):
 
 
 @router.get("/status", response_model=OnboardingStatus)
-async def get_onboarding_status(
+def get_onboarding_status(
     db: Session = Depends(get_database),
 ) -> OnboardingStatus:
     """Return whether the active database has been populated yet."""

--- a/backend/routes/pending_refunds.py
+++ b/backend/routes/pending_refunds.py
@@ -35,7 +35,7 @@ class LinkRefundRequest(BaseModel):
 
 
 @router.post("/")
-async def create_pending_refund(
+def create_pending_refund(
     request: CreatePendingRefundRequest,
     db: Session = Depends(get_database),
 ):
@@ -51,7 +51,7 @@ async def create_pending_refund(
 
 
 @router.get("/")
-async def get_all_pending_refunds(
+def get_all_pending_refunds(
     status: Optional[str] = None,
     db: Session = Depends(get_database),
 ):
@@ -61,7 +61,7 @@ async def get_all_pending_refunds(
 
 
 @router.get("/budget-adjustment")
-async def get_budget_adjustment(
+def get_budget_adjustment(
     year: int,
     month: int,
     db: Session = Depends(get_database),
@@ -92,7 +92,7 @@ async def get_budget_adjustment(
 
 
 @router.get("/{pending_id}")
-async def get_pending_refund(
+def get_pending_refund(
     pending_id: int,
     db: Session = Depends(get_database),
 ):
@@ -102,7 +102,7 @@ async def get_pending_refund(
 
 
 @router.delete("/{pending_id}")
-async def cancel_pending_refund(
+def cancel_pending_refund(
     pending_id: int,
     db: Session = Depends(get_database),
 ):
@@ -113,7 +113,7 @@ async def cancel_pending_refund(
 
 
 @router.post("/{pending_id}/link")
-async def link_refund(
+def link_refund(
     pending_id: int,
     request: LinkRefundRequest,
     db: Session = Depends(get_database),
@@ -129,7 +129,7 @@ async def link_refund(
 
 
 @router.post("/{pending_id}/close")
-async def close_pending_refund(
+def close_pending_refund(
     pending_id: int,
     db: Session = Depends(get_database),
 ):
@@ -139,7 +139,7 @@ async def close_pending_refund(
 
 
 @router.delete("/links/{link_id}")
-async def unlink_refund(
+def unlink_refund(
     link_id: int,
     db: Session = Depends(get_database),
 ):

--- a/backend/routes/retirement.py
+++ b/backend/routes/retirement.py
@@ -148,14 +148,14 @@ class ScrapedDefaultsResponse(BaseModel):
 
 
 @router.get("/goal", response_model=Optional[RetirementGoalResponse])
-async def get_goal(db: Session = Depends(get_database)):
+def get_goal(db: Session = Depends(get_database)):
     """Get the retirement goal profile, or null if not configured."""
     service = RetirementService(db)
     return service.get_goal()
 
 
 @router.put("/goal", response_model=RetirementGoalResponse)
-async def upsert_goal(
+def upsert_goal(
     data: RetirementGoalUpsert, db: Session = Depends(get_database)
 ):
     """Create or update the retirement goal profile."""
@@ -164,21 +164,21 @@ async def upsert_goal(
 
 
 @router.get("/status", response_model=RetirementStatusResponse)
-async def get_status(db: Session = Depends(get_database)):
+def get_status(db: Session = Depends(get_database)):
     """Get current financial status from real tracked data."""
     service = RetirementService(db)
     return service.get_current_status()
 
 
 @router.get("/projections", response_model=RetirementProjectionsResponse)
-async def get_projections(db: Session = Depends(get_database)):
+def get_projections(db: Session = Depends(get_database)):
     """Get FIRE projections from the saved goal."""
     service = RetirementService(db)
     return service.get_projections()
 
 
 @router.post("/projections", response_model=RetirementProjectionsResponse)
-async def preview_projections(
+def preview_projections(
     data: RetirementGoalUpsert, db: Session = Depends(get_database)
 ):
     """Compute FIRE projections from provided goal params without saving."""
@@ -187,14 +187,14 @@ async def preview_projections(
 
 
 @router.get("/suggestions", response_model=RetirementSuggestionsResponse)
-async def get_suggestions(db: Session = Depends(get_database)):
+def get_suggestions(db: Session = Depends(get_database)):
     """Solve all adjustable fields from the saved goal."""
     service = RetirementService(db)
     return service.solve_all_fields()
 
 
 @router.post("/suggestions", response_model=RetirementSuggestionsResponse)
-async def preview_suggestions(
+def preview_suggestions(
     data: RetirementGoalUpsert, db: Session = Depends(get_database)
 ):
     """Solve all adjustable fields from provided goal params without saving."""
@@ -203,14 +203,14 @@ async def preview_suggestions(
 
 
 @router.get("/solve/{field}", response_model=SolveFieldResponse)
-async def solve_for_field(field: str, db: Session = Depends(get_database)):
+def solve_for_field(field: str, db: Session = Depends(get_database)):
     """Solve for a field value that reaches FIRE at target retirement age."""
     service = RetirementService(db)
     return service.solve_for_field(field)
 
 
 @router.get("/keren-hishtalmut-balance", response_model=KerenHishtalmutBalanceResponse)
-async def get_keren_hishtalmut_balance(db: Session = Depends(get_database)):
+def get_keren_hishtalmut_balance(db: Session = Depends(get_database)):
     """Get auto-detected Keren Hishtalmut balance from scraped insurance data."""
     service = RetirementService(db)
     balance = service.get_keren_hishtalmut_scraped_balance()
@@ -218,7 +218,7 @@ async def get_keren_hishtalmut_balance(db: Session = Depends(get_database)):
 
 
 @router.get("/scraped-defaults", response_model=ScrapedDefaultsResponse)
-async def get_scraped_defaults(db: Session = Depends(get_database)):
+def get_scraped_defaults(db: Session = Depends(get_database)):
     """Get all auto-fillable values from scraped insurance data.
 
     Returns Keren Hishtalmut balance and monthly contribution, plus

--- a/backend/routes/savings_goals.py
+++ b/backend/routes/savings_goals.py
@@ -36,19 +36,19 @@ class SavingsGoalUpdate(BaseModel):
 
 
 @router.get("/")
-async def list_goals(db: Session = Depends(get_database)):
+def list_goals(db: Session = Depends(get_database)):
     """Return all savings goals enriched with progress metrics."""
     return SavingsGoalService(db).get_all()
 
 
 @router.post("/")
-async def create_goal(data: SavingsGoalCreate, db: Session = Depends(get_database)):
+def create_goal(data: SavingsGoalCreate, db: Session = Depends(get_database)):
     """Create a new savings goal."""
     return SavingsGoalService(db).create(**data.model_dump())
 
 
 @router.put("/{goal_id}")
-async def update_goal(
+def update_goal(
     goal_id: int, data: SavingsGoalUpdate, db: Session = Depends(get_database)
 ):
     """Update an existing savings goal."""
@@ -56,7 +56,7 @@ async def update_goal(
 
 
 @router.delete("/{goal_id}")
-async def delete_goal(goal_id: int, db: Session = Depends(get_database)):
+def delete_goal(goal_id: int, db: Session = Depends(get_database)):
     """Delete a savings goal."""
     SavingsGoalService(db).delete(goal_id)
     return {"status": "deleted"}

--- a/backend/routes/scraping.py
+++ b/backend/routes/scraping.py
@@ -48,7 +48,7 @@ class StatusResponse(BaseModel):
 
 
 @router.post("/start")
-async def start_scraping_single(
+def start_scraping_single(
     data: StartScrapingRequest, db: Session = Depends(get_database)
 ) -> int:
     """Start a scraping job for a single account.
@@ -80,7 +80,7 @@ async def start_scraping_single(
 
 
 @router.post("/abort", response_model=StatusResponse)
-async def abort_scraping(
+def abort_scraping(
     data: AbortRequest, db: Session = Depends(get_database)
 ) -> dict:
     """Abort a running scraping process.
@@ -101,7 +101,7 @@ async def abort_scraping(
 
 
 @router.get("/status")
-async def get_scraping_status(
+def get_scraping_status(
     scraping_process_id: int, db: Session = Depends(get_database)
 ) -> dict:
     """Return the current status of a scraping job.
@@ -122,7 +122,7 @@ async def get_scraping_status(
 
 
 @router.post("/2fa", response_model=StatusResponse)
-async def handle_2fa(
+def handle_2fa(
     data: TFAFinishRequest, db: Session = Depends(get_database)
 ) -> dict:
     """Submit a 2FA OTP code to unblock a waiting scraping job.
@@ -186,7 +186,7 @@ async def resend_2fa(
 
 
 @router.get("/last-scrapes")
-async def get_last_scrapes(db: Session = Depends(get_database)) -> list:
+def get_last_scrapes(db: Session = Depends(get_database)) -> list:
     """Return the last successful scrape date for each configured account.
 
     Returns

--- a/backend/routes/tagging.py
+++ b/backend/routes/tagging.py
@@ -50,13 +50,13 @@ class TagRename(BaseModel):
 
 
 @router.get("/categories")
-async def get_categories(db: Session = Depends(get_database)):
+def get_categories(db: Session = Depends(get_database)):
     """Get all categories and their tags."""
     return CategoriesTagsService(db).get_categories_and_tags()
 
 
 @router.post("/categories")
-async def add_category(category: CategoryCreate, db: Session = Depends(get_database)):
+def add_category(category: CategoryCreate, db: Session = Depends(get_database)):
     """Add a new category."""
     try:
         CategoriesTagsService(db).add_category(category.name, category.tags)
@@ -66,7 +66,7 @@ async def add_category(category: CategoryCreate, db: Session = Depends(get_datab
 
 
 @router.delete("/categories/{name}")
-async def delete_category(name: str, db: Session = Depends(get_database)):
+def delete_category(name: str, db: Session = Depends(get_database)):
     """Delete a category and all its tags.
 
     Transactions that were assigned to this category or any of its tags
@@ -80,7 +80,7 @@ async def delete_category(name: str, db: Session = Depends(get_database)):
 
 
 @router.post("/tags")
-async def create_tag(tag: TagCreate, db: Session = Depends(get_database)):
+def create_tag(tag: TagCreate, db: Session = Depends(get_database)):
     """Add a tag to a category."""
     try:
         CategoriesTagsService(db).add_tag(tag.category, tag.name)
@@ -90,7 +90,7 @@ async def create_tag(tag: TagCreate, db: Session = Depends(get_database)):
 
 
 @router.delete("/tags/{category}/{name}")
-async def delete_tag(category: str, name: str, db: Session = Depends(get_database)):
+def delete_tag(category: str, name: str, db: Session = Depends(get_database)):
     """Delete a tag from a category.
 
     Transactions tagged with this tag have their ``tag`` field (and optionally
@@ -104,7 +104,7 @@ async def delete_tag(category: str, name: str, db: Session = Depends(get_databas
 
 
 @router.post("/tags/relocate")
-async def relocate_tag(data: TagRelocate, db: Session = Depends(get_database)):
+def relocate_tag(data: TagRelocate, db: Session = Depends(get_database)):
     """Move a tag from one category to another.
 
     Updates the YAML config and re-categorises transactions that carry this
@@ -120,7 +120,7 @@ async def relocate_tag(data: TagRelocate, db: Session = Depends(get_database)):
 
 
 @router.put("/categories/{name}")
-async def rename_category(name: str, data: CategoryRename, db: Session = Depends(get_database)):
+def rename_category(name: str, data: CategoryRename, db: Session = Depends(get_database)):
     """Rename a category and cascade the change across all tables."""
     from backend.errors import ValidationException
 
@@ -133,7 +133,7 @@ async def rename_category(name: str, data: CategoryRename, db: Session = Depends
 
 
 @router.put("/tags/{category}/{name}")
-async def rename_tag(category: str, name: str, data: TagRename, db: Session = Depends(get_database)):
+def rename_tag(category: str, name: str, data: TagRename, db: Session = Depends(get_database)):
     """Rename a tag and cascade the change across all tables."""
     from backend.errors import ValidationException
 
@@ -146,13 +146,13 @@ async def rename_tag(category: str, name: str, data: TagRename, db: Session = De
 
 
 @router.get("/icons")
-async def get_category_icons(db: Session = Depends(get_database)):
+def get_category_icons(db: Session = Depends(get_database)):
     """Get category icons mapping."""
     return CategoriesTagsService(db).get_categories_icons()
 
 
 @router.put("/icons/{category}")
-async def update_category_icon(
+def update_category_icon(
     category: str, icon: str, db: Session = Depends(get_database)
 ):
     """Update a category's icon."""
@@ -161,7 +161,7 @@ async def update_category_icon(
 
 
 @router.post("/add-new-credit-card-tags")
-async def add_new_credit_card_tags(db: Session = Depends(get_database)):
+def add_new_credit_card_tags(db: Session = Depends(get_database)):
     """Discover credit card accounts from transaction data and register them as tags.
 
     Scans credit card transactions for unique provider/account combinations and

--- a/backend/routes/tagging_rules.py
+++ b/backend/routes/tagging_rules.py
@@ -41,7 +41,7 @@ class RuleValidate(BaseModel):
 
 
 @router.get("/rules")
-async def get_tagging_rules(db: Session = Depends(get_database)):
+def get_tagging_rules(db: Session = Depends(get_database)):
     """Get all tagging rules."""
     service = TaggingRulesService(db)
     df = service.get_all_rules()
@@ -49,7 +49,7 @@ async def get_tagging_rules(db: Session = Depends(get_database)):
 
 
 @router.post("/rules")
-async def create_tagging_rule(rule: RuleCreate, db: Session = Depends(get_database)):
+def create_tagging_rule(rule: RuleCreate, db: Session = Depends(get_database)):
     """Create a new tagging rule and immediately apply it to existing transactions.
 
     Returns
@@ -79,7 +79,7 @@ async def create_tagging_rule(rule: RuleCreate, db: Session = Depends(get_databa
 
 
 @router.put("/rules/{rule_id}")
-async def update_tagging_rule(
+def update_tagging_rule(
     rule_id: int, rule: RuleUpdate, db: Session = Depends(get_database)
 ):
     """Update an existing tagging rule and re-apply it.
@@ -109,7 +109,7 @@ async def update_tagging_rule(
 
 
 @router.delete("/rules/{rule_id}")
-async def delete_tagging_rule(rule_id: int, db: Session = Depends(get_database)):
+def delete_tagging_rule(rule_id: int, db: Session = Depends(get_database)):
     """Delete a tagging rule."""
     service = TaggingRulesService(db)
     try:
@@ -120,7 +120,7 @@ async def delete_tagging_rule(rule_id: int, db: Session = Depends(get_database))
 
 
 @router.post("/rules/apply")
-async def apply_tagging_rules(
+def apply_tagging_rules(
     overwrite: bool = False, db: Session = Depends(get_database)
 ):
     """Manually trigger application of all active tagging rules.
@@ -145,7 +145,7 @@ async def apply_tagging_rules(
 
 
 @router.post("/rules/{rule_id}/apply")
-async def apply_single_tagging_rule(
+def apply_single_tagging_rule(
     rule_id: int, overwrite: bool = False, db: Session = Depends(get_database)
 ):
     """Apply a single tagging rule to all transactions.
@@ -174,7 +174,7 @@ async def apply_single_tagging_rule(
 
 
 @router.post("/rules/validate")
-async def validate_rule_conflicts(
+def validate_rule_conflicts(
     rule: RuleValidate, db: Session = Depends(get_database)
 ):
     """Check whether a rule's conditions conflict with existing rules.
@@ -220,7 +220,7 @@ class RulePreview(BaseModel):
 
 
 @router.post("/rules/preview")
-async def preview_rule_matches(
+def preview_rule_matches(
     preview: RulePreview, db: Session = Depends(get_database)
 ):
     """Preview which transactions would be matched by given rule conditions.
@@ -250,7 +250,7 @@ async def preview_rule_matches(
 
 
 @router.post("/rules/auto-tag-credit-cards-bills")
-async def auto_tag_credit_cards_bills(db: Session = Depends(get_database)):
+def auto_tag_credit_cards_bills(db: Session = Depends(get_database)):
     """Auto-tag bank transactions that represent credit card monthly bill payments.
 
     For each credit card account tag (discovered via ``add-new-credit-card-tags``),

--- a/backend/routes/testing.py
+++ b/backend/routes/testing.py
@@ -28,7 +28,7 @@ class DemoModeRequest(BaseModel):
 
 
 @router.post("/toggle_demo_mode")
-async def toggle_demo_mode(
+def toggle_demo_mode(
     request: DemoModeRequest,
 ) -> dict[str, str | bool]:
     """Toggle the application's demo mode on or off.
@@ -73,6 +73,6 @@ async def toggle_demo_mode(
 
 
 @router.get("/demo_mode_status")
-async def get_demo_mode_status():
+def get_demo_mode_status():
     """Get the current demo mode status."""
     return {"demo_mode": AppConfig().is_demo_mode}

--- a/backend/routes/transactions.py
+++ b/backend/routes/transactions.py
@@ -73,7 +73,7 @@ class LatestDateResponse(BaseModel):
 
 
 @router.get("/")
-async def get_transactions(
+def get_transactions(
     service: Optional[str] = Query(
         None, description="Filter by service: credit_card, bank, cash"
     ),
@@ -97,7 +97,7 @@ async def get_transactions(
 
 
 @router.post("/", response_model=StatusResponse)
-async def create_transaction(
+def create_transaction(
     data: TransactionCreate, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Create a new manual transaction."""
@@ -112,7 +112,7 @@ async def create_transaction(
 
 
 @router.put("/{unique_id}", response_model=StatusResponse)
-async def update_transaction(
+def update_transaction(
     unique_id: str, data: TransactionUpdate, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Update editable fields of a transaction.
@@ -149,7 +149,7 @@ async def update_transaction(
 
 
 @router.delete("/{unique_id}", response_model=StatusResponse)
-async def delete_transaction(
+def delete_transaction(
     unique_id: str,
     source: str = Query(..., description="The source of the transaction"),
     db: Session = Depends(get_database),
@@ -166,7 +166,7 @@ async def delete_transaction(
 
 
 @router.post("/{unique_id}/split", response_model=StatusResponse)
-async def split_transaction(
+def split_transaction(
     unique_id: int, data: SplitRequest, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Split a transaction into multiple parts."""
@@ -180,7 +180,7 @@ async def split_transaction(
 
 
 @router.delete("/{unique_id}/split", response_model=StatusResponse)
-async def revert_split(
+def revert_split(
     unique_id: int,
     source: str = Query(..., description="The source of the transaction"),
     db: Session = Depends(get_database),
@@ -195,7 +195,7 @@ async def revert_split(
 
 
 @router.post("/bulk-tag", response_model=StatusResponse)
-async def bulk_tag_transactions(
+def bulk_tag_transactions(
     data: BulkTagUpdate, db: Session = Depends(get_database)
 ) -> dict[str, str]:
     """Apply tagging and optional field updates to multiple transactions of the same source."""
@@ -217,7 +217,7 @@ async def bulk_tag_transactions(
 
 
 @router.get("/latest-date", response_model=LatestDateResponse)
-async def get_latest_data_date(
+def get_latest_data_date(
     db: Session = Depends(get_database),
 ) -> dict[str, str | None]:
     """Get the latest transaction date across all tables."""
@@ -227,7 +227,7 @@ async def get_latest_data_date(
 
 
 @router.get("/{transaction_id}")
-async def get_transaction(
+def get_transaction(
     transaction_id: int, db: Session = Depends(get_database)
 ) -> dict[str, Any]:
     """Get a specific transaction by ID."""
@@ -240,7 +240,7 @@ async def get_transaction(
 
 
 @router.put("/{transaction_id}/tag", response_model=StatusResponse)
-async def update_transaction_tag(
+def update_transaction_tag(
     transaction_id: str,
     category: str,
     tag: str,

--- a/backend/services/analysis_service.py
+++ b/backend/services/analysis_service.py
@@ -799,15 +799,26 @@ class AnalysisService:
             "net_worth": round(prior_wealth_total + cash_prior_wealth, 2),
         }]
 
+        # Value the portfolio at every month end in a single pass rather than
+        # one snapshot/transaction database walk per month (the old per-month
+        # call re-fetched every investment and its snapshots for each month).
+        month_ends = {
+            month: (pd.to_datetime(month + "-01") + pd.offsets.MonthEnd(0))
+            for month in months
+        }
+        inv_values = self.investments_service.get_total_values_at_dates(
+            [month_end.strftime("%Y-%m-%d") for month_end in month_ends.values()]
+        )
+
         for month in months:
-            month_end = pd.to_datetime(month + "-01") + pd.offsets.MonthEnd(0)
+            month_end = month_ends[month]
             month_end_str = month_end.strftime("%Y-%m-%d")
 
             bank_balance = prior_wealth_total + float(
                 bank_df.loc[bank_df["date_parsed"] <= month_end, "amount"].sum()
             )
 
-            inv_value = self.investments_service.get_total_value_at_date(month_end_str)
+            inv_value = inv_values[month_end_str]
 
             cash_balance = cash_prior_wealth + float(
                 cash_df.loc[cash_df["date_parsed"] <= month_end, "amount"].sum()

--- a/backend/services/investments_service.py
+++ b/backend/services/investments_service.py
@@ -4,6 +4,7 @@ Investments service with pure SQLAlchemy (no Streamlit dependencies).
 This module provides business logic for investment tracking and analysis.
 """
 
+from bisect import bisect_right
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -905,26 +906,68 @@ class InvestmentsService:
         float
             Total portfolio value as of ``target_date``.
         """
+        return self.get_total_values_at_dates([target_date])[target_date]
+
+    def get_total_values_at_dates(self, target_dates: List[str]) -> Dict[str, float]:
+        """Snapshot-resolved total portfolio value at many dates in one pass.
+
+        Equivalent to calling :meth:`get_total_value_at_date` for each date,
+        but fetches every investment's snapshots and transactions **once**
+        instead of once per date. This turns the net-worth-over-time chart
+        (which values the portfolio at each month end) from an O(months ×
+        investments) database walk into O(investments) — the per-month
+        resolution then happens in-memory.
+
+        Per investment and per date the resolution is identical to the
+        single-date method: the latest snapshot on or before the date if one
+        exists (snapshots are unique per ``(investment, date)`` and stored as
+        ``YYYY-MM-DD`` strings, so an ordered lexical search is exact),
+        otherwise the transaction-based ``-sum(amounts up to the date)``.
+
+        Parameters
+        ----------
+        target_dates : list[str]
+            Cut-off dates in ``YYYY-MM-DD`` format (inclusive).
+
+        Returns
+        -------
+        dict[str, float]
+            Mapping of each requested date to the total portfolio value as of
+            that date.
+        """
+        totals = {d: 0.0 for d in target_dates}
+        if not target_dates:
+            return totals
+
         investments = self.investments_repo.get_all_investments(include_closed=True)
         if investments.empty:
-            return 0.0
+            return totals
 
-        total = 0.0
         for _, inv in investments.iterrows():
             inv_id = int(inv["id"])
-            snapshot = self.snapshots_repo.get_latest_snapshot_on_or_before(
-                inv_id, target_date
+            snapshots = self.snapshots_repo.get_snapshots_for_investment(inv_id)
+            snapshot_dates = snapshots["date"].tolist() if not snapshots.empty else []
+            snapshot_balances = (
+                snapshots["balance"].tolist() if not snapshots.empty else []
             )
-            if snapshot is not None:
-                total += float(snapshot["balance"])
-                continue
-            txns = self._get_all_transactions_for_investment(
-                inv["category"], inv["tag"], investment_id=inv_id
-            )
-            total += self._calculate_balance_from_transactions(
-                txns, as_of_date=target_date
-            )
-        return total
+
+            # Transactions are only needed for dates with no preceding
+            # snapshot; fetch lazily so investments fully covered by snapshots
+            # never touch the transactions table.
+            txns = None
+            for target_date in target_dates:
+                idx = bisect_right(snapshot_dates, target_date) - 1
+                if idx >= 0:
+                    totals[target_date] += float(snapshot_balances[idx])
+                    continue
+                if txns is None:
+                    txns = self._get_all_transactions_for_investment(
+                        inv["category"], inv["tag"], investment_id=inv_id
+                    )
+                totals[target_date] += self._calculate_balance_from_transactions(
+                    txns, as_of_date=target_date
+                )
+        return totals
 
     def calculate_balance_over_time(
         self, investment_id: int, start_date: str, end_date: str

--- a/frontend/e2e/dashboard-layout.spec.ts
+++ b/frontend/e2e/dashboard-layout.spec.ts
@@ -67,6 +67,10 @@ test.describe("Dashboard layout customization", () => {
     await hiddenRow.getByRole("button", { name: /Show card/i }).click();
     await page.keyboard.press("Escape");
 
+    // A restored card is appended to the end of the order — below the fold,
+    // where cards defer their mount until scrolled near. Scroll to it, then
+    // its content renders.
+    await page.locator('[data-card-id="heatmap"]').scrollIntoViewIfNeeded();
     await expect(page.getByText(/Spending Calendar/i).first()).toBeVisible();
   });
 
@@ -110,6 +114,9 @@ test.describe("Dashboard layout customization", () => {
     await betaRow.getByRole("button", { name: /Show card/i }).click();
     await page.keyboard.press("Escape");
 
+    // The newly enabled card is appended below the fold, where cards defer
+    // their mount until scrolled near. Scroll to it, then its content renders.
+    await page.locator('[data-card-id="forecast"]').scrollIntoViewIfNeeded();
     // "Safe to spend" is unique to the forecast card.
     await expect(page.getByText(/Safe to spend/i).first()).toBeVisible();
   });

--- a/frontend/e2e/dashboard-lazy-cards.spec.ts
+++ b/frontend/e2e/dashboard-lazy-cards.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+import { enableDemoMode, disableDemoMode } from "./helpers";
+
+/**
+ * Below-the-fold dashboard cards defer mounting (and their analytics requests)
+ * until scrolled near the viewport, so the pinned KPI header and the top cards
+ * own the first paint. Eager (above-the-fold) cards must still render on load;
+ * a deferred chart card must mount its Plotly chart only after it scrolls in.
+ */
+test.describe("Dashboard lazy card mounting", () => {
+  test.beforeAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await enableDemoMode(page);
+    await page.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    await disableDemoMode(page);
+    await page.close();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    // Start from the default layout (income_expenses + net_worth visible last).
+    await page.addInitScript(() =>
+      window.localStorage.removeItem("fa.dashboard.layout"),
+    );
+  });
+
+  test("top cards render eagerly; a bottom chart card mounts on scroll", async ({
+    page,
+  }) => {
+    // A short viewport keeps the trailing chart cards well below the fold.
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    // The pinned KPI header is always eager.
+    await expect(page.getByText(/Net Worth/i).first()).toBeVisible({
+      timeout: 45_000,
+    });
+
+    // The first eager chart card (Income by source, row 2) renders its plot
+    // without any scrolling.
+    await expect(
+      page.locator('[data-card-id="income_by_source"] .js-plotly-plot').first(),
+    ).toBeVisible({ timeout: 45_000 });
+
+    // The trailing Net Worth card exists (placeholder reserves its height) but
+    // has NOT mounted its chart yet — it's far below the fold.
+    const netWorthCard = page.locator('[data-card-id="net_worth"]');
+    await expect(netWorthCard).toBeVisible();
+    await expect(netWorthCard.locator(".js-plotly-plot")).toHaveCount(0);
+
+    // Scroll it into view — now it mounts and renders its Plotly chart.
+    await netWorthCard.scrollIntoViewIfNeeded();
+    await expect(netWorthCard.locator(".js-plotly-plot").first()).toBeVisible({
+      timeout: 45_000,
+    });
+  });
+});

--- a/frontend/src/components/common/DeferUntilVisible.tsx
+++ b/frontend/src/components/common/DeferUntilVisible.tsx
@@ -1,0 +1,71 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+interface DeferUntilVisibleProps {
+  /** The card content to mount once the placeholder scrolls near the viewport. */
+  children: ReactNode;
+  /**
+   * Render immediately, skipping the observer. Used for the first few cards
+   * (above the fold on any realistic viewport) so they never flash a skeleton
+   * and their data is requested on the very first paint.
+   */
+  eager?: boolean;
+  /**
+   * Tailwind class reserving the placeholder's height so cards further down
+   * stay genuinely below the fold (otherwise every zero-height placeholder
+   * stacks at the top and the observer mounts them all at once).
+   */
+  reserveClassName?: string;
+}
+
+/**
+ * Defers mounting `children` — and therefore any data queries they fire — until
+ * the card is scrolled to within a short margin of the viewport.
+ *
+ * On first open the dashboard mounts ~a dozen cards, each firing its own
+ * analytics request. Letting the below-the-fold chart cards wait until they're
+ * about to be seen keeps the initial request burst (and the Plotly bundle
+ * parse) focused on the content the user is actually looking at — the pinned
+ * KPI header and the top cards — so the dashboard becomes interactive sooner.
+ *
+ * Once a card becomes visible it stays mounted: the observer disconnects and
+ * the card never unmounts on scroll-away, so its queries don't refetch.
+ */
+export function DeferUntilVisible({
+  children,
+  eager = false,
+  reserveClassName = "min-h-[20rem]",
+}: DeferUntilVisibleProps) {
+  // Environments without IntersectionObserver (jsdom, SSR) render eagerly —
+  // decided at init so the effect never has to call setState synchronously.
+  const [visible, setVisible] = useState(
+    () => eager || typeof IntersectionObserver === "undefined",
+  );
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (visible) return;
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "300px" },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [visible]);
+
+  if (visible) return <>{children}</>;
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={`${reserveClassName} rounded-xl bg-[var(--surface)]/40 animate-pulse`}
+    />
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -23,6 +23,7 @@ import { NetWorthCard } from "../components/dashboard/NetWorthCard";
 import { CashFlowCard } from "../components/dashboard/CashFlowCard";
 import { CategoryBreakdownCard } from "../components/dashboard/CategoryBreakdownCard";
 import { Skeleton } from "../components/common/Skeleton";
+import { DeferUntilVisible } from "../components/common/DeferUntilVisible";
 import { EmptyState } from "../components/common/EmptyState";
 import { DemoModeConfirmPopover } from "../components/common/DemoModeConfirmPopover";
 import { useDemoMode } from "../context/DemoModeContext";
@@ -31,6 +32,12 @@ import { formatCurrency, formatChange, formatPercentChange } from "../utils/numb
 import { formatMonthCompact } from "../utils/dateFormatting";
 import { useDashboardLayout, cardSize, type DashboardCardId } from "../hooks/useDashboardLayout";
 
+
+/* How many leading cards render eagerly on first paint. The rest defer until
+ * scrolled near the viewport. Four covers the two half-card rows that sit above
+ * the fold in the default layout, so the visible dashboard is never gated on a
+ * skeleton while the heavier chart cards below load lazily. */
+const EAGER_CARD_COUNT = 4;
 
 /* ------------------------------------------------------------------ */
 /*  Helper sub-components (extracted to avoid creating during render)  */
@@ -361,7 +368,7 @@ export function Dashboard() {
           taller card (still capped). On mobile the grid is a single column with
           natural, uncapped heights. */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8 [--dash-card-h:39rem]">
-        {layout.order.map((id) => (
+        {layout.order.map((id, index) => (
           <div
             key={id}
             data-card-id={id}
@@ -370,7 +377,17 @@ export function Dashboard() {
               id !== "recent" ? "lg:[&>*]:max-h-[var(--dash-card-h)]" : ""
             } ${cardSize(id) === "full" ? "lg:col-span-2" : ""}`}
           >
-            {cardRenderers[id]()}
+            {/* The first cards render eagerly (above the fold on any viewport);
+                the rest wait until scrolled near, so their analytics requests
+                don't compete with the header + top cards on first paint. The
+                placeholder reserves the card's capped height so lower cards
+                stay below the fold and the layout doesn't jump on mount. */}
+            <DeferUntilVisible
+              eager={index < EAGER_CARD_COUNT}
+              reserveClassName={cardSize(id) === "full" ? "min-h-[39rem]" : "min-h-[20rem]"}
+            >
+              {cardRenderers[id]()}
+            </DeferUntilVisible>
           </div>
         ))}
       </div>

--- a/tests/backend/unit/services/test_investments_service.py
+++ b/tests/backend/unit/services/test_investments_service.py
@@ -168,6 +168,61 @@ class TestInvestmentsServiceCalculations:
         last_date = history[-1]["date"]
         assert last_date == "2024-01-10"
 
+    def test_get_total_values_at_dates_transaction_based(
+        self, db_session, seed_investments
+    ):
+        """Verify batch valuation matches per-date resolution with no snapshots.
+
+        Stock fund txns: -10000 @ 2023-06-15, -2000 @ 2024-01-15.
+        Bond fund txns: -5000 @ 2023-01-10, +5160 @ 2024-01-10.
+        Balance per investment is -(sum of amounts up to the date).
+        """
+        service = InvestmentsService(db_session)
+        dates = ["2023-01-01", "2023-06-15", "2024-01-10", "2024-01-15"]
+
+        totals = service.get_total_values_at_dates(dates)
+
+        assert totals["2023-01-01"] == 0.0  # before any transaction
+        assert totals["2023-06-15"] == 15000.0  # stock 10000 + bond 5000
+        assert totals["2024-01-10"] == pytest.approx(9840.0)  # 10000 + (-160)
+        assert totals["2024-01-15"] == pytest.approx(11840.0)  # 12000 + (-160)
+
+        # A single-date call must agree with the batch call, entry for entry.
+        for d in dates:
+            assert service.get_total_value_at_date(d) == pytest.approx(totals[d])
+
+    def test_get_total_values_at_dates_snapshot_first(
+        self, db_session, seed_investments
+    ):
+        """Verify batch valuation is snapshot-first with transaction fallback.
+
+        A snapshot on 2023-12-31 overrides the stock fund's transaction-based
+        balance for dates on or after it; dates before it still fall back to
+        the transaction calculation.
+        """
+        service = InvestmentsService(db_session)
+        stock_fund = seed_investments["investments"][0]
+        service.snapshots_repo.upsert_snapshot(
+            stock_fund.id, date="2023-12-31", balance=11000.0, source="manual"
+        )
+
+        totals = service.get_total_values_at_dates(
+            ["2023-06-15", "2023-12-31", "2024-01-15"]
+        )
+
+        # Before the snapshot: transaction-based (stock 10000 + bond 5000).
+        assert totals["2023-06-15"] == 15000.0
+        # On the snapshot date: stock snapshot 11000 + bond txns 5000.
+        assert totals["2023-12-31"] == pytest.approx(16000.0)
+        # After the snapshot: stock snapshot 11000 + bond -160.
+        assert totals["2024-01-15"] == pytest.approx(10840.0)
+
+    def test_get_total_values_at_dates_empty_inputs(self, db_session):
+        """Verify empty date list and empty portfolio both return safe defaults."""
+        service = InvestmentsService(db_session)
+        assert service.get_total_values_at_dates([]) == {}
+        assert service.get_total_values_at_dates(["2024-01-01"]) == {"2024-01-01": 0.0}
+
     def test_get_portfolio_overview(self, db_session, seed_investments):
         """Verify portfolio totals reflect open only; allocation includes all."""
         service = InvestmentsService(db_session)


### PR DESCRIPTION
## Why

Opening the app on the dashboard was slow on first load. Root cause was mostly on the backend: the ~20 requests the dashboard fires were being processed **one at a time**, and the KPI header's endpoint did an O(months × investments) database walk.

## What changed

**1. `perf(api)`: run blocking route handlers in the threadpool**
All 135 route handlers were declared `async def` but did purely synchronous work (SQLAlchemy, pandas, keyring, file I/O) with **zero `await`s**. FastAPI runs `async def` handlers on the event loop thread, so every request serialized behind the others. Converted the 135 non-awaiting handlers to plain `def` so FastAPI runs them in its worker threadpool — real request concurrency. The one handler that genuinely awaits (`resend_2fa`) stays async. SQLite is already configured for multi-threaded access (`NullPool`, `check_same_thread=False`, a fresh session per request), so this is safe. *This is the dominant win.*

**2. `perf(analytics)`: value net worth at all month ends in one pass**
`get_net_worth_over_time` valued the portfolio one month at a time, re-fetching every investment plus a per-investment snapshot query each month — an O(months × investments) walk that gates the KPI header. Added `InvestmentsService.get_total_values_at_dates`, which fetches each investment's snapshots and transactions once and resolves every requested date in memory (snapshot-first, transaction fallback — identical semantics; the single-date method now delegates to it). O(investments) now.

**3. `perf(dashboard)`: defer below-the-fold cards until scrolled into view**
The dashboard mounts ~a dozen cards on first open, each firing its own analytics request. Wrapped each customizable card in a new `DeferUntilVisible`: the first four cards (above the fold in the default layout) render eagerly; the rest wait until scrolled near before mounting, so their requests don't fire until they're about to be seen. The placeholder reserves the card's capped height so lower cards stay below the fold and the layout doesn't jump. Plotly was already code-split via `LazyPlot`.

## Testing

- **Backend:** full suite **1290 passed** (88% coverage), including new batch-valuation regression tests.
- **Frontend:** `tsc` clean, ESLint clean, production build OK, Dashboard vitest green.
- **E2E (real browser, demo mode):** **21 specs green** — a new deferral spec plus the dashboard/chart specs most exposed to the change (block-sizes, chart-cards, chart-styling, lazy-plotly, income-by-source, layout). Two layout specs were updated to scroll to a newly enabled bottom card before asserting its content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfV3MSkcFSRBtFU3aSmViQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfV3MSkcFSRBtFU3aSmViQ)_